### PR TITLE
[RA 1] Fix Nova features tab

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter05.md
+++ b/doc/ref_arch/openstack/chapters/chapter05.md
@@ -193,12 +193,11 @@ The exhaustive list of extensions is available at https://docs.openstack.org/api
 
 | **Nova Features**        | **Mandatory** |
 |--------------------------|:-------------:|
-| attach_encrypted_volume  | X             |
+| attach_encrypted_volume  |               |
 | change_password          |               |
 | cold_migration           | X             |
 | console_output           | X             |
 | disk_config              | X             |
-| instance_password        |               |
 | interface_attach         | X             |
 | live_migration           | X             |
 | metadata_service         | X             |


### PR DESCRIPTION
Ceph is selected but doesn't support "attach_encrypted_volume".
Then it sets the feature as optional which will may be listed in gaps.

enable_instance_password is part of testing configuration.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>