### PR TITLE
[RA-2 Ch02] Replace multi-tenancy with desired intents

### DIFF
--- a/doc/ref_arch/kubernetes/chapters/chapter02.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter02.md
@@ -236,9 +236,10 @@ Please note that "shared" is a reference to multi-tenant support and pooled stor
 | `req.kcm.02` | General | The Architecture **must** support discoverability of nodes and their features. |
 | `req.kcm.03` | General | The Architecture **must** support scheduling of workloads based on Enhanced Platform Awareness (EPA) features such as CPU Pinning, huge-pages and SR-IOV. |
 | `req.kcm.04` | General | The Architecture **must** include kubernetes artefacts (e.g., images, Helm charts, etc.) repository capabilities. |
-| `req.kcm.05` | General | The Architecture **should** support multi-tenancy in Kubernetes cluster. |
+| `req.kcm.05` | General | The Architecture **should** prevent workloads from interfering with or observing other mutually ignorant workloads. |
 | `req.kcm.06` | General | The Architecture **must** support resource tagging. |
 | `req.kcm.08` | General | The Architecture **must** support workload resiliency. |
+| `req.kcm.09` | General | The Architecture **should** prevent workloads from starving other workloads of guaranteed resources. |
 -->
 
 <p align="center"><b>Table 2-3:</b> Kubernetes Architecture: Kubernetes Cluster Requirements</p>


### PR DESCRIPTION
Multi-tenancy is an **implementation detail** which Kubernetes has not and likely will not implement. The "multi-tenant" approach in sig-multi-tenancy appears to be focused primarily on nested namespaces and nested CRDs which will likely fall short of the safety requirements and resource restraints which we are seeking.

Instead, we should state the desired goals which consist of at least the following:

1. Security between workloads that are mutually ignorant of each other.
2. Resources must be restrained. A workload must not be capable of starving other workloads of resources unless specified by policy.

A reference implementation may choose to implement multi-tenancy or something else as an isolation and resource management strategy. Furthermore, separating these into two separate goals also eliminates conflating two orthogonal ideas.