### PR TITLE
[RA-1 Ch02] EPA requirement

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter02.md
+++ b/doc/ref_arch/openstack/chapters/chapter02.md
@@ -103,7 +103,7 @@ Traceability to Reference Model.
 | `req.vim.01` | General | The Architecture **must** allow infrastructure resource sharing. |
 | `req.vim.02` | General | The Architecture **should** support deployment of OpenStack components in containers. |
 | `req.vim.03` | General | The Architecture **must** allow VIM to discover and manage NFVI resources. |
-| `req.vim.04` | General | The Architecture **must** support Enhanced Platform Awareness (EPA). |
+| `req.vim.04` | General | The Architecture **must** support Enhanced Platform Awareness (EPA) only for discovery of infrastructure resource capabilities.|
 | `req.vim.05` | General | The Architecture **must** include image repository management. |
 | `req.vim.06` | General | The Architecture **must** allow orchestration solutions to be integrated with VIM. |
 | `req.vim.07` | General | The Architecture **must** support a multi-tenanted environment. |


### PR DESCRIPTION
Changed:
| req.vim.04 | General | The Architecture must support Enhanced Platform Awareness (EPA). |
|--------|------|------------|
| `req.vim.04` | General | The Architecture **must** support Enhanced Platform Awareness (EPA) only for discovery of infrastructure resource capabilities.|

Fixes #792