### PR TITLE
[RM Ch05] Modification of CPU pinnnig definition

### DIFF
--- a/doc/ref_model/chapters/chapter05.md
+++ b/doc/ref_model/chapters/chapter05.md
@@ -51,7 +51,7 @@ The following sections detail the NFVI SW profile features per type of virtual r
 |------------------|----------------|----------------|------------------------------------------------------------------------------------------------|
 | nfvi.com.cfg.001 | CPU allocation ratio  | Value | Number of virtual cores per physical core  |
 | nfvi.com.cfg.002 | NUMA awareness | Yes/No  | Support of NUMA at the virtualization layer  |
-| nfvi.com.cfg.003 | CPU pinning capability  | Yes/No | Binding of a process to a dedicated CPU |
+| nfvi.com.cfg.003 | CPU pinning capability  | Yes/No | Binding a vCPU to either a physical core or a thread of a core with SMT |
 | nfvi.com.cfg.004 | Huge Pages  | Yes/No | Ability to manage huge pages of memory |
 
 <p align="center"><b>Table 5-1:</b> Virtual Compute features.</p>

--- a/doc/ref_model/chapters/chapter05.md
+++ b/doc/ref_model/chapters/chapter05.md
@@ -51,7 +51,7 @@ The following sections detail the NFVI SW profile features per type of virtual r
 |------------------|----------------|----------------|------------------------------------------------------------------------------------------------|
 | nfvi.com.cfg.001 | CPU allocation ratio  | Value | Number of virtual cores per physical core  |
 | nfvi.com.cfg.002 | NUMA awareness | Yes/No  | Support of NUMA at the virtualization layer  |
-| nfvi.com.cfg.003 | CPU pinning capability  | Yes/No | Binding a vCPU to either a physical core or a thread of a core with SMT |
+| nfvi.com.cfg.003 | CPU pinning capability  | Yes/No | Binding a vCPU to either a physical core on a non-SMT architecture or a core thread on a SMT architecture  |
 | nfvi.com.cfg.004 | Huge Pages  | Yes/No | Ability to manage huge pages of memory |
 
 <p align="center"><b>Table 5-1:</b> Virtual Compute features.</p>

--- a/doc/ref_model/chapters/chapter05.md
+++ b/doc/ref_model/chapters/chapter05.md
@@ -51,7 +51,7 @@ The following sections detail the NFVI SW profile features per type of virtual r
 |------------------|----------------|----------------|------------------------------------------------------------------------------------------------|
 | nfvi.com.cfg.001 | CPU allocation ratio  | Value | Number of virtual cores per physical core  |
 | nfvi.com.cfg.002 | NUMA awareness | Yes/No  | Support of NUMA at the virtualization layer  |
-| nfvi.com.cfg.003 | CPU pinning capability  | Yes/No | Binding a vCPU to either a physical core on a non-SMT architecture or a core thread on a SMT architecture  |
+| nfvi.com.cfg.003 | CPU pinning capability  | Yes/No | Binds a process/vCPU to a physical core or SMT thread  |
 | nfvi.com.cfg.004 | Huge Pages  | Yes/No | Ability to manage huge pages of memory |
 
 <p align="center"><b>Table 5-1:</b> Virtual Compute features.</p>


### PR DESCRIPTION
Fixes #521 
The initial definition "Binding of a process to a dedicated CPU" doesn't take into account cores and SMT.
It is changed by:
"Binding a vCPU to either a physical core or a thread of a core with SMT"