### PR TITLE
[RC1] Add RC Cookbook

### DIFF
--- a/doc/ref_cert/lfn/chapters/chapter09.md
+++ b/doc/ref_cert/lfn/chapters/chapter09.md
@@ -69,6 +69,27 @@ test cases must pass as they are for CNTT NFVI Conformance/Certification:
 <a name="9.4"></a>
 ## 9.4 CNTT Compliance Cookbook
 
+[Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) leverages on the
+common test case execution proposed by Xtesting. Thanks to a simple test case
+list, this tool deploys anywhere plug-and-play
+[CI/CD toolchains in a few commands](https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004).
+In addition of this teaching capability needed by the Network Automation
+journey, it supports multiple components such as Jenkins and Gitlab CI (test
+schedulers) and
+[multiple deployment models](https://lists.opnfv.org/g/opnfv-tsc/message/5702)
+such as all-in-one or centralized services.
+
+[Xtesting](https://xtesting.readthedocs.io/en/latest/) and
+[Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) combined meet the
+CNTT requirements about verification, compliance and certification:
+- smoothly assemble multiple heterogeneous test cases
+- generate the Jenkins jobs in
+  [OPNFV Releng](https://git.opnfv.org/releng/tree/jjb/airship/cntt.yaml) to
+  verify CNTT RI
+- deploy local CI/CD toolchains everywhere to check compliance with CNTT
+- [dump all test case results and logs](http://artifacts.opnfv.org/functest/9ID39XK47PMZ.zip)
+  for third-party certification review
+
 [Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) only requires
 GNU/Linux as Operating System and asks for a few dependencies as described in
 [Deploy your own Xtesting CI/CD toolchains](https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004):

--- a/doc/ref_cert/lfn/chapters/chapter09.md
+++ b/doc/ref_cert/lfn/chapters/chapter09.md
@@ -8,7 +8,7 @@
 * [9.2 RM/RA-1 Requirements](#9.2)
 * [9.3 TC Mapping to Requirements](#9.3)
 * [9.4 CNTT Compliance Cookbook](#9.4)
-  * [9.4.1 NVFI API testing configuration](#9.4.1)
+  * [9.4.1 NFVI API testing configuration](#9.4.1)
   * [9.4.2 Run CNTT Compliance](#9.4.1)
 
 <a name="9.1"></a>
@@ -101,7 +101,7 @@ ansible-playbook functest-src/ansible/site.cntt.yml
 ```
 
 <a name="9.4.1"></a>
-### 9.4.1 NVFI API testing configuration
+### 9.4.1 NFVI API testing configuration
 
 Here is the default Functest tree as proposed in
 [Run Alpine Functest containers (Hunter)](https://wiki.opnfv.org/pages/viewpage.action?pageId=29098314):


### PR DESCRIPTION
It describes how to deploy the CI toolchain checking CNTT Compliance
as announced by [1].

At the time of writing, the CI description file lists all the
mantory containers (see RM/RA-1 Requirements).

It depends on the next 2 PRs:
 - https://github.com/cntt-n/CNTT/pull/867
 - https://github.com/cntt-n/CNTT/pull/870

[1] https://lists.opnfv.org/g/opnfv-tsc/message/5717

Fixes: #872

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>