### PR TITLE
[RA2 Ch02] Persistent storage installation should be optional.

### DIFF
--- a/doc/ref_arch/kubernetes/chapters/chapter02.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter02.md
@@ -195,7 +195,7 @@ Reference to "Architecture" in this chapter refers to the NFVI Hardware (e.g. ph
 | `req.inf.stg.04` | Storage | The Architecture **may** support Software Defined Storage (SDS) that seamlessly supports shared block storage, object storage and flat files. |
 | `req.inf.stg.05` | Storage | The Architecture **should** provide high-performance and horizontally scalable storage. |
 | `req.inf.stg.06` | Storage | The Architecture **must** support ephemeral storage (non-persistent) storage for Pods. |
-| `req.inf.stg.07` | Storage | The Architecture **must** support persistent storage for Pods. |
+| `req.inf.stg.07` | Storage | The Architecture **should** support persistent storage for Pods. |
 | `req.inf.ntw.01` | Network | The Architecture **must** support Container Network Interface (CNI). |
 | `req.inf.ntw.02` | Network | The Architecture **must** support intra-node communications, such as between agents on a node and all pods on that node |
 | `req.inf.ntw.03` | Network | The Architecture **must** support inter-node communications without NAT, such as communications between pods on a node with all other pods on all nodes |

--- a/doc/ref_arch/kubernetes/chapters/chapter02.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter02.md
@@ -195,7 +195,8 @@ Reference to "Architecture" in this chapter refers to the NFVI Hardware (e.g. ph
 | `req.inf.stg.04` | Storage | The Architecture **may** support Software Defined Storage (SDS) that seamlessly supports shared block storage, object storage and flat files. |
 | `req.inf.stg.05` | Storage | The Architecture **should** provide high-performance and horizontally scalable storage. |
 | `req.inf.stg.06` | Storage | The Architecture **must** support ephemeral storage (non-persistent) storage for Pods. |
-| `req.inf.stg.07` | Storage | The Architecture **should** support persistent storage for Pods. |
+| `req.inf.stg.07` | Storage | The Architecture **must** support persistent storage for Pods. |
+| `req.inf.stg.08` | Storage | The Architecture **should not** require deploying persistent storage for Pods. |
 | `req.inf.ntw.01` | Network | The Architecture **must** support Container Network Interface (CNI). |
 | `req.inf.ntw.02` | Network | The Architecture **must** support intra-node communications, such as between agents on a node and all pods on that node |
 | `req.inf.ntw.03` | Network | The Architecture **must** support inter-node communications without NAT, such as communications between pods on a node with all other pods on all nodes |


### PR DESCRIPTION
There are likely going to be edge clusters which will be deployed with no storage. Requiring persistent storage is counterintuitive in a cluster when your intention is to deploy a firewall (or similar) with only ephemeral requirements.

For reference, many enterprise clusters are built without persistent storage. 