### PR TITLE
[RA2 Ch02] Values for virtual CPU, memory, and disk capabilities

### DIFF
--- a/doc/ref_arch/kubernetes/chapters/chapter02.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter02.md
@@ -88,9 +88,9 @@ From Reference Model section [4.2.5 Instance Capabilities Mapping](../../../ref_
 
 | Attribute | Description | Value | Supported |
 |-----------|---------------------------|-------|-------|
-| e.nfvi.res.cap.001 | Max number of vCPU that can be assigned to a single pod by the NFVI | 16<sup>1)</sup> | Y |
-| e.nfvi.res.cap.002 | Max memory in MB that can be assigned to a single pod by the NFVI | 32 GB<sup>1)</sup> | Y |
-| e.nfvi.res.cap.003 | Max storage in GB that can be assigned to a single pod by the NFVI | 320 GB<sup>1)</sup> | Y |
+| e.nfvi.res.cap.001 | Max number of vCPU that can be assigned to a single pod by the NFVI | at least 16<sup>1)</sup> | Y |
+| e.nfvi.res.cap.002 | Max memory in MB that can be assigned to a single pod by the NFVI | at least 32 GB<sup>1)</sup> | Y |
+| e.nfvi.res.cap.003 | Max storage in GB that can be assigned to a single pod by the NFVI | at least 320 GB<sup>1)</sup> | Y |
 | e.nfvi.res.cap.004 | # Connection Points | 6 | Y |
 | e.nfvi.res.cap.005 | Total instance (persistent) storage (GB) | 300 GB | Y |
 | e.nfvi.per.cap.001 | CPU pinning support | | Y |


### PR DESCRIPTION
The requirements e.nfvi.res.cap.001, e.nfvi.res.cap.002, and
e.nfvi.res.cap.003 in chapter 2 state maximum values for virtual
CPU, memory and disk sizes. This PR clarifies that those numbers
are not intended as a hard upper limit, but just state that a platform
has to support *at least* those maximum values. The actual maximum
values can be larger in a vendor implementation.

fixes #1068 