### PR TITLE
[RA1][RI1][RC1]Add oauth1 as optional Keystone features

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter05.md
+++ b/doc/ref_arch/openstack/chapters/chapter05.md
@@ -45,6 +45,7 @@ For the purpose of compliance tests, this chapter also identifies the set of the
 | application_credentials | X             |
 | external_idp            |               |
 | federation              |               |
+| oauth1                  |               |
 | project_tags            | X             |
 | security_compliance     | X             |
 | trust                   | X             |

--- a/doc/ref_cert/lfn/chapters/chapter03.md
+++ b/doc/ref_cert/lfn/chapters/chapter03.md
@@ -47,7 +47,7 @@ The following is a Requirements Traceability Matrix (RTM) mapping Test Case, and
 
 The RTM contains RM config (i.e. .conf) requirements listed “per profile”, followed by RA-1 requirements.  Requirements fall into 8 domains: general(gen), infrastructure(inf), VIM(vim), Interface & API(int), Tenants(tnt), LCM(lcm), Assurance(asr), Security(sec).
 
-For detailed information on RM & RA-1 NFVI and VNF requirements, please refer to [RI-1 Chapter 3](https://github.com/cntt-n/CNTT/blob/master/doc/ref_impl/cntt-ri/chapters/chapter03.md). 
+For detailed information on RM & RA-1 NFVI and VNF requirements, please refer to [RI-1 Chapter 3](https://github.com/cntt-n/CNTT/blob/master/doc/ref_impl/cntt-ri/chapters/chapter03.md).
 
 |#|Requirement|Description|Catalog|Status|MUST|Category|RI-1 Implemented (Yes/No)|RC-1 Coverage (project)|RC-1 Project To On-board|
 |--- |--- |--- |--- |--- |--- |--- |--- |--- |--- |
@@ -218,6 +218,7 @@ the following test names must not be executed:
 
 | test rejection regular expressions        | reasons    |
 |-------------------------------------------|------------|
+| .\*api.identity.v3.test_oauth1_tokens     | oauth1     |
 | .\*scenario.test_federated_authentication | federation |
 | .\*identity.admin.v2                      | API v2     |
 | .\*identity.v2                            | API v2     |


### PR DESCRIPTION
It was not listed in Keystone which defacto sets it as optional.
It may be considered as mandatory in a second step.

It should be noted that it's not working in CNTT RI and there is no
true plan to update CNTT RI from the time writing.

RA1 and RC are updated in one change according to the traceability in
place.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>