### PR TITLE
[RA1][RC1] Set Neutron extensions as optional

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter05.md
+++ b/doc/ref_arch/openstack/chapters/chapter05.md
@@ -134,7 +134,7 @@ Discoverability: https://docs.openstack.org/swift/latest/api/discoverability.htm
 | dhcp_agent_scheduler           |               |
 | dns-domain-ports               |               |
 | dns-integration                |               |
-| dvr                            | X             |
+| dvr                            |               |
 | empty-string-filtering         | X             |
 | ext-gw-mode                    | X             |
 | external-net                   | X             |
@@ -146,9 +146,9 @@ Discoverability: https://docs.openstack.org/swift/latest/api/discoverability.htm
 | fip-port-details               |               |
 | floatingip-pools               |               |
 | ip-substring-filtering         | X             |
-| l3_agent_scheduler             | X             |
-| l3-flavors                     | X             |
-| l3-ha                          | X             |
+| l3_agent_scheduler             |               |
+| l3-flavors                     |               |
+| l3-ha                          |               |
 | logging                        |               |
 | metering                       |               |
 | multi-provider                 | X             |

--- a/doc/ref_arch/openstack/chapters/chapter05.md
+++ b/doc/ref_arch/openstack/chapters/chapter05.md
@@ -141,8 +141,8 @@ Discoverability: https://docs.openstack.org/swift/latest/api/discoverability.htm
 | extra_dhcp_opt                 | X             |
 | extraroute                     | X             |
 | flavors                        | X             |
-| filter-validation              | X             |
-| fip-port-details               | X             |
+| filter-validation              |               |
+| fip-port-details               |               |
 | floatingip-pools               |               |
 | ip-substring-filtering         | X             |
 | l3_agent_scheduler             | X             |
@@ -157,7 +157,7 @@ Discoverability: https://docs.openstack.org/swift/latest/api/discoverability.htm
 | network-ip-availability        | X             |
 | network-segment-range          |               |
 | pagination                     | X             |
-| port-mac-address-regenerate    | X             |
+| port-mac-address-regenerate    |               |
 | port-resource-request          |               |
 | port-security                  | X             |
 | port-security-groups-filtering | X             |

--- a/doc/ref_arch/openstack/chapters/chapter05.md
+++ b/doc/ref_arch/openstack/chapters/chapter05.md
@@ -140,6 +140,7 @@ Discoverability: https://docs.openstack.org/swift/latest/api/discoverability.htm
 | external-net                   | X             |
 | extra_dhcp_opt                 | X             |
 | extraroute                     | X             |
+| extraroute-atomic              |               |
 | flavors                        | X             |
 | filter-validation              |               |
 | fip-port-details               |               |

--- a/doc/ref_arch/openstack/chapters/chapter05.md
+++ b/doc/ref_arch/openstack/chapters/chapter05.md
@@ -178,6 +178,8 @@ Discoverability: https://docs.openstack.org/swift/latest/api/discoverability.htm
 | quotas                         | X             |
 | quota_details                  | X             |
 | revision-if-match              | X             |
+| rbac-security-groups           |               |
+| router-interface-fip           |               |
 | security-group                 | X             |
 | service-type                   | X             |
 | sorting                        | X             |
@@ -187,8 +189,7 @@ Discoverability: https://docs.openstack.org/swift/latest/api/discoverability.htm
 | standard-attr-timestamp        | X             |
 | subnet_allocation              | X             |
 | subnet-service-types           | X             |
-| rbac-security-groups           |               |
-| router-interface-fip           |               |
+| subnetpool_prefix_ops          |               |
 | tag-ext                        |               |
 | trunk                          | X             |
 | trunk-details                  | X             |

--- a/doc/ref_cert/lfn/chapters/chapter03.md
+++ b/doc/ref_cert/lfn/chapters/chapter03.md
@@ -248,35 +248,54 @@ According to
 [RA1 Core OpenStack Services APIs]({{ "/doc/ref_arch/openstack/chapters/chapter05.html" | relative_url }})
 the following test names must not be executed:
 
