### PR TITLE
[RC1] Fix broken links due to baseurl (/CNTT) set by GitHub

### DIFF
--- a/doc/ref_cert/lfn/chapters/chapter04.md
+++ b/doc/ref_cert/lfn/chapters/chapter04.md
@@ -80,7 +80,7 @@ and backends selected in the different Gate jobs. The classical
 conform to this model which also fits the heterogeneous user deployments.
 
 From a CNTT Compliance state point, the capabilities are well described in
-[RA1 Core OpenStack Services APIs](/doc/ref_arch/openstack/chapters/chapter05.html)
+[RA1 Core OpenStack Services APIs]({{ "/doc/ref_arch/openstack/chapters/chapter05.html" | relative_url }})
 which allows tuning the test configurations and the test lists to avoid
 skipping any test. It results that all tests covering optional capabilities and
 all upstream skipped tests due to known bugs are not executed. All remaining
@@ -94,7 +94,7 @@ configurations and the default test lists. Any optional capability or services
 The next subsections only detail the Tempest test which must not be executed
 from a Compliance state point. The remaining tests have to pass successfully.
 They cover all together the API testing requirements as asked by
-[RA1 Core OpenStack Services APIs](/doc/ref_arch/openstack/chapters/chapter05.html)
+[RA1 Core OpenStack Services APIs]({{ "/doc/ref_arch/openstack/chapters/chapter05.html" | relative_url }})
 
 According to Hunter (the oldest OPNFV active release), the next software
 versions are considered here to verify OpenStack Pike selected by CNTT:
@@ -118,7 +118,7 @@ as integrated in
 [Functest Smoke CNTT](https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml).
 
 According to
-[RA1 Core OpenStack Services APIs](/doc/ref_arch/openstack/chapters/chapter05.html)
+[RA1 Core OpenStack Services APIs]({{ "/doc/ref_arch/openstack/chapters/chapter05.html" | relative_url }})
 the next test names must not be executed:
 
 | test rejection regular expressions        | reasons    |
@@ -151,7 +151,7 @@ Glance API is covered in the OpenStack Gates via
 [Functest Smoke CNTT](https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml).
 
 According to
-[RA1 Core OpenStack Services APIs](/doc/ref_arch/openstack/chapters/chapter05.html)
+[RA1 Core OpenStack Services APIs]({{ "/doc/ref_arch/openstack/chapters/chapter05.html" | relative_url }})
 the next test names must not be executed:
 
 | test rejection regular expressions | reasons |
@@ -177,7 +177,7 @@ as integrated in
 [Functest Smoke CNTT](https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml).
 
 According to
-[RA1 Core OpenStack Services APIs](/doc/ref_arch/openstack/chapters/chapter05.html)
+[RA1 Core OpenStack Services APIs]({{ "/doc/ref_arch/openstack/chapters/chapter05.html" | relative_url }})
 the next test names must not be executed:
 
 | test rejection regular expressions                                                                   | reasons                               |
@@ -215,7 +215,7 @@ Swift API is covered in the OpenStack Gates via
 [Functest Smoke CNTT](https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml).
 
 According to
-[RA1 Core OpenStack Services APIs](/doc/ref_arch/openstack/chapters/chapter05.html)
+[RA1 Core OpenStack Services APIs]({{ "/doc/ref_arch/openstack/chapters/chapter05.html" | relative_url }})
 the next test names must not be executed:
 
 | test rejection regular expressions                                      | reasons                            |
@@ -241,7 +241,7 @@ as integrated in
 [Functest Smoke CNTT](https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml).
 
 According to
-[RA1 Core OpenStack Services APIs](/doc/ref_arch/openstack/chapters/chapter05.html)
+[RA1 Core OpenStack Services APIs]({{ "/doc/ref_arch/openstack/chapters/chapter05.html" | relative_url }})
 the next test names must not be executed:
 
 | test rejection regular expressions                                           | reasons                               |
@@ -294,7 +294,7 @@ Nova API is covered in the OpenStack Gates via
 [Functest Smoke CNTT](https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml).
 
 According to
-[RA1 Core OpenStack Services APIs](https://github.com/cntt-n/CNTT/blob/master/doc/ref_arch/openstack/chapters/chapter05.md)
+[RA1 Core OpenStack Services APIs]({{ "/doc/ref_arch/openstack/chapters/chapter05.html" | relative_url }})
 the next test names must not be executed:
 
 | test rejection regular expressions                                                                                        | reasons                            |
@@ -383,7 +383,7 @@ Here are the Rally-based test cases proposed by
   Neutron scenarios executed in the OpenStack gates
 
 At the time of writing, no KPI is defined in
-[RA1 Core OpenStack Services APIs](/doc/ref_arch/openstack/chapters/chapter05.html)
+[RA1 Core OpenStack Services APIs]({{ "/doc/ref_arch/openstack/chapters/chapter05.html" | relative_url }})
 which would have asked for an update of the default SLA (maximum failure rate
 of 0%) proposed in
 [Functest Benchmarking CNTT](https://git.opnfv.org/functest/tree/docker/benchmarking-cntt/testcases.yaml)


### PR DESCRIPTION
It leverages on relative_url filter [1] as proposed by Jekyll

[1] https://jekyllrb.com/news/2016/10/06/jekyll-3-3-is-here/

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>