### PR TITLE
[RA1 Ch05] Precise Glance versions

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter05.md
+++ b/doc/ref_arch/openstack/chapters/chapter05.md
@@ -39,10 +39,11 @@ Security compliance and PCI-DSS: https://docs.openstack.org/keystone/train/admin
 
 ### 5.2.2 Glance
 
-| **OpenStack Service** | **Link for API and CLI** | **API/Client Minimum (Baseline) Version** |
-|------------------|----------------------------------------------------|-------------------|
-| Imaging: Glance | https://docs.openstack.org/api-ref/image/v2/index.html#images | Version 2.0 |
-| Imaging: Glance | https://docs.openstack.org/python-glanceclient/latest/ | Version 2.0 |
+| **OpenStack Service** | **Minimal API Version** |
+|-----------------------|-------------------------|
+| Image: Glance         | 2.5                     |
+
+Image Service Versions: https://docs.openstack.org/api-ref/image/versions/index.html#version-history
 
 ### 5.2.3. Cinder
 


### PR DESCRIPTION
v2.5 is more precised than v2.0
https://docs.openstack.org/api-ref/image/versions/index.html#api-versions

Fixes #647

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>