### PR TITLE
RC-1 Ch01 - Fix broken URL issue 1026

### DIFF
--- a/doc/ref_cert/lfn/chapters/chapter01.md
+++ b/doc/ref_cert/lfn/chapters/chapter01.md
@@ -50,7 +50,7 @@ The three step methodology described above of verifying Manifest compliance, exe
 <a name="1.1.1"></a>
 ### 1.1.1 Terminology
 
-Terminology in this document will follow [CNTT Terminology](ref_model/chapters/glossary.md).
+Terminology in this document will follow [CNTT Terminology](../../../ref_model/chapters/glossary.md).
 
 <a name="1.2"></a>
 ## 1.2 Scope


### PR DESCRIPTION
Fixes Issue #1026 .  

Fixing broken glossary/terminology URL 

from:  https://github.com/cntt-n/CNTT/blob/master/doc/ref_cert/lfn/chapters/ref_model/chapters/glossary.md

to:  [CNTT Terminology](../../../ref_model/chapters/glossary.md).