### PR TITLE
Delete all trailing whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@
 * [License](LICENSE)
 
 ### Read the Docs:
-* [Wiki](https://github.com/cntt-n/CNTT/wiki) 
+* [Wiki](https://github.com/cntt-n/CNTT/wiki)
 * [Doc](https://cntt-n.github.io/CNTT/)

--- a/doc/ref_arch/README.md
+++ b/doc/ref_arch/README.md
@@ -11,14 +11,14 @@
 ## Principles
 **Preamble**
 
-CNTT develops a limited number of NFVI reference architectures. While technology and deployment aspects may differ between them, each of the CNTT reference architectures is based on a common CNTT Reference Model. 
+CNTT develops a limited number of NFVI reference architectures. While technology and deployment aspects may differ between them, each of the CNTT reference architectures is based on a common CNTT Reference Model.
 
 There are a number of key architectural principles that apply to all Reference Architectures produced by CNTT. These principles are enumerated below. They are meant to be general and at a high level, and limited in number. Some of the chapters of this document will include more specific principles to provide the implementation guidelines for a particular function or a specific component. Note that the Architectural Principles discussed in this Chapter follow the over-arching principles provided in [CNTT Reference Model:Introduction:Principles](https://cntt-n.github.io/CNTT/doc/ref_model/chapters/chapter01.html#1.3)
 
 
 We need to distinguish between architectural principles and architectural requirements elaborated later in this document. The principles are here to guide our architectural thinking, while requirements should be understood as a check list used to gauge a level of compliance of a NFVI implementation to the CNTT reference architecture.
 
-1. **Open source preference:** To ensure, by building on technology available in open source projects, that suppliers’ and operators’ investment have a tangible pathway towards a standard and production ready NFVI solution portfolio. 
+1. **Open source preference:** To ensure, by building on technology available in open source projects, that suppliers’ and operators’ investment have a tangible pathway towards a standard and production ready NFVI solution portfolio.
 
 1. **Open APIs:** To enable interoperability and component substitution, and minimize integration efforts by uisng openly published API definitions.
 
@@ -34,7 +34,4 @@ We need to distinguish between architectural principles and architectural requir
 
 1. **Security compliance:** To ensure the architecture follows the industry best security practices and is at all levels compliant to relevant security regulations.
 
-1. **Resilience and Availability:** To allow High Availability and Resilience for hosted VNFs, and to avoid Single Point of Failure. 
-
-
-
+1. **Resilience and Availability:** To allow High Availability and Resilience for hosted VNFs, and to avoid Single Point of Failure.

--- a/doc/ref_arch/kubernetes/chapters/chapter01.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter01.md
@@ -21,7 +21,7 @@
 <a name="1.3"></a>
 ## 1.3 Approach
 
-  
+
 <a name="1.4"></a>
 ## 1.4 Principles
 
@@ -41,4 +41,3 @@ Kubernetes Reference Architecture must obey to the following set of principles:
 
 <a name="1.7"></a>
 ## 1.7 Roadmap
-

--- a/doc/ref_arch/kubernetes/chapters/chapter02.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter02.md
@@ -14,7 +14,7 @@
 
 **must**: Requirements that are marked as _must_ are considered mandatory and must exist in the reference architecture and reflected in any implementation targeting this reference architecture. The same applies to _must not_.
 
-**should**: Requirements that are marked as _should_ are expected to be fulfilled by the reference architecture but it is up to each service provider to accept an implementation targeting this reference architecture that is not reflecting on any of those requirements. The same applies to _should not_. 
+**should**: Requirements that are marked as _should_ are expected to be fulfilled by the reference architecture but it is up to each service provider to accept an implementation targeting this reference architecture that is not reflecting on any of those requirements. The same applies to _should not_.
 > RFC2119
 
 **may**: Requirements that are marked as _may_ are considered optional. The same applies to _may not_.

--- a/doc/ref_arch/openstack/chapters/chapter01.md
+++ b/doc/ref_arch/openstack/chapters/chapter01.md
@@ -23,7 +23,7 @@
 ## 1.3 Terminology
 
 <!-- <p align="center"><img src="../figures/ref_arch_ch01_e2e.png" alt="E2E" title="E2E" width="100%"/></p><p align="center"><b>Figure 1-1:</b> E2E</p> -->
-  
+
 <a name="1.4"></a>
 ## 1.4 Principles
 
@@ -45,4 +45,3 @@ Open Stack Reference Architecture must obey to the following set of principles:
 
 <a name="1.7"></a>
 ## 1.7 Roadmap
-

--- a/doc/ref_arch/openstack/chapters/chapter02.md
+++ b/doc/ref_arch/openstack/chapters/chapter02.md
@@ -13,7 +13,7 @@
 
 **must**: Requirements that are marked as _must_ are considered mandatory and must exist in the reference architecture and reflected in any implementation targeting this reference architecture. The same applies to _must not_.
 
-**should**: Requirements that are marked as _should_ are expected to be fulfilled by the reference architecture but it is up to each service provider to accept an implementation targeting this reference architecture that is not reflecting on any of those requirements. The same applies to _should not_. 
+**should**: Requirements that are marked as _should_ are expected to be fulfilled by the reference architecture but it is up to each service provider to accept an implementation targeting this reference architecture that is not reflecting on any of those requirements. The same applies to _should not_.
 > RFC2119
 
 **may**: Requirements that are marked as _may_ are considered optional. The same applies to _may not_.
@@ -176,7 +176,7 @@ Traceability to Reference Model.
 
 <p align="center"><b>Table 2-8:</b> OpenStack Security Requirements.</p>
 
-<!-- 
+<!--
 **Backlog of Req**
 
 1. Manage discovery of resources, resource capabilities/features
@@ -196,7 +196,7 @@ Traceability to Reference Model.
 1. Policy driven performance and fault management
 1. Principles should apply to all reference architectures we design and develop
 1. Traceability between reference model to reference architecture (and vice versa)
-1. Implementable and usable for VNF developer community, i.e. with enough specificity to support the design and development of a VNF 
+1. Implementable and usable for VNF developer community, i.e. with enough specificity to support the design and development of a VNF
 1. Define the NFVI so that developers can understand how to build VNFs
 1. Design the architectures with common elements so that the VNFs require less operator specific customizations
 1. Rationalize need for each discrete architecture
@@ -210,7 +210,7 @@ Traceability to Reference Model.
     1. Resource and Operational Efficiency
     1. E2E Lifecycle Automation (Deployment, Operations, & Maintenance)
     1. High-Availability
-1. Prioritize incorporation of open source components 
+1. Prioritize incorporation of open source components
     1. Design architectures to established open standards as much as possible
 1. Architectures will evolve over time
 1. Mandatory Core services:
@@ -232,13 +232,13 @@ Traceability to Reference Model.
     1. I don’t want to be prescriptive over CPU pinning or NUMA but we can discuss.
 1. Network:
     1. Load balancing – should we base this on Octavia or do we need a plug-in like AVI / F5?
-    1. OpenVSwitch? 
+    1. OpenVSwitch?
     1. Geneve/VXLAN tunnelling?
     1. IPv6… when?
-    
+
 1. Tagging:
     1. We may want to define a standard for tagging resources.
-    
+
 1. Logging, Monitoring, Alerting of the Cloud should ensure any failures in the control plane are either self-healed or alerted on and ideally some sort of centralised log file analysis should be possible without needing to trawl local log files.    Logging in the tenant space is left to the application.
 1. Backup of the control plane configuration (keystone DB, other DB, policy.json’s) to a remote object store.
 -->

--- a/doc/ref_arch/openstack/chapters/chapter02.md
+++ b/doc/ref_arch/openstack/chapters/chapter02.md
@@ -133,7 +133,7 @@ Traceability to Reference Model.
 
 | Ref # | sub-category | Description |
 |----|------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `req.lcm.gen.01`	| General | The Architecture **must** support zero downtime expansion/change of physical capacity (compute hosts, storage increase/replacement). |
+| `req.lcm.gen.01` | General | The Architecture **must** support zero downtime expansion/change of physical capacity (compute hosts, storage increase/replacement). |
 | `req.lcm.adp.01` | Automated deployment | The Architecture **should** allow for “cookie cutter” automated deployment, configuration, provisoning and management of multiple NFVI sites. |
 | `req.lcm.adp.02` | Automated deployment | The Architecture **must** support hitless upgrades of software provided by the cloud provider so that the availability of running workloads is not impacted. |
 | `req.lcm.adp.03` | Automated deployment | The Architecture **should** support hitless upgrade of all software provided by the cloud provider that are not covered by `req.lcm.adp.02`. Whenever hitless upgrades are not feasible, attempt should be made to minimize the duration and nature of impact. |

--- a/doc/ref_arch/openstack/chapters/chapter03.md
+++ b/doc/ref_arch/openstack/chapters/chapter03.md
@@ -20,7 +20,7 @@
 
 <a name="3.2"></a>
 ## 3.2 NFVI Software Services Topology
-- Distribution options for control, storage, compute nodes etc. e.g.  >=3 control nodes 
+- Distribution options for control, storage, compute nodes etc. e.g.  >=3 control nodes
   – also include options for Edge – cater for multiple sized clouds / edge?
   - Baseline versions
 
@@ -32,7 +32,7 @@
 
 <a name="3.4"></a>
 ## 3.4 Cloud Controller Services
-- Highly available OpenStack Services 
+- Highly available OpenStack Services
 - Logging / Monitoring / Alerting (should this be a separate section on its own?)
 - Identity Management
 

--- a/doc/ref_arch/openstack/chapters/chapter04.md
+++ b/doc/ref_arch/openstack/chapters/chapter04.md
@@ -14,7 +14,7 @@
 * [4.8 Telemetry.](#4.8)
 * [4.9 General Hardware requirements.](#4.9)
 
-<a name="4.1"></a> 
+<a name="4.1"></a>
 ## 4.1 Introduction.
 
 This should focus on IaaS elements.
@@ -23,7 +23,7 @@ This should focus on IaaS elements.
 ## 4.2 Network Topology (control plane, storage, tenant, external)
 - Physical Network = Spine / Leaf with dual homing to ToR
 - Proposed logical network layout – VLANs, overlay, FIPs, IPv6   – we will follow common vendor recommendations however we can agree on our minimum expectations
-- LBaaS v2 compliant Load Balancing 
+- LBaaS v2 compliant Load Balancing
 - Neutron ML2 integration to any external SDN controller
 
 
@@ -52,11 +52,11 @@ This should focus on IaaS elements.
   - Software Components
     - > for example: vSwitch DPDK + Contrail
   - Hardware Platform
-    - > for example: dual socket platform. 2x25G NIC, CryptoAcc, etc. 
+    - > for example: dual socket platform. 2x25G NIC, CryptoAcc, etc.
 
-- Compute Intensive Profile 
+- Compute Intensive Profile
   - Software Components
-    - > for example: vSwitch DPDK + Open Contrail 
+    - > for example: vSwitch DPDK + Open Contrail
   - Hardware Platform
   - > for example: dual socket platform. 2x25G NIC, GPU, etc.
 
@@ -68,7 +68,7 @@ This should focus on IaaS elements.
 
 
 <a name="4.7"></a>
-## 4.7 Logging / Monitoring / Alerting of Control Plane 
+## 4.7 Logging / Monitoring / Alerting of Control Plane
 - Prometheus
 
 

--- a/doc/ref_impl/chapter02.md
+++ b/doc/ref_impl/chapter02.md
@@ -6,9 +6,9 @@
 ## Table of Contents
 * [2.1 Introduction](#2.1)
 * [2.2 Lab Requirement](#2.2)
-* [2.3 Lab Topology](#2.3)  
-* [2.4 Lab HW Spec](#2.4)  
-* [2.5 Lab Use Guidelines](#2.5)  
+* [2.3 Lab Topology](#2.3)
+* [2.4 Lab HW Spec](#2.4)
+* [2.5 Lab Use Guidelines](#2.5)
 
 
 <a name="2.1"></a>
@@ -19,7 +19,7 @@
 ## 2.2 Lab Requirement
 
 - Controller Nodes:
-  - 3 x 
+  - 3 x
     - 2x dual-port 10Gbps NIC.
     - 2.2GHz 14C/28T.
     - 256GB RAM.
@@ -57,9 +57,9 @@
 <a name="2.5"></a>
 ## 2.5 Lab Use Guidelines
 
-**SETUP & Maintenance** 
+**SETUP & Maintenance**
 
-OPNFV will facilitate the need for lab procurment, as required, for projects which come into their front door for verification and validation.  
+OPNFV will facilitate the need for lab procurment, as required, for projects which come into their front door for verification and validation.
 
 Individual companies that donated a lab would be responsible for setup and maintenance of a community lab. Labs, once setup, will be shared and posted in a wiki https://wiki.opnfv.org/display/pharos/Community+Labs.
 

--- a/doc/ref_impl/cntt-ri/chapters/chapter01.md
+++ b/doc/ref_impl/cntt-ri/chapters/chapter01.md
@@ -6,7 +6,7 @@
 ## Table of Contents
 * [1.1 Introduction.](#1.1)
   * [1.1.1 About CNTT-RI.](#1.1.1)
-  * [1.1.2 Relationship with other communities.](#1.1.2) 
+  * [1.1.2 Relationship with other communities.](#1.1.2)
 * [1.2 Terminology.](#1.2)
 * [1.3 Scope.](#1.3)
 * [1.4 Roadmap.](#1.4)

--- a/doc/ref_model/chapters/chapter01.md
+++ b/doc/ref_model/chapters/chapter01.md
@@ -20,9 +20,9 @@
 <a name="1.1"></a>
 ## 1.1 Overview & Problem Statement
 The main concept of NFV (Network Function Virtualization) is the ability to use general purpose compute hardware and platforms to run multiple VNFs (Virtualised Network Functions) and hence achieving the desired CapEx and OpEx savings. However, one of big challenges NFV is facing with VNF vendors is that vendors, while building or designing their virtualized services (whether it's VoLTE, EPC, or enterprise services like SD-WAN (Software Defined Wide Area Network)), must bring their own set of infrastructure requirements and custom design parameters. This attitude from vendors triggered the creation of various vendor/function specific silos which are incompatible with each other and have different operating models. In addition, this makes the onboarding and certification processes of VNFs (coming from different vendors) hard to automate and standardise.
- 
+
 Therefore, for a true cloud type deployment, a model, which relies on engagement with specific vendors and unique infrastructure, needs to be reversed in a way that there is a lot more consistency on the infrastructure. Vendors need to bring their software to run on pre-defined environment with common capabilities. That common infrastructure, whether it is optimized for IT (Information Technology) workloads, NFV workloads, or even for AI (Artificial Intelligence) workloads, needs to be fully abstracted to VNFs so that it can be a standard offer.
- 
+
 Additionally, to bring the most value to telco operators as well as vendors, agreeing on a standard set of infrastructure profiles for vendors to use for their VNFs is needed within the industry.
 
 The benefits of this approach are:
@@ -48,7 +48,7 @@ Analysis of On-Boarding and On-Going Support of ‘i’ in relation to the VNF C
 <a name="1.2"></a>
 ## 1.2	Terminology
 
-This section defines the main terms used in this document; these deinitions are primarily based on the ETSI GS NFV 003 V1.4.1 (2018-08) but have been cleaned to avoid deployment technology dependencies when necessary.
+This section defines the main terms used in this document; these definitions are primarily based on the ETSI GS NFV 003 V1.4.1 (2018-08) but have been cleaned to avoid deployment technology dependencies when necessary.
 
 <a name="1.2.1"></a>
 ### 1.2.1 Software layers terminology
@@ -59,23 +59,23 @@ This section defines the main terms used in this document; these deinitions are 
 - **Network Service (NS)**: composition of **Network Function**(s) and/or **Network Service**(s), defined by its functional and behavioural specification, including the service lifecycle.
 - **Virtual Network Function (VNF)**: a software implementation of a **Network Function**, capable of running on the **NFVi**.
   - **VNF**s are built from one or more VNF Components (**VNFC**) and, in most cases,  the VNFC is hosted on a single VM or Container.
-- **Cloud-native (containerised) Network Function (CNF)**: **VNF** with a full adherence to cloud native principles, or a **VNF** that is transitioning to cloud native. 
+- **Cloud-native (containerised) Network Function (CNF)**: **VNF** with a full adherence to cloud native principles, or a **VNF** that is transitioning to cloud native.
   >_*Note:*_ It is a containerised **VNF** that is microservices-oriented, to increase agility and maintainability, and that can be dynamically orchestrated and managed to optimize resource utilization; the containers can be Linux, Docker or other similar container technology.
-- **Virtual Application (VA)**: is more of a general term for software which can be loaded into a Virtual Machine. 
+- **Virtual Application (VA)**: is more of a general term for software which can be loaded into a Virtual Machine.
   >_*Note:*_ a **VNF** is one type of VA.
 - **Workload**: Workload refers to software running on top of compute resources such as **VMs** or **Container**s. Most relevant workload categories in context of NFVI are:
   - **Data Plane Workloads**: are related to packet handling in an end-to-end communication between applications. These tasks are expected to be very intensive in I/O operations and memory read/write operations.
   - **Control Plane Workloads**: are the task related to any other communication between NFs that is not directly related to the end-to-end data communication between applications. This category includes session management, routing or authentication.
   - **Storage Workloads**: are all tasks related to disk storage, from the non-intensive logging of a router, to more intensive read/write operations.
-- **Virtual Machine (VM)**: virtualised computation environment that behaves like a physical computer/server. 
-  >_*Note:*_ a **VM** consists of all of the components (processor (CPU), memory, storage, interfaces/ports, etc.) of a physical computer/server. It is created using Instance Type together with sizing information or Compute Flavour. 
+- **Virtual Machine (VM)**: virtualised computation environment that behaves like a physical computer/server.
+  >_*Note:*_ a **VM** consists of all of the components (processor (CPU), memory, storage, interfaces/ports, etc.) of a physical computer/server. It is created using Instance Type together with sizing information or Compute Flavour.
 - **Instance type**: specifies a set of virtualized hardware resources and capabilities used for the creation of a virtual compute on which a workload runs on; includes capability specifications such as CPU, storage, and memory.
 - **Instance**: is a virtual compute resource, in a known state such as running or suspended, that can be used like a physical server. NOTE: can be used to specify VM Instance or Container Instance.
-- **Compute flavour**: defines the compute, memory, and storage capacity, and the capabilities of the physical compute server that the virtual compute resource can run on. 
+- **Compute flavour**: defines the compute, memory, and storage capacity, and the capabilities of the physical compute server that the virtual compute resource can run on.
      >_*Note:*_ used to define the configuration/capacity limit of a virtualised container.
 - **VM instances Catalogue**: Pre-defined instance types and compute flavours.
 - **Container**: a container provides operating-system-level virtualization by abstracting the “user space”. One big difference between **Container**s and **VM**s is that containers "share" the host system’s kernel with other containers.
-- **Network Function Virtualisation Infrastructure (NFVI)**: totality of all hardware and software components that build up the environment in which **VA** are deployed. 
+- **Network Function Virtualisation Infrastructure (NFVI)**: totality of all hardware and software components that build up the environment in which **VA** are deployed.
   >_*Note:*_ The NFV-Infrastructure can span across several locations, e.g. places where data centres are operated. The network providing connectivity between these locations is regarded to be part of the NFVI. NFVI and VNF are the top-level conceptual entities in the scope of Network Function Virtualisation. All other components are sub-entities of these two main entities.
 - **Virtual resources**:
   -	**Virtual Compute resource (a.k.a. virtualised container)**: partition of a compute node that provides an isolated virtualised computation environment.
@@ -126,7 +126,7 @@ This section specifies the principles of infrastructure abstraction and profilin
    - NFVI resources are consumed by VNFs through standard and open APIs.
    - NFVI resources are configured on behalf of VNFs through standard and open APIs.
    - NFVI resources are discovered/monitored by management entities (such as orchestration) through standard and open APIs.
-1.	VNFs should be modular and utilise minimum resources. 
+1.	VNFs should be modular and utilise minimum resources.
 1. NFVI shall support pre-defined and parameterized T-Shirt sizes.
    - T-Shirt sizes will evolve with time.
 1.	NFVI provides certain resources, capabilities and features and virtual applications (VA) should only consume these resources, capabilities and features.
@@ -135,20 +135,20 @@ This section specifies the principles of infrastructure abstraction and profilin
     - **Minimize Architecture proliferation by stipulating compatible features be contained within a single Architecture as much as possible:**
       - Features which are compatible, meaning they are not mutually exclusive and can coexist in the same NFVI instance, shall be incorporated into the same Reference Architecture. For example, IPv4 and IPv6 should be captured in the same Architecture, because they don't interfere with each other
       - Focus on the commonalities of the features over the perceived differences.  Seek an approach that allows small differences to be handled at either the low level design or implementation stage. For example, assume the use of existing common APIs over new ones.
- 
-    - **Create an additional Architecture only when incompatible elements are unavoidable:** 
+
+    - **Create an additional Architecture only when incompatible elements are unavoidable:**
       - Creating additional Architectures is limited to when incompatible elements are desired by Taskforce members. For example, if one member desires KVM be used as the hypervisor, and another desires ESXi be used as the hypervisor, and no compromise or mitigation* can be negotiated, the Architecture could be forked, subject to review and vote to approve by the CNTT technical Working Group, such that one Architecture would be KVM-based and the other would be ESXi-based.
-     
-        >*Depending on the relationships and substitutability of the component(s) in question, it may be possible to mitigate component incompatibility by creating annexes to a single Architecture, rather than creating an additional Architecture. With this approach, designers at a Telco would implement the Architecture as described in the reference document and when it came to the particular component in question, they would select from one of the relevant annexes, their preferred option. For example, if one member wanted to use Ceph, and another member wanted to use Swift, assuming the components are equally compatible with the rest of the Architecture, there could be one annex for the Ceph implementation and one annex for the Swift implementation. 
+
+        >*Depending on the relationships and substitutability of the component(s) in question, it may be possible to mitigate component incompatibility by creating annexes to a single Architecture, rather than creating an additional Architecture. With this approach, designers at a Telco would implement the Architecture as described in the reference document and when it came to the particular component in question, they would select from one of the relevant annexes, their preferred option. For example, if one member wanted to use Ceph, and another member wanted to use Swift, assuming the components are equally compatible with the rest of the Architecture, there could be one annex for the Ceph implementation and one annex for the Swift implementation.
 
 <a name="1.4"></a>
 ## 1.4	How this document works
-There are three level of documents needed to fulfil the CNTT vision. They are, as highlighted in **Figure 1-4**:  **Reference Model**, **Reference Architecture**, and **Reference Implementation**. 
+There are three level of documents needed to fulfil the CNTT vision. They are, as highlighted in **Figure 1-4**:  **Reference Model**, **Reference Architecture**, and **Reference Implementation**.
 
 <p align="center"><img src="../figures/ch01_scope_doc_types.png" alt="scope" title="Document Types" width="100%"/></p>
 <p align="center"><b>Figure 1-4:</b> Scope of CNTT</p>
 
-- **Reference Model**: (This document) focuses on the __**NFVI Abstraction**__ and how NFVI services and resources are exposed to VNFs. 
+- **Reference Model**: (This document) focuses on the __**NFVI Abstraction**__ and how NFVI services and resources are exposed to VNFs.
 - **Reference Architecture**: High level NFVI system components and their interactions to deliver on the Reference Model goals. It is expected that at least one, but not more than a few, Reference Architecture will conform to the Reference Model.
 - **Reference Implementation**: Focuses on the design and implementation of a NFVI Reference Architecture. Each Reference Architecture is expected to be implemented by at least one Reference Implementation.
 
@@ -166,7 +166,7 @@ This document focuses on the **Reference Model**. **Figure 1-6** below highlight
 This document specifies:
 - NFVI Infrastructure abstraction
   - **NFVI metrics & capabilities**: A set of carrier grade metrics and capabilities of NFVI which VNFs require to perform telco grade network functions.
-  - **Infrastructure profiles catalogue**: A catalogue of standard profiles needed in order to completely abstract the infrastructure from VNFs. With a limited and well defined profiles and well understood characteristics, VNF compatibility and performance predictability can be achieved. 
+  - **Infrastructure profiles catalogue**: A catalogue of standard profiles needed in order to completely abstract the infrastructure from VNFs. With a limited and well defined profiles and well understood characteristics, VNF compatibility and performance predictability can be achieved.
 
     >_The current focus is for VMs but the intention is to expand the definition to include Container profiles too._
 
@@ -181,7 +181,7 @@ This document specifies:
   - **Test framework**: Provide test suites to allow compliance, certification, and verification of VNFs and NFVI against the defined set of profiles.
 
 <a name="1.6"></a>
-## 1.6	Relations to other industry projects 
+## 1.6	Relations to other industry projects
 
 An industry project closely related to CNTT is ETSI's NFV. The CNTT Reference Model's scope has been aligned to the ETSI NFV Infrastructure plus the VIM (Virtualised Infrastructure Manager), inclusive of their external reference points, as specified by ETSI GS NFV002<!--[link to ref: NFV Architectural framework v1.2.1]-->. **Figure 1-7** illustrates which functional blocks of the ETSI NFV Architecture are in scope for CNTT.
 
@@ -191,7 +191,7 @@ An industry project closely related to CNTT is ETSI's NFV. The CNTT Reference Mo
 Following the ETSI model, **Figure 1-7** also depicts the VIM, which controls and manages the NFVI, and while technically not part of the NFVI, is included in the CNTT scope. The interactions between NFVI and VIM will be part of this document as infrastructure resources management and orchestration have a strong impact on NFVI. These interactions will be detailed in **Chapter 7 "API & Interfaces"**.
 
 <a name="1.7"></a>
-## 1.7	What this document is not covering 
+## 1.7	What this document is not covering
 >_**Comment**: This section is still under development._
 <!--Separate document w/labels/artifacts
 Not part of model but will be applicable to architecture -->
@@ -203,5 +203,3 @@ A carefully chosen “Bogo-Meter” rating at the beginning of each chapter indi
 <a name="1.9"></a>
 ## 1.9	Roadmap
 >_**Comment**: Please Contact the CNTT team for access to the Roadmap_
-
-

--- a/doc/ref_model/chapters/chapter01.md
+++ b/doc/ref_model/chapters/chapter01.md
@@ -39,14 +39,14 @@ The benefits of this approach are:
   - Mapping VNFs to flavours which are properly mapped to IaaS will bring better utilization, than current VNFs expressing variety of instance types as their needs on IaaS.
 
 <!--<a name="1.2"></a>
-## 1.2	Problem Statement
+## 1.2 Problem Statement
 Analysis of On-Boarding and On-Going Support of ‘i’ in relation to the VNF Challenges - Identified Long-Poles.
 
 >_**Comment**: This section is still under development._
 -->
 
 <a name="1.2"></a>
-## 1.2	Terminology
+## 1.2 Terminology
 
 This section defines the main terms used in this document; these definitions are primarily based on the ETSI GS NFV 003 V1.4.1 (2018-08) but have been cleaned to avoid deployment technology dependencies when necessary.
 
@@ -78,10 +78,10 @@ This section defines the main terms used in this document; these definitions are
 - **Network Function Virtualisation Infrastructure (NFVI)**: totality of all hardware and software components that build up the environment in which **VA** are deployed.
   >_*Note:*_ The NFV-Infrastructure can span across several locations, e.g. places where data centres are operated. The network providing connectivity between these locations is regarded to be part of the NFVI. NFVI and VNF are the top-level conceptual entities in the scope of Network Function Virtualisation. All other components are sub-entities of these two main entities.
 - **Virtual resources**:
-  -	**Virtual Compute resource (a.k.a. virtualised container)**: partition of a compute node that provides an isolated virtualised computation environment.
-  -	**Virtual Storage resource**: virtualised non-volatile storage allocated to a virtualised computation environment hosting a **VNFC**
-  -	**Virtual Networking resource**: routes information among the network interfaces of a virtual compute resource and physical network interfaces, providing the necessary connectivity
--	**Hypervisor**: software that partitions the underlying physical resources and allocates them to Virtual Machines.
+  - **Virtual Compute resource (a.k.a. virtualised container)**: partition of a compute node that provides an isolated virtualised computation environment.
+  - **Virtual Storage resource**: virtualised non-volatile storage allocated to a virtualised computation environment hosting a **VNFC**
+  - **Virtual Networking resource**: routes information among the network interfaces of a virtual compute resource and physical network interfaces, providing the necessary connectivity
+- **Hypervisor**: software that partitions the underlying physical resources and allocates them to Virtual Machines.
 - **Container Engine**: Software components used to create, destroy, and manage containers on top of an operating system.
 - **NFVI Software Profile (NFVI SW Profile)**: defines the behaviour, capabilities and metrics provided by an NFVI Software Layer
 - **NFVI Software Configuration (NFVI SW Configuration)**: a set of settings (Key:Value) that are applied/mapped to **NFVI** SW deployment.
@@ -90,7 +90,7 @@ This section defines the main terms used in this document; these definitions are
 ### 1.2.2 Hardware layers terminology
 
 - **Physical Network Function (PNF)**: Implementation of a network function via tightly coupled dedicated hardware and software system. NOTE: it is a physical NFVi resource with the NF software.
--	**Hardware resources**: Compute/Storage/Network hardware resources on which the NFVI platform software, virtual machines and containers run on.
+- **Hardware resources**: Compute/Storage/Network hardware resources on which the NFVI platform software, virtual machines and containers run on.
 - **NFVI Hardware Profile**: defines the behaviour, capabilities and metrics provided by an NFVI Hardware Layer.
   - **Host Profile**: is another term for a **NFVI hardware profile**.
 - **NFVI Hardware Configuration**: a set of settings (Key:Value) that are applied/mapped to **NFVI** HW deployment.
@@ -98,21 +98,21 @@ This section defines the main terms used in this document; these definitions are
 <a name="1.2.3"></a>
 ### 1.2.3 Operational and administrative terminology
 
--	**Tenant**: represents an independently manageable pool of virtual compute, storage and network resources.
--	**Tenant (Internal) Networks**: virtual networks that are internal to tenant instances.
--	**External Network**: External networks provide network connectivity for an NFVI tenant to resources outside of the tenant space.
--	**Quota**: upper limit on specific types of resources, usually used to prevent excessive resource consumption in the **VIM** by a given consumer (tenant).
--	**Resource pool**: logical grouping of NFVI hardware and software resources. A resource pool can be based on a certain resource type (for example, compute, storage, network) or a combination of resource types. An **NFVI** resource can be part of none, one or more resource pools.
--	**Compute Node**: abstract definition of a server.
--	**Service Assurance (SA)**: collects alarm and monitoring data. Applications within SA or interfacing with SA can then use this data for fault correlation, root cause analysis, service impact analysis, SLA management, security, monitoring and analytic, etc.
+- **Tenant**: represents an independently manageable pool of virtual compute, storage and network resources.
+- **Tenant (Internal) Networks**: virtual networks that are internal to tenant instances.
+- **External Network**: External networks provide network connectivity for an NFVI tenant to resources outside of the tenant space.
+- **Quota**: upper limit on specific types of resources, usually used to prevent excessive resource consumption in the **VIM** by a given consumer (tenant).
+- **Resource pool**: logical grouping of NFVI hardware and software resources. A resource pool can be based on a certain resource type (for example, compute, storage, network) or a combination of resource types. An **NFVI** resource can be part of none, one or more resource pools.
+- **Compute Node**: abstract definition of a server.
+- **Service Assurance (SA)**: collects alarm and monitoring data. Applications within SA or interfacing with SA can then use this data for fault correlation, root cause analysis, service impact analysis, SLA management, security, monitoring and analytic, etc.
 
 <a name="1.2.4"></a>
 ### 1.2.4 Other terminology
--	**Virtualised Infrastructure Manager (VIM)**: responsible for controlling and managing the **NFVI** compute, storage and network resources.
--	**NFV Orchestrator (NFVO)**: manages the VNF lifecycle and **NFVI** resources (supported by the **VIM**) to ensure an optimised allocation of the necessary resources and connectivity.
+- **Virtualised Infrastructure Manager (VIM)**: responsible for controlling and managing the **NFVI** compute, storage and network resources.
+- **NFV Orchestrator (NFVO)**: manages the VNF lifecycle and **NFVI** resources (supported by the **VIM**) to ensure an optimised allocation of the necessary resources and connectivity.
 
 <a name="1.3"></a>
-## 1.3	Principles
+## 1.3 Principles
 
 This section specifies the principles of infrastructure abstraction and profiling work presented by this document.
 
@@ -121,15 +121,15 @@ This section specifies the principles of infrastructure abstraction and profilin
    - Storage resources.
    - Networking resources. (Limited to connectivity services).
    - Acceleration resources.
-1.	NFVI exposed resources should be supplier independent.
+1. NFVI exposed resources should be supplier independent.
 1. All NFVI APIs must be standard and open to ensure components substitution.
    - NFVI resources are consumed by VNFs through standard and open APIs.
    - NFVI resources are configured on behalf of VNFs through standard and open APIs.
    - NFVI resources are discovered/monitored by management entities (such as orchestration) through standard and open APIs.
-1.	VNFs should be modular and utilise minimum resources.
+1. VNFs should be modular and utilise minimum resources.
 1. NFVI shall support pre-defined and parameterized T-Shirt sizes.
    - T-Shirt sizes will evolve with time.
-1.	NFVI provides certain resources, capabilities and features and virtual applications (VA) should only consume these resources, capabilities and features.
+1. NFVI provides certain resources, capabilities and features and virtual applications (VA) should only consume these resources, capabilities and features.
 1. VNFs that are designed to take advantage of NFVI accelerations should still be able to run without these accelerations with potential performance impacts.
 1. An objective of CNTT is to have a single, overarching Reference Model and the smallest number of Reference Architectures as is practical. Two principles are introduced in support of these objectives:
     - **Minimize Architecture proliferation by stipulating compatible features be contained within a single Architecture as much as possible:**
@@ -142,7 +142,7 @@ This section specifies the principles of infrastructure abstraction and profilin
         >*Depending on the relationships and substitutability of the component(s) in question, it may be possible to mitigate component incompatibility by creating annexes to a single Architecture, rather than creating an additional Architecture. With this approach, designers at a Telco would implement the Architecture as described in the reference document and when it came to the particular component in question, they would select from one of the relevant annexes, their preferred option. For example, if one member wanted to use Ceph, and another member wanted to use Swift, assuming the components are equally compatible with the rest of the Architecture, there could be one annex for the Ceph implementation and one annex for the Swift implementation.
 
 <a name="1.4"></a>
-## 1.4	How this document works
+## 1.4 How this document works
 There are three level of documents needed to fulfil the CNTT vision. They are, as highlighted in **Figure 1-4**:  **Reference Model**, **Reference Architecture**, and **Reference Implementation**.
 
 <p align="center"><img src="../figures/ch01_scope_doc_types.png" alt="scope" title="Document Types" width="100%"/></p>
@@ -156,7 +156,7 @@ There are three level of documents needed to fulfil the CNTT vision. They are, a
 <p align="center"><b>Figure 1-5:</b> Description of the possible different levels of CNTT artefacts</p>
 
 <a name="1.5"></a>
-## 1.5	Scope
+## 1.5 Scope
 
 This document focuses on the **Reference Model**. **Figure 1-6** below highlights its scope in more details.
 
@@ -181,7 +181,7 @@ This document specifies:
   - **Test framework**: Provide test suites to allow compliance, certification, and verification of VNFs and NFVI against the defined set of profiles.
 
 <a name="1.6"></a>
-## 1.6	Relations to other industry projects
+## 1.6 Relations to other industry projects
 
 An industry project closely related to CNTT is ETSI's NFV. The CNTT Reference Model's scope has been aligned to the ETSI NFV Infrastructure plus the VIM (Virtualised Infrastructure Manager), inclusive of their external reference points, as specified by ETSI GS NFV002<!--[link to ref: NFV Architectural framework v1.2.1]-->. **Figure 1-7** illustrates which functional blocks of the ETSI NFV Architecture are in scope for CNTT.
 
@@ -191,15 +191,15 @@ An industry project closely related to CNTT is ETSI's NFV. The CNTT Reference Mo
 Following the ETSI model, **Figure 1-7** also depicts the VIM, which controls and manages the NFVI, and while technically not part of the NFVI, is included in the CNTT scope. The interactions between NFVI and VIM will be part of this document as infrastructure resources management and orchestration have a strong impact on NFVI. These interactions will be detailed in **Chapter 7 "API & Interfaces"**.
 
 <a name="1.7"></a>
-## 1.7	What this document is not covering
+## 1.7 What this document is not covering
 >_**Comment**: This section is still under development._
 <!--Separate document w/labels/artifacts
 Not part of model but will be applicable to architecture -->
 
 <a name="1.8"></a>
-## 1.8	Bogo-Meter
+## 1.8 Bogo-Meter
 A carefully chosen “Bogo-Meter” rating at the beginning of each chapter indicates the completeness and maturity each chapter's content, at a glance.
 
 <a name="1.9"></a>
-## 1.9	Roadmap
+## 1.9 Roadmap
 >_**Comment**: Please Contact the CNTT team for access to the Roadmap_

--- a/doc/ref_model/chapters/chapter02.md
+++ b/doc/ref_model/chapters/chapter02.md
@@ -13,25 +13,25 @@ One of the main targets of the CNTT is to define an agnostic NFVI and removes an
 
 This means, operators will be able to host their Telco Workload (VNF) with different traffic types, behaviour and from any vendor on a unified consistent Infrastructure.
 
-Additionally, a well defined NFVI is also needed for other type of workloads than NFV such as IT, Machine learning, Artificial Intelligence, etc. 
+Additionally, a well defined NFVI is also needed for other type of workloads than NFV such as IT, Machine learning, Artificial Intelligence, etc.
 
 In this chapter we try to analyse various VNF types used in telco and examine their requirements. We will also highlight some of the NFVI parameters needed to achieve the desired performance expected by various workloads.
 
 <a name="2.1"></a>
 # 2.1 VNFs collateral
 
-There are many ways that VNFs can be classified, for example: 
+There are many ways that VNFs can be classified, for example:
 
-- **By Traffic Type:** 
+- **By Traffic Type:**
     - User Plane (Data Plane)
-    - Control Plane (Signalling Plane).  
+    - Control Plane (Signalling Plane).
     - Management Plane.
 -	**By Service offered:**
-    - Mobile broadband service: vEPC, vDPI, vGI-FW 
+    - Mobile broadband service: vEPC, vDPI, vGI-FW
     - Fixed broadband Service vBNG, vDPI
-    - VoLTE / VoWifi : vIMS , UDC , HSBC , vEPDG. 
-    - VASs : vSMS-C ,  vCDN , vCGNAT 
--	**By Technology:** (2G, 3G, 4G, 5G, Fixed...)  
+    - VoLTE / VoWifi : vIMS , UDC , HSBC , vEPDG.
+    - VASs : vSMS-C ,  vCDN , vCGNAT
+-	**By Technology:** (2G, 3G, 4G, 5G, Fixed...)
 
 Below is a list of Network Functions that covers almost _**95%**_ of the Telco workload (and the most likely to be virtualized/moved to cloud). They don't follow any specific categorisation.
 
@@ -58,26 +58,26 @@ _**Note:** definition of some of the VNFs below is based on 3GPP definitions._
   - Gateway GPRS Support Node (GGSN); The location register function in the GGSN stores subscriber data received from the HLR and the SGSN
 
   - Deep packet inspection (DPI) for network data processing for reporting and other services on mobile and fixed networks.
-  - SBC: Session Border Controller (SBC): Secures voice over IP (VoIP) infrastructures while providing interworking between incompatible signalling messages and media flows (sessions) from end devices or application servers. [ Payload ] 
+  - SBC: Session Border Controller (SBC): Secures voice over IP (VoIP) infrastructures while providing interworking between incompatible signalling messages and media flows (sessions) from end devices or application servers. [ Payload ]
   - SMS-C : SMS Center [Control Plane ]
 
 - Other Core/Main VNFs - 3GPP TS 23.002 R15 Network architecture
-  - cRAN – Centralized Unit (CU) BBU, in 5G will be DU and CU 
+  - cRAN – Centralized Unit (CU) BBU, in 5G will be DU and CU
   - IMS (IP-Multimedia Subsystem ):
-    - CSCF :  Call Session Control Function [ control ] 
-    - MTAS mobile telephony application server[ control ] 
+    - CSCF :  Call Session Control Function [ control ]
+    - MTAS mobile telephony application server[ control ]
     - MRF: Media Resource Function [ user plane ]
     - Enum : [ control ]
     - BGCF : Border gateway control function [ control ] . interconnect
     - MGCF: Media Gateway control function :
-  - DNS Domain Name System 
+  - DNS Domain Name System
   - AAA: Authentication, authorization, and accounting (AAA) services
   - UDC: User Data Convergence
     - HSS-FE: Home Subscriber Server) is a database that contains user-related and subscriber-related information
     - HLR–FE: Home Location Register
     - AAA-FE
     - MNP-FE: Mobile Number Portability
-    - EIR–FE: Equipment Identity Register 
+    - EIR–FE: Equipment Identity Register
     - UDR: User Data Repository  is a functional entity that acts as a single logical repository that stores converged user data
   - Carrier-Grade Network Address Translation (CG-NAT) for IPv4 optimization of mobile and fixed networks.
   - Transmission Control Protocol (TCP) optimization for improved customer experience in 3G/4G mobile networks
@@ -85,15 +85,15 @@ _**Note:** definition of some of the VNFs below is based on 3GPP definitions._
   - IPSEC GW
   - IPS/IDS
   - DDOS
-  - Access : 
-    - OLT 
+  - Access :
+    - OLT
     - BNG: Border Network Gateway  / broadband remote access server
     - RGW: Residential gateway
     - Wifi Controller [Control Plane ]
-  - CDN: Content delivery network 
+  - CDN: Content delivery network
 
 - **For 5G:**
-  - Core nodes: Virtualized by nature and strong candidate to be onboarded onto Telco Cloud as "cloud-native application"  
+  - Core nodes: Virtualized by nature and strong candidate to be onboarded onto Telco Cloud as "cloud-native application"
     - AMF: The Access and Mobility Management function (AMF)
     - SMF The Session Management function (SMF)
     - UPF: The User plane function (UPF)
@@ -176,7 +176,7 @@ By trying to sort VNFs into different categories based on the requirements obser
     - Fast computing
     - High throughput
     - Low network latency
-- **Profile Three** 
+- **Profile Three**
   - VNF types
     - Control plane functions with specific computing needs
     - _Examples: MME, AMF, IMS-CSCF_
@@ -197,7 +197,7 @@ By trying to sort VNFs into different categories based on the requirements obser
 
 Based on the above analysis, following NFVI profiles are proposed (Also shown in **Figure 2-1** below)
 
-- **Basic**: VNFs with VNFCs that perform basic compute operations. 
+- **Basic**: VNFs with VNFCs that perform basic compute operations.
 - **Network Intensive**: VNFs with VNFCs that perform network and compute intensive operations with high throughput and low latency requirements.
 - **Compute Intensive**: VNFs with VNFCs that perform compute intensive operations.
 - **Storage Intensive**: VNFs with VNFCs that perform storage intensive operations with high IPOS requirements. (_**Note:** Storage Intensive Profile will not be defined in initial CNTT releases_)

--- a/doc/ref_model/chapters/chapter02.md
+++ b/doc/ref_model/chapters/chapter02.md
@@ -1,5 +1,5 @@
 [<< Back](../../ref_model)
-# 2	VNF requirements & Analysis
+# 2 VNF requirements & Analysis
 <p align="right"><img src="../figures/bogo_lsf.png" alt="scope" title="Scope" width="35%"/></p>
 
 ## Table of Contents
@@ -26,12 +26,12 @@ There are many ways that VNFs can be classified, for example:
     - User Plane (Data Plane)
     - Control Plane (Signalling Plane).
     - Management Plane.
--	**By Service offered:**
+- **By Service offered:**
     - Mobile broadband service: vEPC, vDPI, vGI-FW
     - Fixed broadband Service vBNG, vDPI
     - VoLTE / VoWifi : vIMS , UDC , HSBC , vEPDG.
     - VASs : vSMS-C ,  vCDN , vCGNAT
--	**By Technology:** (2G, 3G, 4G, 5G, Fixed...)
+- **By Technology:** (2G, 3G, 4G, 5G, Fixed...)
 
 Below is a list of Network Functions that covers almost _**95%**_ of the Telco workload (and the most likely to be virtualized/moved to cloud). They don't follow any specific categorisation.
 
@@ -202,7 +202,7 @@ Based on the above analysis, following NFVI profiles are proposed (Also shown in
 - **Compute Intensive**: VNFs with VNFCs that perform compute intensive operations.
 - **Storage Intensive**: VNFs with VNFCs that perform storage intensive operations with high IPOS requirements. (_**Note:** Storage Intensive Profile will not be defined in initial CNTT releases_)
 
->_**Note**: 	This is an initial set of proposed profiles and it is expected that more profiles will be added as more requirements are gathered and as technology enhances and matures._
+>_**Note**:  This is an initial set of proposed profiles and it is expected that more profiles will be added as more requirements are gathered and as technology enhances and matures._
 
 <p align="center"><img src="../figures/ch02_infra_profiles.PNG" alt="infra_profiles" title="Infrastructure Profiles" width="100%"/></p>
 <p align="center"><b>Figure 2-1:</b> Infrastructure profiles proposed based on VNFs categorisation.</p>

--- a/doc/ref_model/chapters/chapter03.md
+++ b/doc/ref_model/chapters/chapter03.md
@@ -1,5 +1,5 @@
 [<< Back](../../ref_model)
-# 3	Modelling
+# 3 Modelling
 <p align="right"><img src="../figures/bogo_lsf.png" alt="bogo" title="Bogo Meter" width="35%"/></p>
 
 ## Table of Contents
@@ -22,18 +22,18 @@ The lack of a common understanding of which resources and corresponding capabili
 The abstraction model presented in this chapter specifies a common set of virtual infrastructure resources which NFVI will need to provide to be able to host most of the typical VNF/CNF workloads required by the operator community.
 
 Although a couple of explicit and implicit abstraction models (e.g. in the context of ETSI NFV) are already available, they fall short when addressing the following design principles:
--	**Scope:** the model should describe the most relevant virtualised infrastructure resources (incl. acceleration technologies) an NFVI needs to provide for hosting Telco workloads
--	**Separation of Concern:** the model should support a clear distinction between the responsibilities related to maintaining the network function virtualisation infrastructure and the responsibilities related to managing the various VNF workloads
--	**Simplicity:** the amount of different types of resources (including their attributes and relationships amongst one another) should be kept to a minimum to reduce the configuration spectrum which needs to be considered
+- **Scope:** the model should describe the most relevant virtualised infrastructure resources (incl. acceleration technologies) an NFVI needs to provide for hosting Telco workloads
+- **Separation of Concern:** the model should support a clear distinction between the responsibilities related to maintaining the network function virtualisation infrastructure and the responsibilities related to managing the various VNF workloads
+- **Simplicity:** the amount of different types of resources (including their attributes and relationships amongst one another) should be kept to a minimum to reduce the configuration spectrum which needs to be considered
 - **Declarative**: the model should allow for the description of the intended state and configuration of the NFVI resources for automated life cycle management
--	**Explicit:** the model needs to be rich enough to allow for a direct mapping towards the APIs of NFVIs for the instantiation of virtual infrastructure elements without requiring any additional parameters
--	**Lifecycle:** the model must distinguish between resources which have independent lifecycles but should group together those resources which share a common lifecycle
--	**Aligned:** the model should clearly highlight the dependencies between the elements to allow for a well-defined and simplified synchronisation of independent automation tasks.
+- **Explicit:** the model needs to be rich enough to allow for a direct mapping towards the APIs of NFVIs for the instantiation of virtual infrastructure elements without requiring any additional parameters
+- **Lifecycle:** the model must distinguish between resources which have independent lifecycles but should group together those resources which share a common lifecycle
+- **Aligned:** the model should clearly highlight the dependencies between the elements to allow for a well-defined and simplified synchronisation of independent automation tasks.
 
 _**To summarise:** the abstraction model presented in this document will build upon existing modelling concepts and simplify and streamline them to the needs of telco operators who intend to distinguish between infrastructure related and workload related responsibilities._
 
 <a name="3.1"></a>
-## 3.1	Model
+## 3.1 Model
 
 The abstraction model for the NFVI makes use of the following layers (only the virtual infrastructure layer will be directly exposed to workloads (VNFs/CNFs)):
 
@@ -47,7 +47,7 @@ The functionalities of each layer are as follows:
 - **Workloads (VNFs/CNFs):** These consist of workloads such as virtualized and/or containerized network functions that run on top of a VM or as a Container.
 
 <a name="3.2"></a>
-## 3.2	Virtual Resources
+## 3.2 Virtual Resources
 
 The virtual infrastructure resources provided by the NFVI can be grouped into four categories as shown in the diagram below:
 
@@ -131,7 +131,7 @@ _**Example**: a virtual compute descriptor as defined in TOSCA Simple Profile fo
 <p align="center"><b>Table 3-4:</b> Attributes of network resources.</p>
 
 <a name="3.3"></a>
-## 3.3	Management Software
+## 3.3 Management Software
 
 A network function virtualisation infrastructure provides the capability to manage virtual resources via application programming interfaces or graphical user interfaces. The management software allows to:
 
@@ -173,7 +173,7 @@ A network function virtualisation infrastructure provides the capability to mana
 : provides a mechanism to provision virtual resources with the help of physical network resources
 
 <a name="3.4"></a>
-## 3.4	Physical Resources
+## 3.4 Physical Resources
 
 The physical compute, storage and network resources serve as the foundation of the network function virtualisation infrastructure. They are as such not directly exposed to the workloads (VNFs/CNFs).
 

--- a/doc/ref_model/chapters/chapter03.md
+++ b/doc/ref_model/chapters/chapter03.md
@@ -1,7 +1,7 @@
 [<< Back](../../ref_model)
 # 3	Modelling
 <p align="right"><img src="../figures/bogo_lsf.png" alt="bogo" title="Bogo Meter" width="35%"/></p>
- 
+
 ## Table of Contents
 * [3.1 Model.](#3.1)
 * [3.2 Virtual Resources.](#3.2)
@@ -39,12 +39,12 @@ The abstraction model for the NFVI makes use of the following layers (only the v
 
 <p align="center"><img src="../figures/ch03_model_overview.png" alt="NFVI Model Overview" Title="NFVI Model Overview" width="65%"/></p>
 <p align="center"><b>Figure 3-1:</b> NFVI Model Overview.</p>
-  
+
 The functionalities of each layer are as follows:
 - **Physical Infrastructure Resources:** These consist of physical hardware components such as servers, (including random access memory, local storage, network ports, and hardware acceleration devices), storage devices, network devices, etc. and the basic input output system (BIOS).
 - **NFVI Management Software:** This consists of both the host Operating System (OS) responsible for managing the physical infrastructure resources as well as the virtualization/containerization technology which, on request, dynamically allocates hardware components and exposes them as virtual resources.
 - **Virtual Infrastructure Resources:** These are all the infrastructure resources (compute, storage and networks) which the NFVI provides to the workloads such as VNFs/CNFs. These virtual resources can be managed by the tenants and tenant workloads directly or indirectly via an application programming interface (API).
-- **Workloads (VNFs/CNFs):** These consist of workloads such as virtualized and/or containerized network functions that run on top of a VM or as a Container. 
+- **Workloads (VNFs/CNFs):** These consist of workloads such as virtualized and/or containerized network functions that run on top of a VM or as a Container.
 
 <a name="3.2"></a>
 ## 3.2	Virtual Resources
@@ -64,7 +64,7 @@ The virtualised infrastructure resources related to these categories are listed 
 <a name="3.2.1"></a>
 ### 3.2.1 Tenant
 
-A network function virtualisation infrastructure (NFVI) needs to be capable of supporting multiple tenants and has to isolate sets of infrastructure resources dedicated to specific workloads (VNF/CNF) from one another. Tenants represent an independently manageable logical pool of compute, storage and network resources abstracted from physical hardware. 
+A network function virtualisation infrastructure (NFVI) needs to be capable of supporting multiple tenants and has to isolate sets of infrastructure resources dedicated to specific workloads (VNF/CNF) from one another. Tenants represent an independently manageable logical pool of compute, storage and network resources abstracted from physical hardware.
 
 _**Example**: a tenant within an OpenStack environment or a Kubernetes cluster._
 
@@ -82,7 +82,7 @@ _**Example**: a tenant within an OpenStack environment or a Kubernetes cluster._
 
 <a name="3.2.2"></a>
 ### 3.2.2 Compute
-A virtual machine or a container/pod belonging to a tenant capable of hosting the application components of workloads (VNFs). A virtual compute therefore requires a tenant context and since it will need to communicate with other communication partners it is assumed that the networks have been provisioned in advance. 
+A virtual machine or a container/pod belonging to a tenant capable of hosting the application components of workloads (VNFs). A virtual compute therefore requires a tenant context and since it will need to communicate with other communication partners it is assumed that the networks have been provisioned in advance.
 
 _**Example**: a virtual compute descriptor as defined in TOSCA Simple Profile for NFV._
 
@@ -100,7 +100,7 @@ _**Example**: a virtual compute descriptor as defined in TOSCA Simple Profile fo
 
 <a name="3.2.3"></a>
 ### 3.2.3 Storage
-A block device of a certain size for persisting information which can be created and dynamically attached to/detached from a virtual compute. A storage device resides in a tenant context and exists independently from any compute host. 
+A block device of a certain size for persisting information which can be created and dynamically attached to/detached from a virtual compute. A storage device resides in a tenant context and exists independently from any compute host.
 
 _**Example**: an OpenStack cinder volume._
 
@@ -118,7 +118,7 @@ _**Comments**: we need to be more specific regarding acceleration and metadata._
 
 <a name="3.2.4"></a>
 ### 3.2.4 Network
-A layer 2 / layer 3 communication domain within a tenant. A network requires a tenant context. 
+A layer 2 / layer 3 communication domain within a tenant. A network requires a tenant context.
 
 _**Example**: a virtual compute descriptor as defined in TOSCA Simple Profile for NFV._
 
@@ -128,7 +128,7 @@ _**Example**: a virtual compute descriptor as defined in TOSCA Simple Profile fo
 | `subnet` | network address of the subnet |
 | `acceleration` | key/value pairs for selection of the appropriate acceleration technology |
 
-<p align="center"><b>Table 3-4:</b> Attributes of network resources.</p> 
+<p align="center"><b>Table 3-4:</b> Attributes of network resources.</p>
 
 <a name="3.3"></a>
 ## 3.3	Management Software
@@ -142,12 +142,12 @@ A network function virtualisation infrastructure provides the capability to mana
 
 <p align="center"><img src="../figures/ch03_model_management_software.png" alt="NFVI Management Software" Title="NFVI Management Software" width="65%"/></p>
 <p align="center"><b>Figure 3-3:</b> NFVI Management Software.</p>
-  
+
  The management software needs to support following functional aspects:
- 
+
  **API/UI**
- : an application programming interface / user interface providing access to the NFVI management functions 
- 
+ : an application programming interface / user interface providing access to the NFVI management functions
+
 **Catalogue**
 : manages the collection of available templates for virtual resource the NFVI can provide
 
@@ -179,7 +179,3 @@ The physical compute, storage and network resources serve as the foundation of t
 
 <p align="center"><img src="../figures/ch03_model_physical_resources.png" alt="NFVI Physical Infrastructure Resources" Title="NFVI Physical Infrastructure Resources" width="65%"/></p>
 <p align="center"><b>Figure 3-4:</b> NFVI Physical Resources.</p>
-  
-
-
-

--- a/doc/ref_model/chapters/chapter04.md
+++ b/doc/ref_model/chapters/chapter04.md
@@ -142,7 +142,7 @@ This section covers a list of implicit NFVI capabilities and metrics that define
 
 <!--
 /* MXS 13/7/2019 - Mapping table 3-14 is being commented out. If someone can provide supporting details,
-   we can put it back. Details should include assumptions (e.g., is it SRIOV, OvS or what?), 
+   we can put it back. Details should include assumptions (e.g., is it SRIOV, OvS or what?),
    citable references, an explanation of what we're mapping and why (#s represent min? max? anticipated?, etc.),
    and a detailed basis for the values, including an explanation for how come the numbers are identical for both
    cores and ram. Thanks, -Mark */
@@ -206,7 +206,7 @@ Security content has been relocated to the Security chapter (RM Chapter 7).
 
 Table 4-9: Reserved
 
-<!-- 
+<!--
 <a name="Table4-9"></a>
 //
 | Ref | NFVI capability | Unit | Definition/Notes |
@@ -220,16 +220,16 @@ Table 4-9: Reserved
 
 <a name="4.1.5"></a>
 ### 4.1.5 Internal Infrastructure metrics
-<!-- 
+<!--
 [COMMENT - Xavier Grall, Orange: section "3.4.2.3 Internal SLA metrics" is removed since it is redundant with network performance metrics]
 //
 [COMMENT - Xavier Grall, Orange: section "3.4.2.4 Internal scalability metrics" is removed since it is redundant with resource management metrics]
---> 
+-->
 <a name="4.1.5.1"></a>
-#### 4.1.5.1 Internal performance metrics 
-<!-- 
+#### 4.1.5.1 Internal performance metrics
+<!--
 [COMMENT - Xavier Grall, Orange: the mapping table is removed since those reference values will depend on architecture and implementation, and/or may be derived for different cases (eg w/ or w/o filtering rules for network throughput) ]
---> 
+-->
 
 The following table shows performance metrics per NFVI node.
 
@@ -323,7 +323,7 @@ Table 4-14 shows security capabilities
 ### 4.1.7 VIM metrics.
 
 <a name="4.1.7.1"></a>
-#### 4.1.7.1 Resources management metrics 
+#### 4.1.7.1 Resources management metrics
 **Table 4-15** shows resource management metrics of VIM as aligned with ETSI GS NFV TST-012 [3].
 
 <a name="Table4-15"></a>
@@ -358,16 +358,16 @@ The idea of the infrastructure instances catalogue is to have a predefined set o
 <a name="4.2.1"></a>
 ### 4.2.1 Compute flavours
 
-Flavours represent the compute, memory, storage capacity, and management network resource templates that are used to create the VMs on the compute hosts. Each VM instance is given a flavour (resource template), which determines the instance's core, memory and storage characteristics. 
+Flavours represent the compute, memory, storage capacity, and management network resource templates that are used to create the VMs on the compute hosts. Each VM instance is given a flavour (resource template), which determines the instance's core, memory and storage characteristics.
 
 Flavours can also specify secondary ephemeral storage, swap disk, etc. A compute flavour geometry consists of the following elements:
 
-Element |Description 
+Element |Description
 --------|----------
 Name	|A descriptive name
 Virtual compute resources (aka vCPUs) |Number of virtual compute resources (vCPUs) presented to the instance.
-Memory MB	|Instance memory in megabytes. 
-Ephemeral/Local Disk |Specifies the size of an ephemeral data disk that exists only for the life of the instance. Default value is 0.<br />The ephemeral disk may be partitioned into boot (base image) and swap space disks. 
+Memory MB	|Instance memory in megabytes.
+Ephemeral/Local Disk |Specifies the size of an ephemeral data disk that exists only for the life of the instance. Default value is 0.<br />The ephemeral disk may be partitioned into boot (base image) and swap space disks.
 Is Public	|Boolean value, whether flavor is available to all users or private to the project it was created in. Defaults to True.
 
 <p align="center"><b>Table 4-16:</b> Flavour Geometry Specification.</p>
@@ -396,7 +396,7 @@ The intent of the following flavours list is to be comprehensive and yet effecti
 
 The network interface specifications extend the flavour customization to specify the network interface “n” followed by the interface bandwidth (in Gbps). Multiple network interface bandwidths, where network interfaces of different bandwidths exist, can be specified by repeating the “n” option.
 
-Note, the number of virtual network interfaces, aka vNICs, associated with an instance of a virtual environment, is directly related to the number of vNIC extensions declared for the environment. The vNIC extension is not part of the base flavour. 
+Note, the number of virtual network interfaces, aka vNICs, associated with an instance of a virtual environment, is directly related to the number of vNIC extensions declared for the environment. The vNIC extension is not part of the base flavour.
 ```
 <network interface bandwidth option> :: <”n”><number (bandwidth in Gbps)>
 ```
@@ -453,7 +453,7 @@ This instance type is intended to be used for both IT workloads as well as NFV w
 This instance type is intended to be used for those applications that has high network throughput requirements (up to 50Gbps). This instance type is more intended for VNFs and is expected to be available in regional (distributed) data centres and more towards the access networks.
 
 ##### 4.2.4.2.1 Network Acceleration Extensions
-N instance types can come with Network Acceleration extensions to assist VNFs offloading some of their network intensive operations to hardware. The list below is preliminary and is expected to grow as more network acceleration resources are developed and standardized. 
+N instance types can come with Network Acceleration extensions to assist VNFs offloading some of their network intensive operations to hardware. The list below is preliminary and is expected to grow as more network acceleration resources are developed and standardized.
 >_Interface types are aligned with ETSI NFV IFA 002 [4]._
 
 | .conf | Interface type | Description |

--- a/doc/ref_model/chapters/chapter04.md
+++ b/doc/ref_model/chapters/chapter04.md
@@ -1,5 +1,5 @@
 [<< Back](../../ref_model)
-# 4	Infrastructure Capabilities, Metrics, and Catalogue
+# 4 Infrastructure Capabilities, Metrics, and Catalogue
 <p align="right"><img src="../figures/bogo_lsf.png" alt="scope" title="Scope" width="35%"/></p>
 
 
@@ -46,7 +46,7 @@ Note: The figure above indicates the areas from where the objects are <i>visible
 ### 4.1.2 Exposed Infrastructure capabilities
 This section describes a set of explicit NFVI capabilities and metrics that define an NFVI. These capabilities and metrics are well known to VNFs as they provide capabilities which VNFs rely on.
 
-> _**Note**: 	It is expected that NFVI capabilities and metrics will evolve with time as more capabilities are added as technology enhances and matures._
+> _**Note**:  It is expected that NFVI capabilities and metrics will evolve with time as more capabilities are added as technology enhances and matures._
 
 <a name="4.1.2.1"></a>
 #### 4.1.2.1 Exposed resource capabilities
@@ -125,7 +125,7 @@ The following shows performance metrics per VNF-C, vNIC or vCPU.
 
 This section covers a list of implicit NFVI capabilities and metrics that define the interior of   NFVI. These capabilities and metrics determine how the NFVI behaves internally. They are hidden from VNFs (i.e. VNFs may not know about them) but they will have a big impact on the overall performance and capabilities of a given NFVI solution.
 
->_**Note**: 	It is expected that implicit NFVI capabilities and metrics will evolve with time as more capabilities are added as technology enhances and matures._
+>_**Note**:  It is expected that implicit NFVI capabilities and metrics will evolve with time as more capabilities are added as technology enhances and matures._
 
 <a name="4.1.4.1"></a>
 #### 4.1.4.1 Internal resource capabilities
@@ -364,11 +364,11 @@ Flavours can also specify secondary ephemeral storage, swap disk, etc. A compute
 
 Element |Description
 --------|----------
-Name	|A descriptive name
+Name |A descriptive name
 Virtual compute resources (aka vCPUs) |Number of virtual compute resources (vCPUs) presented to the instance.
-Memory MB	|Instance memory in megabytes.
+Memory MB |Instance memory in megabytes.
 Ephemeral/Local Disk |Specifies the size of an ephemeral data disk that exists only for the life of the instance. Default value is 0.<br />The ephemeral disk may be partitioned into boot (base image) and swap space disks.
-Is Public	|Boolean value, whether flavor is available to all users or private to the project it was created in. Defaults to True.
+Is Public |Boolean value, whether flavor is available to all users or private to the project it was created in. Defaults to True.
 
 <p align="center"><b>Table 4-16:</b> Flavour Geometry Specification.</p>
 
@@ -380,12 +380,12 @@ The intent of the following flavours list is to be comprehensive and yet effecti
 
 .conf |vCPU ("c") |RAM ("r") |Local Disk ("d") | Management Interface
 -----|------------|----------|-----|-----
-.tiny	|1	|512 MB	|1 GB	|1 Gbps
-.small	|1	|2 GB	|20 GB 	|1 Gbps
-.medium	|2	|4 GB	|40 GB	|1 Gbps
-.large	|4	|8 GB	|80 GB	|1 Gbps
-.2xlarge*	|8	|16 GB	|160 GB	|1 Gbps
-.4xlarge*	|16	|32 GB	|320 GB	|1 Gbps
+.tiny |1 |512 MB |1 GB |1 Gbps
+.small |1 |2 GB |20 GB  |1 Gbps
+.medium |2 |4 GB |40 GB |1 Gbps
+.large |4 |8 GB |80 GB |1 Gbps
+.2xlarge* |8 |16 GB |160 GB |1 Gbps
+.4xlarge* |16 |32 GB |320 GB |1 Gbps
 
 <p align="center"><b>Table 4-17:</b> Predefined Compute flavours.</p>
 
@@ -401,13 +401,13 @@ Note, the number of virtual network interfaces, aka vNICs, associated with an in
 <network interface bandwidth option> :: <”n”><number (bandwidth in Gbps)>
 ```
 
-Virtual Network Interface Option	|Interface Bandwidth
+Virtual Network Interface Option |Interface Bandwidth
 ---|---
-n1, n2, n3, n4, n5, n6	|1, 2, 3, 4, 5, 6 Gbps
-n10, n20, n30, n40, n50, n60	|10, 20, 30, 40, 50, 60 Gbps
-n25, n50, n75, n100, n125, n150	|25, 50, 75, 100, 125, 150 Gbps
-n50, n100, n150, n200, n250, n300	|50, 100, 150, 200, 250, 300 Gbps
-n100, n200, n300, n400, n500, n600	|100, 200, 300, 400, 500, 600 Gbps
+n1, n2, n3, n4, n5, n6 |1, 2, 3, 4, 5, 6 Gbps
+n10, n20, n30, n40, n50, n60 |10, 20, 30, 40, 50, 60 Gbps
+n25, n50, n75, n100, n125, n150 |25, 50, 75, 100, 125, 150 Gbps
+n50, n100, n150, n200, n250, n300 |50, 100, 150, 200, 250, 300 Gbps
+n100, n200, n300, n400, n500, n600 |100, 200, 300, 400, 500, 600 Gbps
 
 <p align="center"><b>Table 4-18:</b> Virtual Network Interface Specification Examples.</p>
 
@@ -415,11 +415,11 @@ n100, n200, n300, n400, n500, n600	|100, 200, 300, 400, 500, 600 Gbps
 ###  4.2.3 Storage Extensions
 Multiple non-ephemeral storage volumes can be attached to virtual computes  for persistent data storage. Each of those volumes can be configured with the required performance category.
 
-.conf	|Read IO/s	|Write IO/s	Read |Throughput (MB/s)	|Write Throughput (MB/s)
+.conf |Read IO/s |Write IO/s Read |Throughput (MB/s) |Write Throughput (MB/s)
 ---|---|---|---|---
-.bronze	|Up to 3K	|Up to 15K	|Up to 180	|Up to 120
-.silver	|Up to 60K	|Up to 30K	|Up to 1200	|Up to 400
-.gold	|Up to 680K	|Up to 360K	|Up to 2650	|Up to 1400
+.bronze |Up to 3K |Up to 15K |Up to 180 |Up to 120
+.silver |Up to 60K |Up to 30K |Up to 1200 |Up to 400
+.gold |Up to 680K |Up to 360K |Up to 2650 |Up to 1400
 
 <p align="center"><b>Table 4-19:</b> Storage Performance Profiles.</p>
 
@@ -487,10 +487,10 @@ C instance types can come with compute acceleration extensions to assist VNFs/VA
 
 | Virtual interface option* | Basic Type | Network Intensive Type | Compute Intensive Type
 |---------------------------|-----|-----|-----
-n1, n10, n1T*, n1Q*, n1P*, n1H*	| Y | N |N
-n10, n10D, n10T*, n10Q*, n10P*, n10H*	| Y | Y | Y
-n25, n25D, n25T*, n25Q*, n25P*, n25H*	| N | Y | Y
-n50, n50D, n50T*, n50Q*, n50P*, n50H*	| N | Y | Y
+n1, n10, n1T*, n1Q*, n1P*, n1H* | Y | N |N
+n10, n10D, n10T*, n10Q*, n10P*, n10H* | Y | Y | Y
+n25, n25D, n25T*, n25Q*, n25P*, n25H* | N | Y | Y
+n50, n50D, n50T*, n50Q*, n50P*, n50H* | N | Y | Y
 n100, n100D, n100T*, n100Q*, n100P*, n100H* | N | Y | N
 
 <p align="center"><b>Table 4-23:</b> Virtual NIC interfaces options</p>

--- a/doc/ref_model/chapters/chapter05.md
+++ b/doc/ref_model/chapters/chapter05.md
@@ -1,5 +1,5 @@
 [<< Back](../../ref_model)
-# 5	Feature set and Requirements from Infrastructure
+# 5 Feature set and Requirements from Infrastructure
 <p align="right"><img src="../figures/bogo_lsf.png" alt="scope" title="Scope" width="35%"/></p>
 
 ## Table of Contents
@@ -41,9 +41,9 @@ Depending on the requirements of VNFs, a VNFC will be deployed with a NFVI insta
 
 The following sections detail the NFVI SW profile features per type of virtual resource. The list of these features will evolve over time.
 
-### 5.1.1	Virtual Compute
+### 5.1.1 Virtual Compute
 
-**Table 5-1** and **Table 5-2**	depict the features related to virtual compute.
+**Table 5-1** and **Table 5-2** depict the features related to virtual compute.
 
 | .conf | Feature | Type  | Description |
 |------------------|----------------|----------------|------------------------------------------------------------------------------------------------|
@@ -63,7 +63,7 @@ The following sections detail the NFVI SW profile features per type of virtual r
 <p align="center"><b>Table 5-2:</b> Virtual Compute Acceleration features.</p>
 
 <a name="5.2"></a>
-### 5.1.2	Virtual Storage
+### 5.1.2 Virtual Storage
 
 **Table 5-3** and **Table 5-4** depict the features related to virtual storage.
 
@@ -110,7 +110,7 @@ The following sections detail the NFVI SW profile features per type of virtual r
 <p align="center"><b>Table 5-6:</b> Virtual Networking Acceleration features.</p>
 
 <a name="5.1.4"></a>
-### 5.1.4	Security
+### 5.1.4 Security
 _**Comment:** To be worked on._
 
 <a name="5.2"></a>

--- a/doc/ref_model/chapters/chapter05.md
+++ b/doc/ref_model/chapters/chapter05.md
@@ -6,7 +6,7 @@
 * [5.1 NFVI SW profile description.](#5.1)
   * [5.1.1 Virtual Compute.](#5.1.1)
   * [5.1.2 Virtual Storage.](#5.1.2)
-  * [5.1.3 Virtual Networking.](#5.1.3) 
+  * [5.1.3 Virtual Networking.](#5.1.3)
   * [5.1.4 Security.](#5.1.4)
 * [5.2 NFVI SW profiles features and requirements.](#5.2)
   * [5.2.1 Virtual Compute.](#5.2.1)
@@ -70,10 +70,10 @@ The following sections detail the NFVI SW profile features per type of virtual r
 | .conf | Feature | Type  | Description |
 |------------------|----------------|----------------|------------------------------------------------------------------------------------------------|
 | nfvi.stg.cfg.001 | Storage Types | Yes/No   | Support of Storage types described in the catalogue |
-| nfvi.stg.cfg.002 | Storage Block | Yes/No  |  |  
-| nfvi.stg.cfg.003 | Storage Object | Yes/No |  |  
-| nfvi.stg.cfg.004 | Storage with replication |  Yes/No |  |  
-| nfvi.stg.cfg.005 | Storage with encryption | Yes/No |  |  
+| nfvi.stg.cfg.002 | Storage Block | Yes/No  |  |
+| nfvi.stg.cfg.003 | Storage Object | Yes/No |  |
+| nfvi.stg.cfg.004 | Storage with replication |  Yes/No |  |
+| nfvi.stg.cfg.005 | Storage with encryption | Yes/No |  |
 
 <p align="center"><b>Table 5-3:</b> Virtual Storage features.</p>
 
@@ -94,7 +94,7 @@ The following sections detail the NFVI SW profile features per type of virtual r
 | nfvi.net.cfg.002 | Overlay protocol | Protocols | The overlay network encapsulation protocol needs to enable ECMP in the underlay to take advantage of the scale-out features of the network fabric. |
 | nfvi.net.cfg.003 | NAT |  Yes/No |  Support of Network Address Translation |
 | nfvi.net.cfg.004 | Security Groups | Yes/No  | Set of rules managing incoming and outgoing network traffic |
-| nfvi.net.cfg.005 | SFC  |Yes/No   |  Support of Service Function Chaining |  
+| nfvi.net.cfg.005 | SFC  |Yes/No   |  Support of Service Function Chaining |
 | nfvi.net.cfg.006 | Traffic patterns symmetry | Yes/No  | Traffic patterns should be optimal, in terms of packet flow. North-south traffic shall not be concentrated in specific elements in the architecture, making those critical choke-points, unless strictly necessary (i.e. when NAT 1:many is required). |
 
 
@@ -150,11 +150,11 @@ This section will detail NFVI SW profiles and associated configurations for the 
 
 | .conf | Feature | Type  | Basic | Network Intensive | Compute Intensive |
 |------------------|----------------|----------------|----------------|----------------|----------------|
-| nfvi.stg.cfg.001 | Catalogue storage Types | Yes/No | Y  | Y  | Y |  
-| nfvi.stg.cfg.002 | Storage Block | Yes/No | Y | Y |Y  | 
-| nfvi.stg.cfg.003 | Storage Object |Yes/No  | Y | Y | Y | 
-| nfvi.stg.cfg.004 | Storage with replication | Yes/No | N | Y | Y | 
-| nfvi.stg.cfg.005 | Storage with encryption |Yes/No | Y | Y | Y | 
+| nfvi.stg.cfg.001 | Catalogue storage Types | Yes/No | Y  | Y  | Y |
+| nfvi.stg.cfg.002 | Storage Block | Yes/No | Y | Y |Y  |
+| nfvi.stg.cfg.003 | Storage Object |Yes/No  | Y | Y | Y |
+| nfvi.stg.cfg.004 | Storage with replication | Yes/No | N | Y | Y |
+| nfvi.stg.cfg.005 | Storage with encryption |Yes/No | Y | Y | Y |
 
 <p align="center"><b>Table 5-9:</b> Virtual Storage features and configuration for the 3 types of SW profiles.</p>
 
@@ -162,8 +162,8 @@ This section will detail NFVI SW profiles and associated configurations for the 
 
 | .conf | Feature | Type  | Basic | Network Intensive | Compute Intensive |
 |------------------|----------------|----------------|----------------|----------------|----------------|
-| nfvi.stg.acc.cfg.001 | Storage IOPS oriented | Yes/No | N | Y | Y |  
-| nfvi.stg.acc.cfg.002 | Storage capacity oriented |  Yes/No| N | N | Y |  
+| nfvi.stg.acc.cfg.001 | Storage IOPS oriented | Yes/No | N | Y | Y |
+| nfvi.stg.acc.cfg.002 | Storage capacity oriented |  Yes/No| N | N | Y |
 
 <p align="center"><b>Table 5-10:</b> Virtual Storage Acceleration features.</p>
 
@@ -202,10 +202,10 @@ This chapter defines a simplified host, host profile and related capabilities mo
 <p align="center"><img src="../figures/ch06_ref_nfvi_hw_profiles_v3.png" alt="ref_hw_profiles" title="Reference HW Profiles" width="100%"/></p>
 <p align="center"><b>Figure 5-4:</b> NFVI hardware profiles and host associated capabilities.</p>
 
-The host profile model and configuration parameters (hereafter for simplicity simply "host profile") will be utilized in the **Reference Architecture** to define different hardware profiles. The host profiles can be considered to be the set of EPA-related (Enhanced Performance Awareness) configurations on NFVI resources. 
+The host profile model and configuration parameters (hereafter for simplicity simply "host profile") will be utilized in the **Reference Architecture** to define different hardware profiles. The host profiles can be considered to be the set of EPA-related (Enhanced Performance Awareness) configurations on NFVI resources.
 >Please note that in this chapter we shall not list all of the EPA-related configuration parameters.
 
-A software profile (see **Chapter 4** and **Chapter 5**) defines the characteristics of NFVI SW of which Virtual Machines (or Containers) will be deployed on. A many to many relationship exists between software profiles and host profiles. A given host can only be assigned a single host profile; a host profile can be assigned to multiple hosts. Different Cloud Service Providers (CSP) may utilize different naming standards for their host profiles. 
+A software profile (see **Chapter 4** and **Chapter 5**) defines the characteristics of NFVI SW of which Virtual Machines (or Containers) will be deployed on. A many to many relationship exists between software profiles and host profiles. A given host can only be assigned a single host profile; a host profile can be assigned to multiple hosts. Different Cloud Service Providers (CSP) may utilize different naming standards for their host profiles.
 
 The following naming convention is used in this document:
 
@@ -228,7 +228,7 @@ The host profile and capabilities include:
 1. **Local Disk Capacity**: is the # of local disks and teh capacity of the disks installed on the physical server.
 1. **HT (Hyper Threading; technically, SMT: Simultaneous Multithreading)**: Enabled on all physical servers. Gets 2 hyper threads per physical core. Always ON. Configured in the host (BIOS).
 1. **NUMA (Non-Uniform Memory Access)**: Indicates that vCPU will be on a Socket that is aligned with the associated NIC card and memory. Important for performance optimized VNFs. Configured in the host (BIOS).
-1. **SR-IOV (Single-Root Input/Output Virtualisation)**: Configure PCIe ports to support SR-IOV. 
+1. **SR-IOV (Single-Root Input/Output Virtualisation)**: Configure PCIe ports to support SR-IOV.
 1. **smartNIC (aka Intelligent Server Adaptors)**: Accelerated virtual switch using smartNIC
 1. **Cryptography Accelerators**: such as AES-NI, SIMD/AVX, QAT.
 1. **Security features**: such as TRusted Platform Module (TPM).
@@ -238,7 +238,7 @@ The host profile and capabilities include:
 <!--1. **CPU Pinning**: vCPU is pinned to a physical core and dedicated to the requesting VM. Configured in VIM and Hypervisor.-->
 <!--1. **Huge Pages**: By default, CPUs allocate RAM in 4K chunks. Hugepages can be enabled to allocate in larger Chunks (such as 2MB, 1GB). This helps improve performance in some cases. Configured in the Operating System. -->
 
-The following model, **Figure 5-6**, depicts the essential characteristics of a host that are of interest in specifying a host profile. The host (physical server) is composed of compute, network and storage resources. The compute resources are composed of physical CPUs (aka CPU sockets or sockets) and memory (RAM). The network resources and storage resources are similarly modelled. 
+The following model, **Figure 5-6**, depicts the essential characteristics of a host that are of interest in specifying a host profile. The host (physical server) is composed of compute, network and storage resources. The compute resources are composed of physical CPUs (aka CPU sockets or sockets) and memory (RAM). The network resources and storage resources are similarly modelled.
 
 <p align="center"><img src="../figures/ch06_generic_model.PNG" alt="generic_model" title="Generic Model" width="100%"/></p>
 <p align="center"><b>Figure 5-6:</b> Generic model of a compute host for use in Host Profile configurations.</p>
@@ -266,7 +266,7 @@ The configurations specified in here will be utilized in specifying the actual h
 
 <!--
 | nfvi.hw.cpu.cfg.005 | CPU Pinning |  | N | Y | Y
-| nfvi.hw.cpu.cfg.006 | CPU Oversubscription Ratio* |  | n:1 | 1:1 | 1:1 
+| nfvi.hw.cpu.cfg.006 | CPU Oversubscription Ratio* |  | n:1 | 1:1 | 1:1
 | nfvi.hw.cpu.cfg.007 | Hugepages* |  | N | Y | Y
 -->
 

--- a/doc/ref_model/chapters/chapter06.md
+++ b/doc/ref_model/chapters/chapter06.md
@@ -1,5 +1,5 @@
 [<< Back](../../ref_model)
-# 6	External Interfaces
+# 6 External Interfaces
 <p align="right"><img src="../figures/bogo_sdc.png" alt="scope" title="Scope" width="35%"/></p>
 
 ## Table of Contents
@@ -37,13 +37,13 @@ The NFVI APIs consist of set of APIs that are externally and internally visible.
 <p align="center"><img src="../figures/ch01_etsi_archi_mapping_v2.PNG" alt="ETSI NFVI Interface" title="ETSI NFVI Interface" width="65%"/></p>
 <p align="center"><b>Figure 6-1:</b> ETSI NFVI Interface points.</p>
 
-| Interface Point	| NFVI Exposure	| Interface Between |	Description|
+| Interface Point | NFVI Exposure | Interface Between | Description|
 |--------------|--------------|--------------|--------------|
-| Vi-Ha	| Internal	NFVI | Software Layer and Hardware Resources |	1.	Discover/collect resources and their configuration information <br>2.	Create execution environment (e.g., VM) for workloads (VNF) |
-| Vn-Nf| 	External	| NFVI and VM (VNF)	| Here VNF represents the execution environment. The interface is used to specify interactions between the VNF and abstract NFVI accelerators. The inetrafecs can be used to discover, configure and manage these acceleartors and for the VNF to register/deregister for receiving acceleartor events and data. |
-| NF-Vi	| External	| NFVI and VIM |	1.	Discover/collect physical/virtual resources and their configuration information<br>2.	Manage (create, resize, (un) suspend, reboot, etc.) physical/virtualised resources<br>3.	Physical/Virtual resources configuration changes<br>4.	Physical/Virtual resource configuration. |
-| Or-Vi	| External	| VNF Orchestrator and VIM	| See below |
-| Vi-Vnfm	| External	| VNF Manager and VIM	| See below |
+| Vi-Ha | Internal NFVI | Software Layer and Hardware Resources | 1. Discover/collect resources and their configuration information <br>2. Create execution environment (e.g., VM) for workloads (VNF) |
+| Vn-Nf|  External | NFVI and VM (VNF) | Here VNF represents the execution environment. The interface is used to specify interactions between the VNF and abstract NFVI accelerators. The inetrafecs can be used to discover, configure and manage these acceleartors and for the VNF to register/deregister for receiving acceleartor events and data. |
+| NF-Vi | External | NFVI and VIM | 1. Discover/collect physical/virtual resources and their configuration information<br>2. Manage (create, resize, (un) suspend, reboot, etc.) physical/virtualised resources<br>3. Physical/Virtual resources configuration changes<br>4. Physical/Virtual resource configuration. |
+| Or-Vi | External | VNF Orchestrator and VIM | See below |
+| Vi-Vnfm | External | VNF Manager and VIM | See below |
 
 <p align="center"><b>Table 6-1:</b> NFVI and VIM Interfaces with Other System Components.</p>
 

--- a/doc/ref_model/chapters/chapter06.md
+++ b/doc/ref_model/chapters/chapter06.md
@@ -32,7 +32,7 @@ Chapter 3 introduced a model of the Network Function Virtualisation Infrastructu
 
 <a name="6.2"></a>
 ## 6.2 NFVI APIs
-The NFVI APIs consist of set of APIs that are externally and internally visible. The externally visible APIs are made available for orchestration and management of the execution environments that host workloads (e.g., VNFs) while the internally visible APIs support actions on the hypervisor and the physical resources. The ETSI NFV Reference Architecture Framework (**Figure 6-1**) shows a number of Interface points where specific or sets of APIs are supported. For the scope of the reference model the relevant interface points are shown in **Table 6-1**. 
+The NFVI APIs consist of set of APIs that are externally and internally visible. The externally visible APIs are made available for orchestration and management of the execution environments that host workloads (e.g., VNFs) while the internally visible APIs support actions on the hypervisor and the physical resources. The ETSI NFV Reference Architecture Framework (**Figure 6-1**) shows a number of Interface points where specific or sets of APIs are supported. For the scope of the reference model the relevant interface points are shown in **Table 6-1**.
 
 <p align="center"><img src="../figures/ch01_etsi_archi_mapping_v2.PNG" alt="ETSI NFVI Interface" title="ETSI NFVI Interface" width="65%"/></p>
 <p align="center"><b>Figure 6-1:</b> ETSI NFVI Interface points.</p>
@@ -46,7 +46,7 @@ The NFVI APIs consist of set of APIs that are externally and internally visible.
 | Vi-Vnfm	| External	| VNF Manager and VIM	| See below |
 
 <p align="center"><b>Table 6-1:</b> NFVI and VIM Interfaces with Other System Components.</p>
-			
+
 The Or-Vi and Vi-VNfm are both specifying interfaces provided by the VIM and therefore are related. The Or-Vi reference point is used for exchanges between NFV Orchestrator and VIM, and supports the following interfaces; virtualised resources refers to virtualised compute, storage and network resources:
 
 - Software Image Management
@@ -65,10 +65,10 @@ The Or-Vi and Vi-VNfm are both specifying interfaces provided by the VIM and the
 ### 6.2.1 Tenant Level APIs
 
 In the abstraction model of the NFVI (**Chapter 3**) a conceptual model of a Tenant (**Figure 3-2**) represents the slice of a cloud zone dedicated to a VNF. This slice, the Tenant, is composed of virtual resources being utilized by VNFs within that Tenant. The Tenant has an assigned quota of virtual resources, a set of users can perform operations as per their assigned roles, and the Tenant exists within a Cloud Zone. The APIs will specify the allowed operations on the Tenant including its component virtual resources and the different APIs can only be executed by users with the appropriate roles. For example, a Tenant may only be allowed to be created and deleted by Cloud Zone administrators while virtual compute resources could be allowed to be created and deleted by Tenant administrators.
- 
+
 For a VNF stack to be created in a Tenant also requires APIs for the management (creation, deletion and operation) of the Tenant, software flavours (Chapter 5), Operating System and VNF images (“Images”), Identity and Authorization (“Identity”), virtual resources, security and the VNF application (“stack”).
 
-A virtual compute resource is created as per the flavour template (specifies the compute, memory and local storage capacity) and is launched using an image with access and security credentials; once launched, it is referred to as a virtual compute instance or just “Instance”). Instances can be launched by specifying the compute, memory and local storage capacity parameters instead of an existing flavour; reference to flavours coves the situation where the capacity parameters are specified. IP addresses and storage volumes can be attached to a running Instance. 
+A virtual compute resource is created as per the flavour template (specifies the compute, memory and local storage capacity) and is launched using an image with access and security credentials; once launched, it is referred to as a virtual compute instance or just “Instance”). Instances can be launched by specifying the compute, memory and local storage capacity parameters instead of an existing flavour; reference to flavours coves the situation where the capacity parameters are specified. IP addresses and storage volumes can be attached to a running Instance.
 
 | Resource | Create | List | Attach | Detach | Delete | Notes |
 |-----------------|--------|------|--------|--------|--------|-------------------------------------------------------------------------------------------------------------|
@@ -86,11 +86,11 @@ A virtual compute resource is created as per the flavour template (specifies the
 | Virtual network | + | + | + | + | + | Create/delete by VDC users with appropriate role |
 
 <p align="center"><b>Table 6-2:</b> API types for a minimal set of resources.</p>
- 
+
 **Table 6-2** specifies a minimal set of operations for a minimal set of resources that are needed to orchestrate VNF workloads. The actual APIs for the listed operations will be specified in the Reference Architectures; each listed operation could have a number of associated APIs with a different set of parameters. For example, create virtual resource using an image or a device.
 
 <a name="6.2.2"></a>
-### 6.2.2 Hardware Acceleration Interfaces 
+### 6.2.2 Hardware Acceleration Interfaces
 
 **Acceleration Interface Specifications**
 ETSI GS NFV-IFA 002 defines a technology and implementation independent virtual accelerator, the accelerator interface requirements and specifications that would allow a VNF to leverage a Virtual Accelerator. The virtual accelerator is modeled on extensible para-virtualised devices (EDP). ETSI GS NFV-IFA 002 specifies the architectural model in Chapter 4 and the abstract interfaces for management, configuration, monitoring and Data exchange in Chapter 7.
@@ -175,7 +175,7 @@ Table 6-1 lists a number of NFVI and VIM inetrfaces, including the internal VI-H
 
 <a name="6.4"></a>
 ## 6.4. Enabler Services Interfaces
-An operational cloud needs a set of standard services to function. Services such as NTP for time synchronization, DHCP for IP address allocation, DNS for obtaining IP addresses for domain names, and LBaaS (version 2) to distribute incoming requests amongst a pool of designated resources. 
+An operational cloud needs a set of standard services to function. Services such as NTP for time synchronization, DHCP for IP address allocation, DNS for obtaining IP addresses for domain names, and LBaaS (version 2) to distribute incoming requests amongst a pool of designated resources.
 
 ## References
 Network Functions Virtualisation (NFV); Infrastructure; Hypervisor Domain. ETSI GS NFV-INF 004

--- a/doc/ref_model/chapters/chapter07.md
+++ b/doc/ref_model/chapters/chapter07.md
@@ -7,7 +7,7 @@
 * [7.2 Principles and Guidelines.](#7.2)
   * [7.2.1 Overarching Objectives and Goals.](#7.2.1)
   * [7.2.2 Verification Methodologies.](#7.2.2)
-  * [7.2.3 Governance.](#7.2.3)  
+  * [7.2.3 Governance.](#7.2.3)
 * [7.3 Common standards.](#7.3)
   * [7.3.1 Potential attack vectors.](#7.3.1)
   * [7.3.2 Testing demarcation points.](#7.3.2)
@@ -80,14 +80,14 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 Security vulnerabilities and attack vectors are everywhere.  The telecom industry and its cloud infrastructures are even more vulnerable to potential attacks due to the ubiquitous nature of the infrastructures and services combined with the vital role Telecommunications play in the modern world.   The attack vectors are many and varied, ranging from the potential for exposure of sensitive data, both personal and corporate, to weaponized disruption to the global Telecommunications networks.  The threats can take the form of a physical attack on the locations the infrastructure hardware is housed, to network attacks such as denial of service and targeted corruption of the network service applications themselves.  Whatever the source, any NFVI infrastructure built needs to be able to withstand attacks in whatever form they take.
 
-With that in mind, the NFVI reference model and the supporting architectures are not only required to optimally support networking functions, but they must be designed with common security principles and standards from inception.  These best practices must be applied at all layers of the infrastructure stack and across all points of interconnections with outside networks, APIs and contact points with the NFV network functions overlaying or interacting with that infrastructure. 
-Standards organizations with recommendations and best practices, and certifications that need to be taken into consideration include the following examples. However this is by no means an exhaustive list, just some of the more important standards in current use.  
+With that in mind, the NFVI reference model and the supporting architectures are not only required to optimally support networking functions, but they must be designed with common security principles and standards from inception.  These best practices must be applied at all layers of the infrastructure stack and across all points of interconnections with outside networks, APIs and contact points with the NFV network functions overlaying or interacting with that infrastructure.
+Standards organizations with recommendations and best practices, and certifications that need to be taken into consideration include the following examples. However this is by no means an exhaustive list, just some of the more important standards in current use.
 
  •	Center for Internet Security - https://www.cisecurity.org/
 
  •	Cloud Security Alliance - https://cloudsecurityalliance.org/
 
- •	Open Web Application Security Project https://www.owasp.org  
+ •	Open Web Application Security Project https://www.owasp.org
 
  •	The National Institute of Standards and Technology (NIST) (US Only)
 
@@ -102,9 +102,9 @@ Standards organizations with recommendations and best practices, and certificati
     o	ISO/IEC 27032 - ISO/IEC 27032is the international Standard focusing explicitly on cybersecurity.
 
     o	ISO/IEC 27035 - ISO/IEC 27035 is the international Standard for incident management. Incident management
-    
+
     o	ISO/IEC 27031 - ISO/IEC 27031 is the international Standard for ICT readiness for business continuity.
-    
+
 A good place to start to understand the requirements is to use the widely accepted definitions developed by the OWASP – Open Web Application Security Project.  These include the following core principles:
 
 •	Confidentiality – Only allow access to data for which the user is permitted
@@ -124,7 +124,7 @@ Previously attacks designed to place and migrate workload outside the legal boun
 <a name="7.3.2"></a>
 ## 7.3.2 Testing demarcation points.
 
-It is not enough to just secure all potential points of entry and hope for the best, any NFVI architecture must be able to be tested and validated that it is in fact protected from attack as much as possible. The ability to test the infrastructure for vulnerabilities on a continuous basis is critical for maintaining the highest level of security possible.  Testing needs to be done both from the inside and outside of the systems and networks.  Below is a small sample of some of the testing methodologies and frameworks available.  
+It is not enough to just secure all potential points of entry and hope for the best, any NFVI architecture must be able to be tested and validated that it is in fact protected from attack as much as possible. The ability to test the infrastructure for vulnerabilities on a continuous basis is critical for maintaining the highest level of security possible.  Testing needs to be done both from the inside and outside of the systems and networks.  Below is a small sample of some of the testing methodologies and frameworks available.
 
 •	OWASP testing guide
 
@@ -464,7 +464,7 @@ There will be a different set of security requirements for each NFVi reference a
                 -   Security event logging (All security events should
                     be logged, including informational)
                 -   Privilege escalation detection
-  
+
   <a name="7.7.5"></a>
 ### 7.7.5 Logging
                 -   (Logging output should support customizable Log
@@ -476,7 +476,7 @@ There will be a different set of security requirements for each NFVi reference a
             -   Container Images
                 -   Container Management
                 -   Immutability
-                
+
 <a name="7.7.7"></a>
 ### 7.7.7 Identity and Access Management
 
@@ -495,7 +495,7 @@ There will be a different set of security requirements for each NFVi reference a
 ### 7.7.10 Password complexity support
                 -   Software should support configurable, or industry
                     standard, password complexity rules
-                    
+
  <a name="7.7.11"></a>
 ### 7.7.11 Banner
                 -   Software should have support for configurable
@@ -523,12 +523,12 @@ The Operator’s responsibility is to not only make sure that security is includ
 NFVI operators must ensure that remote attestation methods are used to remotely verify the trust status of a given NFVI platform.  The basic concept is based on boot integrity measurements leveraging the TPM built into the underlying hardware. Remote attestation can be provided as a service, and may be used by either the platform owner or a consumer/customer to verify that the platform has booted in a trusted manner. Practical implementations of the remote attestation service include the open cloud integrity tool (Open CIT).   Open CIT provides ‘Trust’ visibility of the cloud infrastructure and enables compliance in cloud datacenters by establishing the root of trust and builds the chain of trust across hardware, operating system, hypervisor, VM and container.  It includes asset tagging for location and boundary control. The platform trust and asset tag attestation information is used by Orchestrators and/or Policy Compliance management to ensure workloads are launched on trusted and location/boundary compliant platforms. They provide the needed visibility and auditability of infrastructure in both public and private cloud environments.
 
 Insert diagram here:
-https://01.org/sites/default/files/users/u26957/32_architecture.png 
+https://01.org/sites/default/files/users/u26957/32_architecture.png
 
 <a name="7.8.2"></a>
 ### 7.8.2 VNF Image Scanning / Signing
 
-It is easy to tamper with VNF images. It requires only a few seconds to insert some malware into a VNF image file while it is being uploaded to an image database or being transferred from an image database to a compute node. To guard against this possibility, VNF images can be cryptographically signed and verified during launch time. This can be achieved by setting up a signing authority and modifying the hypervisor configuration to verify an image’s signature before they are launched. To implement image security, the VNF operator must test the image and supplementary components verifying that everything conforms to security policies and best practices. 
+It is easy to tamper with VNF images. It requires only a few seconds to insert some malware into a VNF image file while it is being uploaded to an image database or being transferred from an image database to a compute node. To guard against this possibility, VNF images can be cryptographically signed and verified during launch time. This can be achieved by setting up a signing authority and modifying the hypervisor configuration to verify an image’s signature before they are launched. To implement image security, the VNF operator must test the image and supplementary components verifying that everything conforms to security policies and best practices.
 
 <a name="7.9"></a>
 ## 7.9 VNF Vendors responsibility.
@@ -544,7 +544,7 @@ The VNF vendors need to incorporate security elements to support the highest lev
 •	Management and controller systems used to support the VNFs directly, examples include a SIEM system or a SD WAN policy manager
 
 •	Regulatory compliance failure as it relates to the application itself only
- 
+
 Image from https://www.networkworld.com/article/2840273/sdn-security-attack-vectors-and-sdn-hardening.html Will replace with a better image when I create it in the future.
 
 <a name="7.10"></a>
@@ -576,7 +576,7 @@ Recommended practice to set network security policies following the principle of
 <a name="7.10.2"></a>
 ### 7.10.2 Encryption
 
-Virtual volume disks associated with VNFs may contain sensitive data. Therefore, they need to be protected. Best practice is to secure the VNF volumes by encrypting them and storing the cryptographic keys at safe locations. Be aware that the decision to encrypt the volumes might cause reduced performance, so the decision to encrypt needs to be dependent on the requirements of the given infrastructure.  The TPM module can also be used to securely store these keys. In addition, the hypervisor should be configured to securely erase the virtual volume disks in the event a VNF crashes or is intentionally destroyed to prevent it from unauthorized access.  
+Virtual volume disks associated with VNFs may contain sensitive data. Therefore, they need to be protected. Best practice is to secure the VNF volumes by encrypting them and storing the cryptographic keys at safe locations. Be aware that the decision to encrypt the volumes might cause reduced performance, so the decision to encrypt needs to be dependent on the requirements of the given infrastructure.  The TPM module can also be used to securely store these keys. In addition, the hypervisor should be configured to securely erase the virtual volume disks in the event a VNF crashes or is intentionally destroyed to prevent it from unauthorized access.
 
 •	Composition analysis: New vulnerabilities are discovered in common open source libraries every week. As such, mechanisms to validate components of the VNF application stack by checking libraries and supporting code against the Common Vulnerabilities and Exposures (CVE) databases to determine whether the code contains any known vulnerabilities must be embedded into the NFVI architecture itself.  Some of the components required include:
 
@@ -587,7 +587,7 @@ Virtual volume disks associated with VNFs may contain sensitive data. Therefore,
 <a name="7.10.3"></a>
 ### 7.10.3 Platform Patching
 
-NFVI operators should ensure that the platform including the components (hypervisors, VMs, etc.) are kept up to date with the latest patch. 
+NFVI operators should ensure that the platform including the components (hypervisors, VMs, etc.) are kept up to date with the latest patch.
 
 <a name="7.10.4"></a>
 ### 7.10.4 Boot Integrity Measurement (TPM)
@@ -595,12 +595,12 @@ NFVI operators should ensure that the platform including the components (hypervi
 Using trusted platform module (TPM) as a hardware root of trust, the measurement of system sensitive components such as platform firmware, BIOS, bootloader, OS kernel, and other system components can be securely stored and verified. NFVI Operators should ensure that the platform measurement can only be taken when the system is reset or rebooted; there needs to be no ability to write the new platform measurement in TPM during system run-time. The validation of the platform measurements can be performed by TPM’s launch control policy (LCP) or through the remote attestation server
 
 <a name="7.10.5"></a>
-### 7.10.5 NFVI & VIM 
+### 7.10.5 NFVI & VIM
 
 Resources management is essential. Requests coming from NFVO or VNFM to the VIM must validated and the integrity of these requets must be verified.
 <!-- The following tables have been relocated from Chapter 4, per Issue #245. -MXS 10/9/2019
 #### 4.1.4.5 Internal security capabilities
---> 
+-->
 <a name="Table5-1"></a>
 
 | Ref | NFVI capability | Unit | Definition/Notes |
@@ -641,4 +641,3 @@ Table 5-2 shows security capabilities
     tools
 -   Resiliency tests run (such as hardware failures, or power failure
     tests).
-

--- a/doc/ref_model/chapters/chapter07.md
+++ b/doc/ref_model/chapters/chapter07.md
@@ -1,5 +1,5 @@
 [<< Back](../../ref_model)
-# 7	Security
+# 7 Security
 <p align="right"><img src="../figures/bogo_sdc.png" alt="scope" title="Scope" width="35%"/></p>
 
 ## Table of Contents
@@ -83,39 +83,39 @@ Security vulnerabilities and attack vectors are everywhere.  The telecom industr
 With that in mind, the NFVI reference model and the supporting architectures are not only required to optimally support networking functions, but they must be designed with common security principles and standards from inception.  These best practices must be applied at all layers of the infrastructure stack and across all points of interconnections with outside networks, APIs and contact points with the NFV network functions overlaying or interacting with that infrastructure.
 Standards organizations with recommendations and best practices, and certifications that need to be taken into consideration include the following examples. However this is by no means an exhaustive list, just some of the more important standards in current use.
 
- •	Center for Internet Security - https://www.cisecurity.org/
+ • Center for Internet Security - https://www.cisecurity.org/
 
- •	Cloud Security Alliance - https://cloudsecurityalliance.org/
+ • Cloud Security Alliance - https://cloudsecurityalliance.org/
 
- •	Open Web Application Security Project https://www.owasp.org
+ • Open Web Application Security Project https://www.owasp.org
 
- •	The National Institute of Standards and Technology (NIST) (US Only)
+ • The National Institute of Standards and Technology (NIST) (US Only)
 
- •	FedRAMP Certification https://www.fedramp.gov/ (US Only)
+ • FedRAMP Certification https://www.fedramp.gov/ (US Only)
 
- •	ETSI Cyber Security Technical Committee (TC CYBER) - https://www.etsi.org/committee/cyber
+ • ETSI Cyber Security Technical Committee (TC CYBER) - https://www.etsi.org/committee/cyber
 
-•	ISO (the International Organization for Standardization) and IEC (the International Electrotechnical Commission) - www.iso.org.  The following ISO standards are of particular interest for NFVI
+• ISO (the International Organization for Standardization) and IEC (the International Electrotechnical Commission) - www.iso.org.  The following ISO standards are of particular interest for NFVI
 
-    o	ISO/IEC 27002:2013 - ISO/IEC 27001 is the international Standard for best-practice information security management systems (ISMSs).
+    o ISO/IEC 27002:2013 - ISO/IEC 27001 is the international Standard for best-practice information security management systems (ISMSs).
 
-    o	ISO/IEC 27032 - ISO/IEC 27032is the international Standard focusing explicitly on cybersecurity.
+    o ISO/IEC 27032 - ISO/IEC 27032is the international Standard focusing explicitly on cybersecurity.
 
-    o	ISO/IEC 27035 - ISO/IEC 27035 is the international Standard for incident management. Incident management
+    o ISO/IEC 27035 - ISO/IEC 27035 is the international Standard for incident management. Incident management
 
-    o	ISO/IEC 27031 - ISO/IEC 27031 is the international Standard for ICT readiness for business continuity.
+    o ISO/IEC 27031 - ISO/IEC 27031 is the international Standard for ICT readiness for business continuity.
 
 A good place to start to understand the requirements is to use the widely accepted definitions developed by the OWASP – Open Web Application Security Project.  These include the following core principles:
 
-•	Confidentiality – Only allow access to data for which the user is permitted
+• Confidentiality – Only allow access to data for which the user is permitted
 
-•	Integrity – Ensure data is not tampered with or altered by unauthorized users
+• Integrity – Ensure data is not tampered with or altered by unauthorized users
 
-•	Availability – ensure systems and data are available to authorized users when they need it
+• Availability – ensure systems and data are available to authorized users when they need it
 
 Additional NFVI security principles that need to be incorporated:
 
-•	Authenticity – The ability to confirm the users are in fact valid users with the correct rights to access the systems or data.
+• Authenticity – The ability to confirm the users are in fact valid users with the correct rights to access the systems or data.
 
 <a name="7.3.1"></a>
 ## 7.3.1 Potential attack vectors.
@@ -126,25 +126,25 @@ Previously attacks designed to place and migrate workload outside the legal boun
 
 It is not enough to just secure all potential points of entry and hope for the best, any NFVI architecture must be able to be tested and validated that it is in fact protected from attack as much as possible. The ability to test the infrastructure for vulnerabilities on a continuous basis is critical for maintaining the highest level of security possible.  Testing needs to be done both from the inside and outside of the systems and networks.  Below is a small sample of some of the testing methodologies and frameworks available.
 
-•	OWASP testing guide
+• OWASP testing guide
 
-•	PCI Penetration testing guide
+• PCI Penetration testing guide
 
-•	Penetration Testing Execution Standard
+• Penetration Testing Execution Standard
 
-•	NIST 800-115
+• NIST 800-115
 
-    o	VULCAN: Vulnerability Assessment Framework for Cloud Computing (NIST)
+    o VULCAN: Vulnerability Assessment Framework for Cloud Computing (NIST)
 
-•	Penetration Testing Framework
+• Penetration Testing Framework
 
-•	Information Systems Security Assessment Framework (ISSAF)
+• Information Systems Security Assessment Framework (ISSAF)
 
-•	Open Source Security Testing Methodology Manual (“OSSTMM”)
+• Open Source Security Testing Methodology Manual (“OSSTMM”)
 
-•	FedRAMP Penetration Test Guidance (US Only)
+• FedRAMP Penetration Test Guidance (US Only)
 
-•	CREST Penetration Testing Guide
+• CREST Penetration Testing Guide
 
 Insuring that the security standards and best practices are incorporated into the NFVI model and architectures must be a shared responsibility, among the Telecommunications operators interested in building and maintaining the infrastructures in support of their services, the VNF vendors developing the network services that will be consumed by the operators, and the NFVI vendors creating the infrastructures for their Telecommunications customers.  All of the parties need to incorporate security and testing components, and maintain operational processes and procedures to address any security threats or incidents in an appropriate manner.  Each of the stakeholders need to contribute their part to create effective security for NFVI.
 
@@ -507,15 +507,15 @@ There will be a different set of security requirements for each NFVi reference a
 
 The Operator’s responsibility is to not only make sure that security is included in all the vendor supplied infrastructure and NFV components, but it is also responsible for the maintenance of the security functions from an operational and management perspective.   This includes but is not limited to securing the following elements:
 
-•	Maintaining standard security operational management methods and processes
+• Maintaining standard security operational management methods and processes
 
-•	Monitoring and reporting functions
+• Monitoring and reporting functions
 
-•	Processes to address regulatory compliance failure
+• Processes to address regulatory compliance failure
 
-•	Support for appropriate incident response and reporting
+• Support for appropriate incident response and reporting
 
-•	Methods to support appropriate remote attestation certification of the validity of the security components, architectures and methodologies used
+• Methods to support appropriate remote attestation certification of the validity of the security components, architectures and methodologies used
 
 <a name="7.8.1"></a>
 ### 7.8.1 Remote Attestation/openCIT
@@ -535,15 +535,15 @@ It is easy to tamper with VNF images. It requires only a few seconds to insert s
 
 The VNF vendors need to incorporate security elements to support the highest level of security of the networks they support.  This includes but is not limited to securing the following elements:
 
-•	Operating system or container
+• Operating system or container
 
-•	Application
+• Application
 
-•	Network interfaces
+• Network interfaces
 
-•	Management and controller systems used to support the VNFs directly, examples include a SIEM system or a SD WAN policy manager
+• Management and controller systems used to support the VNFs directly, examples include a SIEM system or a SD WAN policy manager
 
-•	Regulatory compliance failure as it relates to the application itself only
+• Regulatory compliance failure as it relates to the application itself only
 
 Image from https://www.networkworld.com/article/2840273/sdn-security-attack-vectors-and-sdn-hardening.html Will replace with a better image when I create it in the future.
 
@@ -552,19 +552,19 @@ Image from https://www.networkworld.com/article/2840273/sdn-security-attack-vect
 
 The NFVI vendors need to incorporate security elements to support the highest level of security of the infrastructure they support.  This includes but is not limited to securing the following elements:
 
-•	Hypervisor
+• Hypervisor
 
-•	VM/container management system
+• VM/container management system
 
-•	APIs
+• APIs
 
-•	Network interfaces
+• Network interfaces
 
-•	Networking security zoning
+• Networking security zoning
 
-•	Platform patching mechanisms
+• Platform patching mechanisms
 
-•	Regulatory compliance Failure
+• Regulatory compliance Failure
 
 <a name="7.10.1"></a>
 ### 7.10.1 Networking Security Zoning
@@ -578,11 +578,11 @@ Recommended practice to set network security policies following the principle of
 
 Virtual volume disks associated with VNFs may contain sensitive data. Therefore, they need to be protected. Best practice is to secure the VNF volumes by encrypting them and storing the cryptographic keys at safe locations. Be aware that the decision to encrypt the volumes might cause reduced performance, so the decision to encrypt needs to be dependent on the requirements of the given infrastructure.  The TPM module can also be used to securely store these keys. In addition, the hypervisor should be configured to securely erase the virtual volume disks in the event a VNF crashes or is intentionally destroyed to prevent it from unauthorized access.
 
-•	Composition analysis: New vulnerabilities are discovered in common open source libraries every week. As such, mechanisms to validate components of the VNF application stack by checking libraries and supporting code against the Common Vulnerabilities and Exposures (CVE) databases to determine whether the code contains any known vulnerabilities must be embedded into the NFVI architecture itself.  Some of the components required include:
+• Composition analysis: New vulnerabilities are discovered in common open source libraries every week. As such, mechanisms to validate components of the VNF application stack by checking libraries and supporting code against the Common Vulnerabilities and Exposures (CVE) databases to determine whether the code contains any known vulnerabilities must be embedded into the NFVI architecture itself.  Some of the components required include:
 
-•	Tools for checking common libraries against CVE databases integrated into the deployment and orchestration pipelines.
+• Tools for checking common libraries against CVE databases integrated into the deployment and orchestration pipelines.
 
-•	The use of Image scanners such as OpenSCAP to determine security vulnerabilities
+• The use of Image scanners such as OpenSCAP to determine security vulnerabilities
 
 <a name="7.10.3"></a>
 ### 7.10.3 Platform Patching

--- a/doc/ref_model/chapters/chapter08-annex.md
+++ b/doc/ref_model/chapters/chapter08-annex.md
@@ -27,14 +27,14 @@ FuncTest test suites will be run as part of the validations, and as a pre-requis
 
 
 - Additional Resources for FuncTest detailse:
-	- Project Description: https://wiki.opnfv.org/display/functest/Opnfv+Functional+Testing#OpnfvFunctionalTesting-Testcases
-	- User Guide: https://opnfv-functest.readthedocs.io/en/stable-hunter/testing/user/userguide/index.html
-	- Overview of test suites: https://opnfv-functest.readthedocs.io/en/stable-hunter/testing/user/userguide/test_overview.html.
+ - Project Description: https://wiki.opnfv.org/display/functest/Opnfv+Functional+Testing#OpnfvFunctionalTesting-Testcases
+ - User Guide: https://opnfv-functest.readthedocs.io/en/stable-hunter/testing/user/userguide/index.html
+ - Overview of test suites: https://opnfv-functest.readthedocs.io/en/stable-hunter/testing/user/userguide/test_overview.html.
 
 
 - Example, or Reference, Functest Status Reporting Artifacts:
-	- Rally Verification (Status): http://artifacts.opnfv.org/functest/functest-opnfv-functest-smoke-iruya-tempest_full-run-259/results/tempest_full/tempest-report.html
-	- Rally Tasks (Status): http://artifacts.opnfv.org/functest/functest-opnfv-functest-benchmarking-iruya-rally_full-run-169/results/rally_full/rally_full.html
+ - Rally Verification (Status): http://artifacts.opnfv.org/functest/functest-opnfv-functest-smoke-iruya-tempest_full-run-259/results/tempest_full/tempest-report.html
+ - Rally Tasks (Status): http://artifacts.opnfv.org/functest/functest-opnfv-functest-benchmarking-iruya-rally_full-run-169/results/rally_full/rally_full.html
 
 <a name="8.3"></a>
 ## 8.3 Architecture Specific Test Cases (if needed)

--- a/doc/ref_model/chapters/chapter08-annex.md
+++ b/doc/ref_model/chapters/chapter08-annex.md
@@ -23,13 +23,13 @@ The following test projects, and their respective test cases, will be executed w
 
 **FuncTest**
 
-FuncTest test suites will be run as part of the validations, and as a pre-requisite with approximately 2000+ functional test cases leveraging Tempest plugins.  At a minimum, FuncTest executions will include reuse of functest-smoke (functional tests), functional-benchmarking (rally_full and rally_jobs).  
+FuncTest test suites will be run as part of the validations, and as a pre-requisite with approximately 2000+ functional test cases leveraging Tempest plugins.  At a minimum, FuncTest executions will include reuse of functest-smoke (functional tests), functional-benchmarking (rally_full and rally_jobs).
 
 
 - Additional Resources for FuncTest detailse:
 	- Project Description: https://wiki.opnfv.org/display/functest/Opnfv+Functional+Testing#OpnfvFunctionalTesting-Testcases
 	- User Guide: https://opnfv-functest.readthedocs.io/en/stable-hunter/testing/user/userguide/index.html
-	- Overview of test suites: https://opnfv-functest.readthedocs.io/en/stable-hunter/testing/user/userguide/test_overview.html.   
+	- Overview of test suites: https://opnfv-functest.readthedocs.io/en/stable-hunter/testing/user/userguide/test_overview.html.
 
 
 - Example, or Reference, Functest Status Reporting Artifacts:

--- a/doc/ref_model/chapters/chapter08.md
+++ b/doc/ref_model/chapters/chapter08.md
@@ -8,7 +8,7 @@
 * [8.2 Principles and Guidelines.](#8.2)
   * [8.2.1 Overarching Objectives and Goals.](#8.2.1)
   * [8.2.2 Verification Methodologies.](#8.2.2)
-  * [8.2.3 Governance.](#8.2.3)  
+  * [8.2.3 Governance.](#8.2.3)
 * [8.3 Terms and Resources.](#8.3)
   * [8.3.1 Terms.](#8.3.1)
   * [8.3.2 Resources.](#8.3.2)
@@ -64,9 +64,9 @@ Perform NFVI+VNF Verification and Validations using CNTT reference architecture,
 **Scope**
 - Manifest Verifications (aka CVC Compliance) will ensure the NFVI is compliant, and delivered for testing, with hardware and software profile specifications defined by the Ref Model and Ref Architecture.
 - Empirical Validation with Reference Golden VNFs (aka CVC Validation) will ensure the NFVI runs with a set of VNF Families, or Classes, to minic production-like VNF connectivity, for the purposes of interopability checks.
-- Candidate VNF Validation (Validation & Performance) will ensure complete interopablity of VNF behavior on the NFVI leverage VVP/CVC test suites.  Testing ensures VNF can be spun up, modified, or removed, on the target NFVI (aka Interoperability).  
+- Candidate VNF Validation (Validation & Performance) will ensure complete interopablity of VNF behavior on the NFVI leverage VVP/CVC test suites.  Testing ensures VNF can be spun up, modified, or removed, on the target NFVI (aka Interoperability).
 
-**Repeat** the approach of Manifest compliance, Empirical Golden VNF, and Interopability Testing with new Distributions. 
+**Repeat** the approach of Manifest compliance, Empirical Golden VNF, and Interopability Testing with new Distributions.
 
 **Not in Scope**
 
@@ -85,7 +85,7 @@ This document includes process flow, logistics, and requirements which must be s
 
 The objectives of the verification program are to deliver a validated implementation of reference architecture which satisifes infrastructure needs for VNF-developer teams, leveraging the OVP ecosystem as the vehicle for delivering validated NFVI.
 
-These core principles will guide NFV verification deliverables: 
+These core principles will guide NFV verification deliverables:
 
 <a name="8.2.1"></a>
 ### 8.2.1 Overarching Objectives and Goals
@@ -129,11 +129,11 @@ These core principles will guide NFV verification deliverables:
 <a name="8.3"></a>
 ## 8.3 Terms and Resources
 
-NFVI+VNF testing will be performed for **Verification** and **Validations** purpose.  
+NFVI+VNF testing will be performed for **Verification** and **Validations** purpose.
 
-- **Verification** will be used to indicate conformance to design requirement specifications.  Activities involved Reviews and Walk-Throughs to ensure the NFVI is delivered per implementation specifications.  
-- **Validations** is used to indicate testing performed to confirm the actual output of a product meets the expected, or desired outcome, or behavior.  
-- **Certfications**, which are Out of Scope, include a measured performance of the adherence to, and demonstrated proficiency with, all aspects of software delivery including but no limited to planning, development (of which there are no code developed/delivered), and logistics for communications.  
+- **Verification** will be used to indicate conformance to design requirement specifications.  Activities involved Reviews and Walk-Throughs to ensure the NFVI is delivered per implementation specifications.
+- **Validations** is used to indicate testing performed to confirm the actual output of a product meets the expected, or desired outcome, or behavior.
+- **Certfications**, which are Out of Scope, include a measured performance of the adherence to, and demonstrated proficiency with, all aspects of software delivery including but no limited to planning, development (of which there are no code developed/delivered), and logistics for communications.
 
 Source information for additional reading:
 - [https://www.softwaretestingmaterial.com/verification-and-validation/](https://www.softwaretestingmaterial.com/verification-and-validation/ "What is Verification And Validation In Software Testing")
@@ -185,12 +185,12 @@ Additional Terms utilized throughout the document:
 ### 8.3.2 Resources
 1. **OPNFV** https://www.opnfv.org/ - project and community that facilitates a common NFVI, continuous integration (CI) with upstream projects, stand-alone testing toolsets, and a compliance and verification program for industry-wide testing and integration to accelerate the transformation of enterprise and service provider networks.<br>
 2. **CVC** https://wiki.lfnetworking.org/display/LN/Compliance+and+Verification+Committee - members-driven committee within LF Networking that recommends policies and oversight for compliance and certification program to the Governing Board of LF Networking (“Governing Board”).
-3. **Conducting OVP Testing with Dovetail** https://docs.opnfv.org/en/stable-danube/submodules/dovetail/docs/testing/user/userguide/testing_guide.html 
+3. **Conducting OVP Testing with Dovetail** https://docs.opnfv.org/en/stable-danube/submodules/dovetail/docs/testing/user/userguide/testing_guide.html
 4. **Dovetail**
-	1. Framework https://wiki.opnfv.org/display/dovetail/Dovetail+Test+Case+Requirements 
-	2. Test Plan: https://wiki.opnfv.org/display/dovetail/Dovetail+%28Danube%29+Documentation+for+Review?preview=/11698759/11698757/User%20Guide.pdf 
-	3. TCs: 
-		1. https://wiki.opnfv.org/display/dovetail/Dovetail+%28Danube%29+Documentation+for+Review 
+	1. Framework https://wiki.opnfv.org/display/dovetail/Dovetail+Test+Case+Requirements
+	2. Test Plan: https://wiki.opnfv.org/display/dovetail/Dovetail+%28Danube%29+Documentation+for+Review?preview=/11698759/11698757/User%20Guide.pdf
+	3. TCs:
+		1. https://wiki.opnfv.org/display/dovetail/Dovetail+%28Danube%29+Documentation+for+Review
 		2. Called by functest (repo): https://github.com/opnfv/dovetail/tree/master/etc/testcase
 		3. Per OVP release in the release notes:
 			1. https://docs.opnfv.org/en/stable-fraser/submodules/dovetail/docs/release/release-notes/index.html
@@ -214,7 +214,7 @@ OPNNV Iterations with the CNTT (mgmt and communication of)
 
 <a name="8.4.3"></a>
 ### 8.4.3 Onboarding RA and Supplier VNF
-Onboarding (for OVP certification) 
+Onboarding (for OVP certification)
 
 <a name="8.4.4"></a>
 ### 8.4.4 SLAs and Issue Resolution
@@ -409,7 +409,7 @@ Perform VNF interoperability verifications against an implementation of CNTT ref
 </li>
 </ul>
 <p>&nbsp;</p>
-	
+
 <a name="8.6.3"></a>
 ### 8.6.3 Best Practices.
 <ul>
@@ -496,7 +496,7 @@ NFVI+VNF testing will be considered **Testable** if the follow qualifiers are pr
 In addition, respective Entrance criteria is a prerequisite which needs to be satisfied for NFVI+VNF to be considered **Testable**.  Refer to [https://github.com/cntt-n/CNTT/blob/chapter08/doc/ref_model/chapters/chapter08.md#8.7.3](https://github.com/cntt-n/CNTT/blob/chapter08/doc/ref_model/chapters/chapter08.md#8.7.3 "Entrance & Exit Criteria") for detailed information.
 
 **Dependencies**
-NFVI+VNF verification will rely upon test harnesses, test tools, and test suites provided by upstream OPNFV projects, including dovetaill, yardstick, and Bottleneck. These upstream projects will be reviewed semi-annually to verify they are still healthy and active projects. Over time, the projects representing the certification process may change, but test parity is required if new test suites are added in place of older, stale projects. 
+NFVI+VNF verification will rely upon test harnesses, test tools, and test suites provided by upstream OPNFV projects, including dovetaill, yardstick, and Bottleneck. These upstream projects will be reviewed semi-annually to verify they are still healthy and active projects. Over time, the projects representing the certification process may change, but test parity is required if new test suites are added in place of older, stale projects.
 
 - NFVI+VNF verifications will be performed against well defined instance types consisting of a HW and SW Profile, Configured Options, and Applied Extensions (See image.)
 
@@ -583,7 +583,7 @@ Compute Intensive | High | Medium | Offered load high<br>Latency threshold low |
 <li>Standard NTP servers are working and verified (using tenant's CIDR source IP)</li>
 <li>NFVI/VNF is tested at steady state and high load</li>
 <li>Continuously monitored to ensure SLAs are met and used as feedback to load/perf tests<u></u></li>
-<li>Passing Interoperability Validations: a) <b>Compatibility Checks</b> (e.g. documented s/w, driver rev levels, etc, in use and confirmed compatible between Platform and VNF); b) 
+<li>Passing Interoperability Validations: a) <b>Compatibility Checks</b> (e.g. documented s/w, driver rev levels, etc, in use and confirmed compatible between Platform and VNF); b)
 	<b>Integration Checks</b> (e.g. empirical validation confirming positive performance and stability between Platform and VNF; for example, packet loss within acceptable tolerances)
 </ol>
 </li>

--- a/doc/ref_model/chapters/chapter08.md
+++ b/doc/ref_model/chapters/chapter08.md
@@ -149,7 +149,7 @@ Additional Terms utilized throughout the document:
 
 <table>
   <tr><th>Term</th><th>Description</th></tr>
-  <tr><td>AZ</td><td>AZ	Availability Zone</td></tr>
+  <tr><td>AZ</td><td>AZ Availability Zone</td></tr>
   <tr><td>CPE</td><td>Customer Premises Equipment</td></tr>
   <tr><td>CVC</td><td>Compliance and Verification Committee</td></tr>
   <tr><td>ETSI</td><td>European Telecommunications Standards Institute</td></tr>
@@ -157,28 +157,28 @@ Additional Terms utilized throughout the document:
   <tr><td>ETSI NFV-IFA</td><td>ETSI - Network Functions Virtualisation - Infrastructure</td></tr>
   <tr><td>GB</td><td>Gigabit</td></tr>
   <tr><td>HW</td><td>Hardware</td></tr>
-<tr><td>IMS</td>	<td>IP Multimedia Subsystem</td></tr>
-<tr><td>I/O</td>	<td>Input/Output</td></tr>
-<tr><td>MB</td>	<td>Megabit</td></tr>
-<tr><td>NFV</td>	<td>Network Function Virtualization</td></tr>
-<tr><td>NFVI</td>	<td>NFV Infrastructure</td></tr>
-<tr><td>NUMA</td>	<td>Non-Unified Memory Access</td></tr>
-<tr><td>OPNFV</td>	<td>Open Platform for NFV</td></tr>
-	<tr><td>OVP</td><td>OPNFV Verification Program (OVP)</td></tr>
+<tr><td>IMS</td> <td>IP Multimedia Subsystem</td></tr>
+<tr><td>I/O</td> <td>Input/Output</td></tr>
+<tr><td>MB</td> <td>Megabit</td></tr>
+<tr><td>NFV</td> <td>Network Function Virtualization</td></tr>
+<tr><td>NFVI</td> <td>NFV Infrastructure</td></tr>
+<tr><td>NUMA</td> <td>Non-Unified Memory Access</td></tr>
+<tr><td>OPNFV</td> <td>Open Platform for NFV</td></tr>
+ <tr><td>OVP</td><td>OPNFV Verification Program (OVP)</td></tr>
 <tr><td>RAM</td><td>Random Access Memory</td></tr>
-<tr><td>SDN</td>	<td>Software Defined Networking</td></tr>
-<tr><td>SD-WAN</td>	<td>Software Defined Wide Area Network</td></tr>
-<tr><td>SLA</td>	<td>Service Level Agreement</td></tr>
-<tr><td>SUT</td>	<td>System Under Test</td></tr>
-<tr><td>SW</td>	<td>Software</td></tr>
-<tr><td>vCPU</td>	<td>Virtual CPU (Central Processing Unit)</td></tr>
-<tr><td>vNIC</td>	<td>Virtual NIC (Network Interface Card)</td></tr>
-<tr><td>vRouter</td>	<td>Virtual Router</td></tr>
-<tr><td>vSwitch</td>	<td>Virtual Switch</td></tr>
-<tr><td>VIM</td>	<td>Virtual Infrastructure Manager</td></tr>
-<tr><td>VNF</td>	<td>Virtualised Network Function</td></tr>
-<tr><td>VNF-C</td>	<td>VNF Component (can be hosted on a VM, Container, etc)</td></tr>
-<tr><td>VNFM</td>	<td>VNF Manager</td></tr>
+<tr><td>SDN</td> <td>Software Defined Networking</td></tr>
+<tr><td>SD-WAN</td> <td>Software Defined Wide Area Network</td></tr>
+<tr><td>SLA</td> <td>Service Level Agreement</td></tr>
+<tr><td>SUT</td> <td>System Under Test</td></tr>
+<tr><td>SW</td> <td>Software</td></tr>
+<tr><td>vCPU</td> <td>Virtual CPU (Central Processing Unit)</td></tr>
+<tr><td>vNIC</td> <td>Virtual NIC (Network Interface Card)</td></tr>
+<tr><td>vRouter</td> <td>Virtual Router</td></tr>
+<tr><td>vSwitch</td> <td>Virtual Switch</td></tr>
+<tr><td>VIM</td> <td>Virtual Infrastructure Manager</td></tr>
+<tr><td>VNF</td> <td>Virtualised Network Function</td></tr>
+<tr><td>VNF-C</td> <td>VNF Component (can be hosted on a VM, Container, etc)</td></tr>
+<tr><td>VNFM</td> <td>VNF Manager</td></tr>
 </table>
 
 <a name="8.3.2"></a>
@@ -187,19 +187,19 @@ Additional Terms utilized throughout the document:
 2. **CVC** https://wiki.lfnetworking.org/display/LN/Compliance+and+Verification+Committee - members-driven committee within LF Networking that recommends policies and oversight for compliance and certification program to the Governing Board of LF Networking (“Governing Board”).
 3. **Conducting OVP Testing with Dovetail** https://docs.opnfv.org/en/stable-danube/submodules/dovetail/docs/testing/user/userguide/testing_guide.html
 4. **Dovetail**
-	1. Framework https://wiki.opnfv.org/display/dovetail/Dovetail+Test+Case+Requirements
-	2. Test Plan: https://wiki.opnfv.org/display/dovetail/Dovetail+%28Danube%29+Documentation+for+Review?preview=/11698759/11698757/User%20Guide.pdf
-	3. TCs:
-		1. https://wiki.opnfv.org/display/dovetail/Dovetail+%28Danube%29+Documentation+for+Review
-		2. Called by functest (repo): https://github.com/opnfv/dovetail/tree/master/etc/testcase
-		3. Per OVP release in the release notes:
-			1. https://docs.opnfv.org/en/stable-fraser/submodules/dovetail/docs/release/release-notes/index.html
-			2. https://docs.opnfv.org/en/stable-danube/submodules/dovetail/docs/release/release-notes/index.html
+ 1. Framework https://wiki.opnfv.org/display/dovetail/Dovetail+Test+Case+Requirements
+ 2. Test Plan: https://wiki.opnfv.org/display/dovetail/Dovetail+%28Danube%29+Documentation+for+Review?preview=/11698759/11698757/User%20Guide.pdf
+ 3. TCs:
+  1. https://wiki.opnfv.org/display/dovetail/Dovetail+%28Danube%29+Documentation+for+Review
+  2. Called by functest (repo): https://github.com/opnfv/dovetail/tree/master/etc/testcase
+  3. Per OVP release in the release notes:
+   1. https://docs.opnfv.org/en/stable-fraser/submodules/dovetail/docs/release/release-notes/index.html
+   2. https://docs.opnfv.org/en/stable-danube/submodules/dovetail/docs/release/release-notes/index.html
 5. **Overall documentation** is on docs.opnfv.org for the corresponding Fraser and Danube releases
-	1. https://docs.opnfv.org/en/stable-fraser/testing/testing-user.html (Fraser)
-	2. https://docs.opnfv.org/en/stable-fraser/testing/testing-dev.html (Fraser)
+ 1. https://docs.opnfv.org/en/stable-fraser/testing/testing-user.html (Fraser)
+ 2. https://docs.opnfv.org/en/stable-fraser/testing/testing-dev.html (Fraser)
 6. **OPNFV Verification Program** is an open source, community-led compliance and verification program to demonstrate the readiness and availability of commercial NFV products and services, including NFVI and VNFs, using OPNFV and ONAP components (https://www.lfnetworking.org/OVP/).
-	1. OVP Whitepaper - https://www.lfnetworking.org/resources/2019/04/03/ovp:-opnfv-verification-program/
+ 1. OVP Whitepaper - https://www.lfnetworking.org/resources/2019/04/03/ovp:-opnfv-verification-program/
 
 <a name="8.4"></a>
 ## 8.4 Lifecycle and Process Flow
@@ -584,7 +584,7 @@ Compute Intensive | High | Medium | Offered load high<br>Latency threshold low |
 <li>NFVI/VNF is tested at steady state and high load</li>
 <li>Continuously monitored to ensure SLAs are met and used as feedback to load/perf tests<u></u></li>
 <li>Passing Interoperability Validations: a) <b>Compatibility Checks</b> (e.g. documented s/w, driver rev levels, etc, in use and confirmed compatible between Platform and VNF); b)
-	<b>Integration Checks</b> (e.g. empirical validation confirming positive performance and stability between Platform and VNF; for example, packet loss within acceptable tolerances)
+ <b>Integration Checks</b> (e.g. empirical validation confirming positive performance and stability between Platform and VNF; for example, packet loss within acceptable tolerances)
 </ol>
 </li>
 <li><u><strong>END USER CONSIDERATIONS (TELCO PERSPECTIVE)</strong></u>

--- a/doc/ref_model/chapters/chapter09.md
+++ b/doc/ref_model/chapters/chapter09.md
@@ -1,5 +1,5 @@
 [<< Back](../../ref_model)
-# 9	Infrastructure Operations and Lifecycle Management
+# 9 Infrastructure Operations and Lifecycle Management
 <p align="right"><img src="../figures/bogo_sdc.png" alt="scope" title="Scope" width="35%"/></p>
 
 ## Table of Contents

--- a/doc/ref_model/chapters/chapter09.md
+++ b/doc/ref_model/chapters/chapter09.md
@@ -48,4 +48,4 @@ This is a placeholder for Infrastructure Maintenance requirements. e.g.
 
 - ability to drain hosts
 - ability to update control plane before host agents etc.
-- ability to 
+- ability to


### PR DESCRIPTION
It partially fixes #303 [1] ("R2 Line has trailing whitespace").
It also modifies one typo (definitions)

[1] https://github.com/cntt-n/CNTT/issues/303

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>