### PR TITLE
[RC1] Fill all gaps already tracked as issues in CNTT

### DIFF
--- a/doc/ref_cert/lfn/chapters/chapter11.md
+++ b/doc/ref_cert/lfn/chapters/chapter11.md
@@ -26,16 +26,18 @@
 <a name="11.3"></a>
 ## 11.3 Automation Gaps
 
-At the time being,
+At the time of writing,
 [the yaml file](https://git.opnfv.org/releng/tree/jjb/airship/cntt.yaml)
 configuring all RI Jenkins jobs are postprocessed by hand which requires lots
 of skills especially about
 [Jenkins job builder](https://docs.openstack.org/infra/jenkins-job-builder/).
 The RI Cookbook will be deeply simplified if the deployment scripts are
-delivered in a new Xtesting-based container as proposed in
-"[new RI deployment container](https://github.com/cntt-n/CNTT/issues/828)".
-In addition to avoid configuring the jumphost, it will allow configuring the
-Jenkins jobs via a simple yaml file.
+delivered in a new
+[Xtesting](https://xtesting.readthedocs.io/en/latest/)-based container as
+proposed in
+[new RI deployment container](https://github.com/cntt-n/CNTT/issues/828).
+In addition to avoid configuring the jumphost, it will allow generating the
+Jenkins jobs via a simple yaml file and
 [Xtesting CI](https://galaxy.ansible.com/collivier/xtesting).
 
 <a name="11.4"></a>
@@ -46,7 +48,7 @@ OPNFV has developed many test cases in the different
 can quickly improve RC. As highlighted in OPNFV Marketing Goals for 2020 and
 listed in
 [RC Test case integration requirements]({{ "/doc/ref_cert/lfn/chapters/chapter02.html" | relative_url }}),
-porting all the existing testcase to Xtesting will unify the test case
+porting all the existing testcases to Xtesting will unify the test case
 execution and simplify the test integration as required by RC. Here are all the
 related issues:
 - [port YardStick testcases to Xtesting](https://github.com/cntt-n/CNTT/issues/509)
@@ -56,12 +58,12 @@ related issues:
 
 Here are the possible new test cases which could be integrated in the existing
 OPNFV projects to improve RC:
-- [update and integrate heat-tempest-plugin in Functest](https://github.com/cntt-n/CNTT/issues/483):
-  Heat API testing
-- [integrate KloudBuster in Functest](https://github.com/cntt-n/CNTT/issues/508):
-  disk benchmarking
-- [add tempest-stress in Functest](https://github.com/cntt-n/CNTT/issues/916):
-  stress testing
+
+| issues                                                                                            | requirements      |
+|---------------------------------------------------------------------------------------------------|-------------------|
+| [update and integrate heat-tempest-plugin in Functest](https://github.com/cntt-n/CNTT/issues/483) | Heat API testing  |
+| [integrate KloudBuster in Functest](https://github.com/cntt-n/CNTT/issues/508)                    | disk benchmarking |
+| [add tempest-stress in Functest](https://github.com/cntt-n/CNTT/issues/916)                       | stress testing    |
 
 <a name="11.5"></a>
 ## 11.5 Framework Gaps

--- a/doc/ref_cert/lfn/chapters/chapter11.md
+++ b/doc/ref_cert/lfn/chapters/chapter11.md
@@ -26,23 +26,50 @@
 <a name="11.3"></a>
 ## 11.3 Automation Gaps
 
-Here is the automation gap already tracked by an issue in CNTT:
-- [new RI deployment container](https://github.com/cntt-n/CNTT/issues/828)
+At the time being,
+[the yaml file](https://git.opnfv.org/releng/tree/jjb/airship/cntt.yaml)
+configuring all RI Jenkins jobs are postprocessed by hand which requires lots
+of skills especially about
+[Jenkins job builder](https://docs.openstack.org/infra/jenkins-job-builder/).
+The RI Cookbook will be deeply simplified if the deployment scripts are
+delivered in a new Xtesting-based container as proposed in
+"[new RI deployment container](https://github.com/cntt-n/CNTT/issues/828)".
+In addition to avoid configuring the jumphost, it will allow configuring the
+Jenkins jobs via a simple yaml file.
+[Xtesting CI](https://galaxy.ansible.com/collivier/xtesting).
 
 <a name="11.4"></a>
 ## 11.4 Test Case Gaps
 
-Here are the test case gaps already tracked by issues in CNTT:
-- [update and integrate heat-tempest-plugin in Functest](https://github.com/cntt-n/CNTT/issues/483)
-- [integrate KloudBuster in Functest](https://github.com/cntt-n/CNTT/issues/508)
+OPNFV has developed many test cases in the different
+[OPNFV test projects](https://wiki.opnfv.org/display/testing/TestPerf) which
+can quickly improve RC. As highlighted in OPNFV Marketing Goals for 2020 and
+listed in
+[RC Test case integration requirements]({{ "/doc/ref_cert/lfn/chapters/chapter02.html" | relative_url }}),
+porting all the existing testcase to Xtesting will unify the test case
+execution and simplify the test integration as required by RC. Here are all the
+related issues:
 - [port YardStick testcases to Xtesting](https://github.com/cntt-n/CNTT/issues/509)
 - [port Bottlenecks to Xtesting](https://github.com/cntt-n/CNTT/issues/511)
 - [port StorPerf testcases to Xtesting](https://github.com/cntt-n/CNTT/issues/673)
 - [port NFVbench testcases to Xtesting](https://github.com/cntt-n/CNTT/issues/865)
-- [add tempest-stress in Functest](https://github.com/cntt-n/CNTT/issues/916)
+
+Here are the possible new test cases which could be integrated in the existing
+OPNFV projects to improve RC:
+- [update and integrate heat-tempest-plugin in Functest](https://github.com/cntt-n/CNTT/issues/483):
+  Heat API testing
+- [integrate KloudBuster in Functest](https://github.com/cntt-n/CNTT/issues/508):
+  disk benchmarking
+- [add tempest-stress in Functest](https://github.com/cntt-n/CNTT/issues/916):
+  stress testing
 
 <a name="11.5"></a>
 ## 11.5 Framework Gaps
 
-Here is the framework gap already tracked by an issue in CNTT:
-- [port VTP test cases to Xtesting](https://github.com/cntt-n/CNTT/issues/917)
+As proposed in [port VTP test cases to Xtesting](https://github.com/cntt-n/CNTT/issues/917),
+VTP selected in
+[VNF E2E C&V Framework ]({{ "/doc/ref_cert/lfn/chapters/chapter05.html" | relative_url }})
+requires small adaptations to fully fulfill the current
+[RC Test case integration requirements]({{ "/doc/ref_cert/lfn/chapters/chapter02.html" | relative_url }}).
+It seems trivial changes as VTP proposed a REST API but will ensure that
+NFVI and VNF can be executed in the same CI toolchain very easily.

--- a/doc/ref_cert/lfn/chapters/chapter11.md
+++ b/doc/ref_cert/lfn/chapters/chapter11.md
@@ -26,14 +26,23 @@
 <a name="11.3"></a>
 ## 11.3 Automation Gaps
 
-- Provide details of any automation gaps which require new/modified automation tools, or suites
+Here is the automation gap already tracked by an issue in CNTT:
+- [new RI deployment container](https://github.com/cntt-n/CNTT/issues/828)
 
 <a name="11.4"></a>
-## 11.4 Test Case Gaps (analysis)
+## 11.4 Test Case Gaps
 
-- Provide details/analysis of Test Case gaps which required addition/editing of existing test suites, or creation of new suites altogether
+Here are the test case gaps already tracked by issues in CNTT:
+- [update and integrate heat-tempest-plugin in Functest](https://github.com/cntt-n/CNTT/issues/483)
+- [integrate KloudBuster in Functest](https://github.com/cntt-n/CNTT/issues/508)
+- [port YardStick testcases to Xtesting](https://github.com/cntt-n/CNTT/issues/509)
+- [port Bottlenecks to Xtesting](https://github.com/cntt-n/CNTT/issues/511)
+- [port StorPerf testcases to Xtesting](https://github.com/cntt-n/CNTT/issues/673)
+- [port NFVbench testcases to Xtesting](https://github.com/cntt-n/CNTT/issues/865)
+- [add tempest-stress in Functest](https://github.com/cntt-n/CNTT/issues/916)
 
 <a name="11.5"></a>
 ## 11.5 Framework Gaps
 
-- Provide details/analysis of Test Framework Gaps which required addition/editing of existing frameworks, incompatibility with frameworks, depreciation of frameworks.
+Here is the framework gap already tracked by an issue in CNTT:
+- [port VTP test cases to Xtesting](https://github.com/cntt-n/CNTT/issues/917)


### PR DESCRIPTION
Port VTP test cases to Xtesting [1] is key because the TC doesn't conform
to the principles and requirements defined.

https://github.com/cntt-n/CNTT/issues/917

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>