### PR TITLE
[RA1 Ch03, Ch04, Ch05] Cyborg removed for Baldy

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter03.md
+++ b/doc/ref_arch/openstack/chapters/chapter03.md
@@ -182,7 +182,9 @@ The following OpenStack components are deployed on the Infrastructure. Some of t
 | Compute Resources Manager| Ironic| the Bare Metal Provisioning service| Optional| X| X |
 | (Tool that utilizes APIs)| Heat| the orchestration service| Required| X|  |
 | UI| Horizon| the WEB UI service| Required| X|  |
+<!--
 | Acceleration Resources Manager| Cyborg| the acceleration resources management| Optional| X| X |
+-->
 
 All components must be deployed within a high available architecture that can withstand at least a single node failure and respects the anti-affinity rules for the location of the services (i.e. instances of a same service must run on different nodes).
 

--- a/doc/ref_arch/openstack/chapters/chapter04.md
+++ b/doc/ref_arch/openstack/chapters/chapter04.md
@@ -395,6 +395,7 @@ Heat is the orchestration service using template to provision cloud resources, H
 #### 4.3.1.9 Horizon
 Horizon is the Web User Interface to all OpenStack services. Horizon has services running on the control nodes and no services running on the compute nodes.
 
+<!--
 #### 4.3.1.10 Cyborg
 Cyborg is the acceleration resources management service. Cyborg depends on Nova and has services running on the control node and compute node. Cyborg-api, cyborg-conductor and cyborg-db are hosted on control nodes.
 -	cyborg-api
@@ -402,8 +403,9 @@ Cyborg is the acceleration resources management service. Cyborg depends on Nova 
 -	cyborg-db
 - cyborg-agent  which runs on compute nodes
 - *-driver drivers which run on compute nodes and depend on the acceleration hardware
+-->
 
-#### 4.3.1.11 Placement
+#### 4.3.1.10 Placement
 The OpenStack Placement service enables tracking (or accounting) and scheduling of resources. It provides a RESTful API and a data model for the managing of resource provider inventories and usage for different classes of resources. In addition to standard resource classes, such as VCPU, MEMORY_MB and DISK_GB, the Placement service supports custom resource classes (prefixed with “CUSTOM_”).  The placement service is primarily utilized by nova-compute and nova-scheduler. Other OpenStack services such as Neutron or Cyborg can also utilize placement and do so by creating [Provider Trees]( https://docs.openstack.org/placement/latest/user/provider-tree.html). The following data objects are utilized in the [placement service]( https://docs.openstack.org/placement/latest/user/index.html): 
 
 <p>Resource Providers provide consumable inventory of one or more classes of resources (cpu, memory or disk). A resource provider can be a compute host, for example.</p>

--- a/doc/ref_arch/openstack/chapters/chapter05.md
+++ b/doc/ref_arch/openstack/chapters/chapter05.md
@@ -280,8 +280,9 @@ libraries.
 | Object Storage: Swift | https://docs.openstack.org/api-ref/object-store/     | v1              |                              |
 | Placement             | https://docs.openstack.org/api-ref/placement/        | v1              | 1.10                         |
 | Orchestration: Heat   | https://docs.openstack.org/api-ref/orchestration/v1/ | v1              |                              |
+<!--
 | Acceleration: Cyborg  | https://docs.openstack.org/api-ref/accelerator/v2/ | v2    |
-|
+-->
 
 ### 5.3.2. Kubernetes Interfaces
 The Kubernetes APIs are available at https://kubernetes.io/docs/concepts/overview/kubernetes-api/.
@@ -292,6 +293,7 @@ The KVM APIs are documented in Section 4 of the document https://www.kernel.org/
 #### 5.3.3.1. Libvirt Interfaces
 The Libvirt APIs are documented in https://libvirt.org/html/index.html.
 
+<!--
 ### 5.3.4. Cyborg
 
 | **OpenStack Service** | **API Version** |
@@ -300,8 +302,9 @@ The Libvirt APIs are documented in https://libvirt.org/html/index.html.
 
 Acceleration Service API: https://docs.openstack.org/api-ref/accelerator/v2/index.html
 Please note that the initial version of the [Cyborg API v1.0](https://docs.openstack.org/cyborg/stein/admin/api.html) was deprecated in the OpenStack Train release and will be removed in the Ussuri release.
+-->
 
-### 5.3.5. Barbican
+### 5.3.4. Barbican
 
 | **OpenStack Service**           | **API Version** |
 |---------------------------------|-----------------|


### PR DESCRIPTION
Fixes #1411
Cyborg is removed for Baldy RA1 release and will be introduced later on with relevant OpenStack releases.

Modifications applied to Chapter 3, 4 and 5

Chapter 3, Section 3.3.1.3, Cyborg removed from components table
