### PR TITLE
Build script of the documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem "github-pages", group: :jekyll_plugins
+gem "jekyll"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+echo "This is a dummy script to install all needed dependencies to build and run the CNTT documentation."
+# Copied from https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -r|--run)
+    RUN="true"
+    shift # past argument
+    ;;
+    *)    # unknown option
+    POSITIONAL+=("$1") # save it in an array for later
+    shift # past argument
+    ;;
+esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+# Copied form https://unix.stackexchange.com/questions/6345/how-can-i-get-distribution-name-and-version-number-in-a-simple-shell-script
+if [ -f /etc/os-release ]; then
+    # freedesktop.org and systemd
+    . /etc/os-release
+    OS=$NAME
+    VER=$VERSION_ID
+elif type lsb_release >/dev/null 2>&1; then
+    # linuxbase.org
+    OS=$(lsb_release -si)
+    VER=$(lsb_release -sr)
+elif [ -f /etc/lsb-release ]; then
+    # For some versions of Debian/Ubuntu without lsb_release command
+    . /etc/lsb-release
+    OS=$DISTRIB_ID
+    VER=$DISTRIB_RELEASE
+elif [ -f /etc/debian_version ]; then
+    # Older Debian/Ubuntu/etc.
+    OS=Debian
+    VER=$(cat /etc/debian_version)
+elif [ -f /etc/SuSe-release ]; then
+    # Older SuSE/etc.
+    ...
+elif [ -f /etc/redhat-release ]; then
+    # Older Red Hat, CentOS, etc.
+    ...
+else
+    # Fall back to uname, e.g. "Linux <version>", also works for BSD, etc.
+    OS=$(uname -s)
+    VER=$(uname -r)
+fi
+
+echo "OS is: $OS" 
+
+if [ $OS == "Ubuntu" ] ; then
+    sudo apt install ruby-bundler
+    sudo apt install zlib1g-dev
+else
+    echo "Sorry your operating system not yet supported by this script. You can open the script and see what dependencies are installed."
+fi
+
+bundle install
+
+if [ $RUN ] ; then
+    echo -e "\n\nRunning the server for the docs. Open http://127.0.0.1:4000/ in your browser to see the docs.\n\n"
+    bundle exec jekyll serve
+fi


### PR DESCRIPTION
This change adds a build script to build the documentation.
At the moment the script supports only Ubuntu and it is very
rudymentary, but at least a start.

This is the 0th step to fix #1023 