-| test rejection regular expressions                                           | reasons                               |
-|------------------------------------------------------------------------------|---------------------------------------|
-| .\*test_dhcp_agent_scheduler                                                 | dhcp_agent_scheduler                  |
-| .\*test_logging                                                              | logging                               |
-| .\*test_logging_negative                                                     | logging                               |
-| .\*test_network_segment_range                                                | network-segment-range                 |
-| .\*test_ports.PortTestCasesResourceRequest                                   | port-resource-request                 |
-| .\*test_floating_ips.FloatingIPPoolTestJSON                                  | floatingip-pools                      |
-| .\*test_metering_extensions                                                  | metering                              |
-| .\*test_metering_negative                                                    | metering                              |
-| .\*test_networks.NetworksTestAdmin.test_create_tenant_network_vxlan.         | vxlan                                 |
-| .\*test_networks.NetworksTestJSON.test_create_update_network_dns_domain      | dns-integration                       |
-| .\*test_ports.PortsTestJSON.test_create_port_with_propagate_uplink_status    | uplink-status-propagation             |
-| .\*test_ports.PortsTestJSON.test_create_port_without_propagate_uplink_status | uplink-status-propagation             |
-| .\*test_ports.PortsTestJSON.test_create_update_port_with_dns_domain          | dns-domain-ports                      |
-| .\*test_ports.PortsTestJSON.test_create_update_port_with_dns_name            | dns-integration                       |
-| .\*test_ports.PortsTestJSON.test_create_update_port_with_no_dns_name         | dns-integration                       |
-| .\*test_revisions.TestRevisions.test_update_dns_domain_bumps_revision        | dns-integration                       |
-| .\*test_router_interface_fip                                                 | router-interface-fip                  |
-| .\*test_security_groups.RbacSharedSecurityGroupTest                          | rbac-security-groups                  |
-| .\*test_timestamp.TestTimeStamp.test_segment_with_timestamp                  | standard-attr-segment                 |
-| .\*test_trunk.TrunkTestMtusJSON                                              | vxlan                                 |
-| .\*test_trunk_negative.TrunkTestJSON.test_create_subport_invalid_inherit_network_segmentation_type | vxlan           |
-| .\*test_trunk_negative.TrunkTestMtusJSON                                     | vxlan                                 |
-| .\*test_qos.QosMinimumBandwidthRuleTestJSON                                  | https://gerrit.opnfv.org/gerrit/69105 |
-| .\*network.test_tags                                                         | tag-ext                               |
-| .\*test_routers.RoutersIpV6Test.test_create_router_set_gateway_with_fixed_ip | https://launchpad.net/bugs/1676207    |
-| .\*test_routers.RoutersTest.test_create_router_set_gateway_with_fixed_ip     | https://launchpad.net/bugs/1676207    |
-| .\*test_network_v6                                                           | https://gerrit.opnfv.org/gerrit/69105 |
+| test rejection regular expressions                                                                 | reasons                               |
+|----------------------------------------------------------------------------------------------------|---------------------------------------|
+| .\*admin.test_agent_availability_zone                                                              | DHCP agent and L3 agent               |
+| .\*admin.test_dhcp_agent_scheduler                                                                 | dhcp_agent_scheduler                  |
+| .\*admin.test_l3_agent_scheduler                                                                   | l3_agent_scheduler                    |
+| .\*admin.test_logging                                                                              | logging                               |
+| .\*admin.test_logging_negative                                                                     | logging                               |
+| .\*admin.test_network_segment_range                                                                | network-segment-range                 |
+| .\*admin.test_ports.PortTestCasesAdmin.test_regenerate_mac_address                                 | port-mac-address-regenerate           |
+| .\*admin.test_ports.PortTestCasesResourceRequest                                                   | port-resource-request                 |
+| .\*admin.test_routers_dvr                                                                          | dvr                                   |
+| .\*admin.test_routers_flavors                                                                      | l3-flavors                            |
+| .\*admin.test_routers_ha                                                                           | l3-ha                                 |
+| .\*test_floating_ips.FloatingIPPoolTestJSON                                                        | floatingip-pools                      |
+| .\*test_floating_ips.FloatingIPTestJSON.test_create_update_floatingip_port_details                 | fip-port-details                      |
+| .\*test_metering_extensions                                                                        | metering                              |
+| .\*test_metering_negative                                                                          | metering                              |
+| .\*test_networks.NetworksSearchCriteriaTest.test_list_validation_filters                           | filter-validation                     |
+| .\*test_networks.NetworksTestAdmin.test_create_tenant_network_vxlan.                               | vxlan                                 |
+| .\*test_networks.NetworksTestJSON.test_create_update_network_dns_domain                            | dns-integration                       |
+| .\*test_ports.PortsTestJSON.test_create_port_with_propagate_uplink_status                          | uplink-status-propagation             |
+| .\*test_ports.PortsTestJSON.test_create_port_without_propagate_uplink_status                       | uplink-status-propagation             |
+| .\*test_ports.PortsTestJSON.test_create_update_port_with_dns_domain                                | dns-domain-ports                      |
+| .\*test_ports.PortsTestJSON.test_create_update_port_with_dns_name                                  | dns-integration                       |
+| .\*test_ports.PortsTestJSON.test_create_update_port_with_no_dns_name                               | dns-integration                       |
+| .\*test_revisions.TestRevisions.test_update_dns_domain_bumps_revision                              | dns-integration                       |
+| .\*test_revisions.TestRevisions.test_update_router_extra_attributes_bumps_revision                 | l3-ha                                 |
+| .\*test_router_interface_fip                                                                       | router-interface-fip                  |
+| .\*test_routers.DvrRoutersTest                                                                     | dvr                                   |
+| .\*test_routers.HaRoutersTest                                                                      | l3-ha                                 |
+| .\*test_routers.RoutersIpV6Test.test_extra_routes_atomic                                           | extraroute-atomic                     |
+| .\*test_routers.RoutersTest.test_extra_routes_atomic                                               | extraroute-atomic                     |
+| .\*test_routers_negative.DvrRoutersNegativeTest                                                    | dvr                                   |
+| .\*test_routers_negative.DvrRoutersNegativeTestExtended                                            | dvr                                   |
+| .\*test_routers_negative.HaRoutersNegativeTest                                                     | l3-ha                                 |
+| .\*test_security_groups.RbacSharedSecurityGroupTest                                                | rbac-security-groups                  |
+| .\*test_subnetpools.SubnetPoolsSearchCriteriaTest.test_list_validation_filters                     | filter-validation                     |
+| .\*test_subnets.SubnetsSearchCriteriaTest.test_list_validation_filters                             | filter-validation                     |
+| .\*test_timestamp.TestTimeStamp.test_segment_with_timestamp                                        | standard-attr-segment                 |
+| .\*test_trunk.TrunkTestInheritJSONBase.test_add_subport                                            | https://launchpad.net/bugs/1863707    |
+| .\*test_trunk.TrunkTestMtusJSON                                                                    | vxlan                                 |
+| .\*test_trunk_negative.TrunkTestJSON.test_create_subport_invalid_inherit_network_segmentation_type | vxlan                                 |
+| .\*test_trunk_negative.TrunkTestMtusJSON                                                           | vxlan                                 |
+| .\*test_qos.QosMinimumBandwidthRuleTestJSON                                                        | https://gerrit.opnfv.org/gerrit/69105 |
+| .\*network.test_tags                                                                               | tag-ext                               |
+| .\*test_routers.RoutersIpV6Test.test_create_router_set_gateway_with_fixed_ip                       | https://launchpad.net/bugs/1676207    |
+| .\*test_routers.RoutersTest.test_create_router_set_gateway_with_fixed_ip                           | https://launchpad.net/bugs/1676207    |
+| .\*test_network_v6                                                                                 | https://gerrit.opnfv.org/gerrit/69105 |
 
 Neutron API is also covered by [Rally](https://opendev.org/openstack/rally).
 


### PR DESCRIPTION
It updates both RA1 and RC1 according to the traceability in place:
- set as optional a few neutron extensions newer than Pike
- set l3 extensions (linked to reference implementations) as optional

It's being completed by the regex update in Functest both verified via OVS agents and OVN.

Close: #1106 