### PR TITLE
[RA-2 Ch02] req.inf.ntw.16 states a capability rather than an implementation detail

### DIFF
--- a/doc/ref_arch/kubernetes/chapters/chapter02.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter02.md
@@ -208,7 +208,7 @@ Reference to "Architecture" in this chapter refers to the NFVI Hardware (e.g. ph
 | `req.inf.ntw.11` | Network | The networking solution **should** be able to be centrally administrated and configured. |
 | `req.inf.ntw.14` | Network | The Architecture **must** support capabilities for integrating SDN controllers. |
 | `req.inf.ntw.15` | Network | The Architecture **should** support Service Mesh Interface (SMI). |
-| `req.inf.ntw.16` | Network | The Architecture **should**  support co-exisence of multiple network interfaces. |
+| `req.inf.ntw.16` | Network | The Architecture **should**  support coexistence of multiple connection points in a pod. |
 | `req.inf.acc.01` | Acceleration | The Architecture **should** support Application Specific Acceleration. |
 | `req.inf.acc.02` | Acceleration | The Architecture **should** support NFVI Acceleration (such as SmartNICs). |
 | `req.inf.vir.01`   | Virtual Infrastructure | The Architecture must support the capability for Containers to consume infrastructure resources abstracted by Host Operating Systems that are running within a virtual machine. |

--- a/doc/ref_arch/kubernetes/chapters/chapter02.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter02.md
@@ -208,7 +208,7 @@ Reference to "Architecture" in this chapter refers to the NFVI Hardware (e.g. ph
 | `req.inf.ntw.11` | Network | The networking solution **should** be able to be centrally administrated and configured. |
 | `req.inf.ntw.14` | Network | The Architecture **must** support capabilities for integrating SDN controllers. |
 | `req.inf.ntw.15` | Network | The Architecture **should** support Service Mesh Interface (SMI). |
-| `req.inf.ntw.16` | Network | The Architecture **should**  support co-exisence of multiple Container Network Interface (CNI). |
+| `req.inf.ntw.16` | Network | The Architecture **should**  support co-exisence of multiple network interfaces. |
 | `req.inf.acc.01` | Acceleration | The Architecture **should** support Application Specific Acceleration. |
 | `req.inf.acc.02` | Acceleration | The Architecture **should** support NFVI Acceleration (such as SmartNICs). |
 | `req.inf.vir.01`   | Virtual Infrastructure | The Architecture must support the capability for Containers to consume infrastructure resources abstracted by Host Operating Systems that are running within a virtual machine. |


### PR DESCRIPTION
The former requirement enforces an implementation detail.

The new wording outlines a capability instead of an implementation detail.

If we want this capability to be programmatically configured/controlled via an API, then that should be a separate requirement. Even then, such a requirement should not specifically call for a custom CNI plugin since this is an implementation detail.