### PR TITLE
[RA1 Ch05] Remove Ironic APIs

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter05.md
+++ b/doc/ref_arch/openstack/chapters/chapter05.md
@@ -219,14 +219,7 @@ Compute API: https://docs.openstack.org/api-ref/compute/
 
 REST API Version History: https://docs.openstack.org/nova/latest/reference/api-microversion-history.html
 
-### 5.2.7. Ironic
-
-| **OpenStack Service** | **Link for API and CLI** | **API/CLI Minimum (Baseline) Version** |
-|------------------|----------------------------------------------------|-------------------|
-| Bare Metal: Ironic | https://docs.openstack.org/api-ref/baremetal/ | Version 1.0 |
-| Bare Metal: Ironic | https://docs.openstack.org/python-ironicclient/latest/cli/index.html | Version 1.25 |
-
-### 5.2.8. Heat
+### 5.2.7. Heat
 
 |**OpenStack Service** | **Link for API and CLI** | **API/CLI Minimum (Baseline) Version** |
 |------------------|----------------------------------------------------|-------------------|
@@ -256,7 +249,6 @@ libraries.
 | Block Storage: Cinder | https://docs.openstack.org/api-ref/block-storage/v3/index.html#api-versions  | Version 3.0 |
 | Object Storage: Swift | https://docs.openstack.org/api-ref/object-store/  | Version 1.0 |
 | Orchestration: Heat | https://docs.openstack.org/api-ref/orchestration/v1/index.html#api-versions  | Version 1.0 |
-| Bare Metal: Ironic |  |  |
 | Acceleration: Cyborg | https://docs.openstack.org/api-ref/accelerator/v1/index.html  | Version 1.0 |
 
 **CLIs**
@@ -270,7 +262,6 @@ libraries.
 | Block Storage: Cinder | https://docs.openstack.org/python-cinderclient/latest/ | Version 3.0 |
 | Object Storage: Swift | https://docs.openstack.org/python-swiftclient/latest/ | Version 1.0 |
 | Orchestration: Heat | https://docs.openstack.org/python-heatclient/latest/ | Version 1.0 |
-| Bare Metal: Ironic | https://docs.openstack.org/python-ironicclient/latest/cli/index.html  | Version 1.25 |
 | Acceleration: Cyborg | https://docs.openstack.org/python-cyborgclient/latest/ | Version 1.0 |
 | OpenStack Client (python) | https://docs.openstack.org/python-openstackclient/pike/index.html  | Version 3.2.1 |
 


### PR DESCRIPTION
Fixes #732 
As a result of the decision taken during RA #1 meeting (October 25), remove Ironic APIs, for the 2 following reasons: Ironic is an optional service and Ironic APIs are not called directly.
5.2 ->Section about Ironic removed
5.3 -> Lines about Ironic removed from  API and CLI tables