### PR TITLE
[RA-1 Ch02]Fix '2.3.8 Security Requirements' table show

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter02.md
+++ b/doc/ref_arch/openstack/chapters/chapter02.md
@@ -188,7 +188,6 @@ Traceability to Reference Model.
 <!-- | `req.sec.ntw.01` | Networking | The Architecture **must** have the underlay network include strong access controls that comply with the applicable security standard (national, regional), for example ISO27001. | |
 | `req.sec.ntw.02` | Networking | The Architecture **must** have all security logs stored in accordance with applicable security standard (national, regional), for example ISO27001. | | -->
 | `req.sec.ntw.03` | Networking | The Architecture **must** have the underlay network incorporate encrypted and/or private communications channels to ensure its security. | |
-|----|--------------|-----------------------------|-------|
 | `req.sec.ntw.04` | Networking | The Architecture **must** configure all of the underlay network components to ensure the complete separation from the overlay customer deployments. | |
 | `req.sec.ntw.05` | Networking | The Architecture **must** have the underlay network include strong access controls that adhere to the V1.1 NIST Cybersecurity Framework. | |
 <p align="center"><b>Table 2-8:</b> OpenStack Security Requirements.</p>

--- a/doc/ref_arch/openstack/chapters/chapter02.md
+++ b/doc/ref_arch/openstack/chapters/chapter02.md
@@ -190,6 +190,7 @@ Traceability to Reference Model.
 | `req.sec.ntw.03` | Networking | The Architecture **must** have the underlay network incorporate encrypted and/or private communications channels to ensure its security. | |
 | `req.sec.ntw.04` | Networking | The Architecture **must** configure all of the underlay network components to ensure the complete separation from the overlay customer deployments. | |
 | `req.sec.ntw.05` | Networking | The Architecture **must** have the underlay network include strong access controls that adhere to the V1.1 NIST Cybersecurity Framework. | |
+|----|--------------|-----------------------------|-------|
 <p align="center"><b>Table 2-8:</b> OpenStack Security Requirements.</p>
 
 <!--


### PR DESCRIPTION
the extra |----| make the table can not show normally, this patch remove this.