### PR TITLE
[RA1][RC1] Update Regex list in RC

### DIFF
--- a/doc/ref_cert/lfn/chapters/chapter03.md
+++ b/doc/ref_cert/lfn/chapters/chapter03.md
@@ -296,6 +296,7 @@ the following test names must not be executed:
 | .\*test_routers.RoutersIpV6Test.test_create_router_set_gateway_with_fixed_ip                       | https://launchpad.net/bugs/1676207    |
 | .\*test_routers.RoutersTest.test_create_router_set_gateway_with_fixed_ip                           | https://launchpad.net/bugs/1676207    |
 | .\*test_network_v6                                                                                 | https://gerrit.opnfv.org/gerrit/69105 |
+| .\*test_network_basic_ops.TestNetworkBasicOps.test_router_rescheduling                             | l3_agent_scheduler                    |
 
 Neutron API is also covered by [Rally](https://opendev.org/openstack/rally).
 
@@ -686,7 +687,7 @@ Here are all samples:
 The generator used with the rapid scripts is PROX with a specific generator configuration file.
 When multiple flows are requested, the generator starts randomizing bits in the source and destination UDP ports.
 The number of flows to be generated during each run of the test is specified in the test files (e.g. TST009_Throughput.test).
-Packet size used during the test is also defined in the test file. IMIX is not supported yet, but you could take the average packet size of the IMIX for now. 
+Packet size used during the test is also defined in the test file. IMIX is not supported yet, but you could take the average packet size of the IMIX for now.
 When defining n packet sizes with m different flow sizes, the test will run n x m times and will produce the results for these n x m combinations.
 All throughput benchmarking is done by a generator sending packets to a reflector. This results in bidirectional traffic which should be identical (src and dest IP and ports swapped) if all traffic goes through.
 The VMs or containers use only 1 vNIC for incoming and outgoing traffic. Multiple queues can be used.


### PR DESCRIPTION
It update tempest_slow regex (Neutron) according to the last changes in
CNTT RA1 Chapter5 (l3_agent_scheduler is now optional).

Closes: #1106

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>