### PR TITLE
[RM Ch04] Update metrics for Storage

### DIFF
--- a/doc/ref_model/chapters/chapter04.md
+++ b/doc/ref_model/chapters/chapter04.md
@@ -432,7 +432,7 @@ Note, CNTT documentation uses GB and GiB to refer to a Gibibyte (2<sup>30</sup> 
 
 .conf |Read IO/s |Write IO/s | Read Throughput (MB/s) |Write Throughput (MB/s) |Max Ext Size
 ---|---|---|---|---|---
-.bronze |Up to 3K |Up to 15K |Up to 180 |Up to 120 |16TB
+.bronze |Up to 3K |Up to 1.5K |Up to 180 |Up to 120 |16TB
 .silver |Up to 60K |Up to 30K |Up to 1200 |Up to 400 |1TB
 .gold |Up to 680K |Up to 360K |Up to 2650 |Up to 1400 |1TB
 


### PR DESCRIPTION
It looks like the write IOPS for bronze was quite out of line with the other metrics.

Has any thought been given to synthetic workload for the disk test?  Is it based on a single thread of I/O waiting for completion?  Or async, with multiple requests in flight?

Also, will there be latency requirements?