### PR TITLE
[RM Ch6]: Partial removal of NFVI, VIM and VNF

### DIFF
--- a/doc/ref_model/chapters/chapter06.md
+++ b/doc/ref_model/chapters/chapter06.md
@@ -14,7 +14,7 @@
 
 <a name="6.1"></a>
 ## 6.1 Introduction
-In this document’s earlier chapters, the various resources and capabilities of the Cloud Infrastructure have been catalogued and the workloads have been profiled with respect to those capabilities. The intent behind this chapter and an “API Layer” is to similarly provide a single place to catalogue and thereby codify, a common set of open APIs to access (i.e. request, consume, control, etc.) the aforementioned resources, be them directly exposed to the workloadss, or purely internal to the Cloud Infrastructure.
+In this document’s earlier chapters, the various resources and capabilities of the Cloud Infrastructure have been catalogued and the workloads have been profiled with respect to those capabilities. The intent behind this chapter and an “API Layer” is to similarly provide a single place to catalogue and thereby codify, a common set of open APIs to access (i.e. request, consume, control, etc.) the aforementioned resources, be them directly exposed to the workloads, or purely internal to the Cloud Infrastructure.
 
 It is a further intent of this chapter and this document to ensure the APIs adopted for CNTT Cloud Infrastructure implementations are open and not proprietary, in support of compatibility, component substitution, and ability to realize maximum value from existing and future test heads and harnesses.
 

--- a/doc/ref_model/chapters/chapter06.md
+++ b/doc/ref_model/chapters/chapter06.md
@@ -3,41 +3,41 @@
 <p align="right"><img src="../figures/bogo_sdc.png" alt="scope" title="Scope" width="35%"/></p>
 
 ## Table of Contents
-* [6.1 Introduction.](#6.1)
-* [6.2 NFVI APIs.](#6.2)
-  * [6.2.1 Tenant Level APIs.](#6.2.1)
-  * [6.2.2 Hardware Acceleration Interfaces and APIs.](#6.2.2)
-* [6.3 Intra-NFVI Interfaces.](#6.3)
-  * [6.3.1. Hypervisor Hardware Interface.](#6.3.1)
-* [6.4 Enabler Services Interfaces.](#6.4)
+* [6.1 Introduction](#6.1)
+* [6.2 Cloud Infrastructure APIs](#6.2)
+  * [6.2.1 Tenant Level APIs](#6.2.1)
+  * [6.2.2 Hardware Acceleration Interfaces and APIs](#6.2.2)
+* [6.3 Intra-Cloud Infrastructure Interfaces](#6.3)
+  * [6.3.1. Hypervisor Hardware Interface](#6.3.1)
+* [6.4 Enabler Services Interfaces](#6.4)
 
 
 <a name="6.1"></a>
 ## 6.1 Introduction
-In this document’s earlier chapters, the various resources and capabilities of the NFVI have been catalogued and the workloads (VNFs) have been profiled with respect to those capabilities. The intent behind this chapter and an “API Layer” is to similarly provide a single place to catalogue and thereby codify, a common set of open APIs to access (i.e. request, consume, control, etc.) the aforementioned resources, be them directly exposed to the VNFs, or purely internal to the NFVI.
+In this document’s earlier chapters, the various resources and capabilities of the Cloud Infrastructure have been catalogued and the workloads have been profiled with respect to those capabilities. The intent behind this chapter and an “API Layer” is to similarly provide a single place to catalogue and thereby codify, a common set of open APIs to access (i.e. request, consume, control, etc.) the aforementioned resources, be them directly exposed to the workloadss, or purely internal to the Cloud Infrastructure.
 
-It is a further intent of this chapter and this document to ensure the APIs adopted for CNTT NFVI implementations are open and not proprietary, in support of compatibility, component substitution, and ability to realize maximum value from existing and future test heads and harnesses.
+It is a further intent of this chapter and this document to ensure the APIs adopted for CNTT Cloud Infrastructure implementations are open and not proprietary, in support of compatibility, component substitution, and ability to realize maximum value from existing and future test heads and harnesses.
 
-While it is the intent of this chapter, when included in a Reference Architecture, to catalogue the APIs, it is not the intent of this chapter to reprint the APIs, as this would make maintenance of the chapter impractical and the length of the chapter disproportionate within the Reference Model document. Instead, the APIs selected for CNTT NFVI implementations and specified in this chapter, will be incorporated by reference and URLs for the latest, authoritative versions of the APIs, provided in the References section of this document.
+While it is the intent of this chapter, when included in a Reference Architecture, to catalogue the APIs, it is not the intent of this chapter to reprint the APIs, as this would make maintenance of the chapter impractical and the length of the chapter disproportionate within the Reference Model document. Instead, the APIs selected for CNTT Cloud Infrastructure implementations and specified in this chapter, will be incorporated by reference and URLs for the latest, authoritative versions of the APIs, provided in the References section of this document.
 
-Although the document does not attempt to reprint the APIs themselves, where appropriate and generally where the mapping of resources and capabilities within the NFVI to objects in APIs would be otherwise ambiguous, this chapter shall provide explicit identification and mapping.
+Although the document does not attempt to reprint the APIs themselves, where appropriate and generally where the mapping of resources and capabilities within the Cloud Infrastructure to objects in APIs would be otherwise ambiguous, this chapter shall provide explicit identification and mapping.
 
-In addition to the raw or base-level NFVI functionality to API and object mapping, it is further the intent to specify an explicit, normalized set of APIs and mappings to control the logical interconnections and relationships between these objects, notably, but not limited to, support of SFC (Service Function Chaining) and other networking and network management functionality.
+In addition to the raw or base-level Cloud Infrastructure functionality to API and object mapping, it is further the intent to specify an explicit, normalized set of APIs and mappings to control the logical interconnections and relationships between these objects, notably, but not limited to, support of SFC (Service Function Chaining) and other networking and network management functionality.
 
-Chapter 3 introduced a model of the Network Function Virtualisation Infrastructure (NFVI). Figure 3-1 shows an overview of the NFVI model including the external application programming interface (API)/ user interface (UI) for providing access to the NFVI management functions. Section 3.3 lists the actions supported by the NFVI Management Software.  This chapter specifies the abstract interfaces (API, CLI, etc.) supported by the NFVI Reference Model. The purpose of this chapter is to define and catalogue a common set of open (not proprietary) APIs, of the following types:
+Chapter 3 introduced a model of the Cloud Infrastructure. Figure 3-1 shows an overview of the Cloud Infrastructure model including the external application programming interface (API)/ user interface (UI) for providing access to the Cloud Infrastructure management functions. Section 3.3 lists the actions supported by the Cloud Infrastructure Management Software.  This chapter specifies the abstract interfaces (API, CLI, etc.) supported by the Cloud Infrastructure Reference Model. The purpose of this chapter is to define and catalogue a common set of open (not proprietary) APIs, of the following types:
 
-- NFVI APIs: These APIs are provided to the VNF workloads (i.e. exposed), by the infrastructure in order for VNF workloads to access (i.e. request, consume, control, etc.) NFVI resources.
-- Intra-NFVI APIs: These APIs are provided and consumed directly by the infrastructure. These APIs are purely internal to the NFVI and are not exposed to the workloads.
-- Enabler Services APIs: These APIs are provided by non-NFVI services and provide capabilities that are required for a majority of VNF workloads, e.g. DHCP, DNS, NTP, DBaaS, etc.
+- Cloud Infrastructure APIs: These APIs are provided to the workloads (i.e. exposed), by the infrastructure in order for workloads to access (i.e. request, consume, control, etc.) Cloud Infrastructure resources.
+- Intra-Cloud Infrastructure APIs: These APIs are provided and consumed directly by the infrastructure. These APIs are purely internal to the Cloud Infrastructure and are not exposed to the workloads.
+- Enabler Services APIs: These APIs are provided by non-Cloud Infrastructure services and provide capabilities that are required for a majority of VNF workloads, e.g. DHCP, DNS, NTP, DBaaS, etc.
 
 <a name="6.2"></a>
-## 6.2 NFVI APIs
-The NFVI APIs consist of set of APIs that are externally and internally visible. The externally visible APIs are made available for orchestration and management of the execution environments that host workloads (e.g., VNFs) while the internally visible APIs support actions on the hypervisor and the physical resources. The ETSI NFV Reference Architecture Framework (**Figure 6-1**) shows a number of Interface points where specific or sets of APIs are supported. For the scope of the reference model the relevant interface points are shown in **Table 6-1**.
+## 6.2 Cloud Infrastructure APIs
+The Cloud Infrastructure APIs consist of set of APIs that are externally and internally visible. The externally visible APIs are made available for orchestration and management of the execution environments that host workloads while the internally visible APIs support actions on the hypervisor and the physical resources. The ETSI NFV Reference MANO Architecture (**Figure 6-1**) shows a number of Interface points where specific or sets of APIs are supported. For the scope of the reference model the relevant interface points are shown in **Table 6-1**.
 
-<p align="center"><img src="../figures/ch01_etsi_archi_mapping_v2.PNG" alt="ETSI NFVI Interface" title="ETSI NFVI Interface" width="65%"/></p>
-<p align="center"><b>Figure 6-1:</b> ETSI NFVI Interface points.</p>
+<p align="center"><img src="../figures/ch09-etsi-nfv-architecture-mapping.png" alt="ETSI NFV architecture mapping" title="ETSI NFV architecture mapping" width="65%"/></p>
+<p align="center"><b>Figure 6-1:</b> ETSI NFV architecture mapping</p>
 
-| Interface Point | NFVI Exposure | Interface Between                     | Description                                                                                                                                                                                                                                                                                                     |
+| Interface Point | Cloud Infrastructure Exposure | Interface Between                     | Description                                                                                                                                                                                                                                                                                                     |
 |-----------------|---------------|---------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Vi-Ha           | Internal NFVI | Software Layer and Hardware Resources | 1. Discover/collect resources and their configuration information <br>2. Create execution environment (e.g., VM) for workloads (VNF)                                                                                                                                                                            |
 | Vn-Nf           | External      | NFVI and VM (VNF)                     | Here VNF represents the execution environment. The interface is used to specify interactions between the VNF and abstract NFVI accelerators. The interfaces can be used to discover, configure, and manage these acceleartors and for the VNF to register/deregister for receiving acceleartor events and data. |
@@ -45,7 +45,7 @@ The NFVI APIs consist of set of APIs that are externally and internally visible.
 | Or-Vi           | External      | VNF Orchestrator and VIM              | See below                                                                                                                                                                                                                                                                                                       |
 | Vi-Vnfm         | External      | VNF Manager and VIM                   | See below                                                                                                                                                                                                                                                                                                       |
 
-<p align="center"><b>Table 6-1:</b> NFVI and VIM Interfaces with Other System Components.</p>
+<p align="center"><b>Table 6-1:</b> NFVI and VIM Interfaces with Other System Components in the ETSI NFV architecture</p>
 
 The Or-Vi and Vi-VNfm are both specifying interfaces provided by the VIM and therefore are related. The Or-Vi reference point is used for exchanges between NFV Orchestrator and VIM, and supports the following interfaces; virtualised resources refers to virtualised compute, storage, and network resources:
 
@@ -64,9 +64,9 @@ The Or-Vi and Vi-VNfm are both specifying interfaces provided by the VIM and the
 <a name="6.2.1"></a>
 ### 6.2.1 Tenant Level APIs
 
-In the abstraction model of the NFVI (**Chapter 3**) a conceptual model of a Tenant (**Figure 3-2**) represents the slice of a cloud zone dedicated to a VNF. This slice, the Tenant, is composed of virtual resources being utilized by VNFs within that Tenant. The Tenant has an assigned quota of virtual resources, a set of users can perform operations as per their assigned roles, and the Tenant exists within a Cloud Zone. The APIs will specify the allowed operations on the Tenant including its component virtual resources and the different APIs can only be executed by users with the appropriate roles. For example, a Tenant may only be allowed to be created and deleted by Cloud Zone administrators while virtual compute resources could be allowed to be created and deleted by Tenant administrators.
+In the abstraction model of the Cloud Infrastructure (**Chapter 3**) a conceptual model of a Tenant (**Figure 3-2**) represents the slice of a cloud zone dedicated to a workload. This slice, the Tenant, is composed of virtual resources being utilized by workloads within that Tenant. The Tenant has an assigned quota of virtual resources, a set of users can perform operations as per their assigned roles, and the Tenant exists within a Cloud Zone. The APIs will specify the allowed operations on the Tenant including its component virtual resources and the different APIs can only be executed by users with the appropriate roles. For example, a Tenant may only be allowed to be created and deleted by Cloud Zone administrators while virtual compute resources could be allowed to be created and deleted by Tenant administrators.
 
-For a VNF stack to be created in a Tenant also requires APIs for the management (creation, deletion, and operation) of the Tenant, software flavours (Chapter 5), Operating System and VNF images (“Images”), Identity and Authorization (“Identity”), virtual resources, security, and the VNF application (“stack”).
+For a workload to be created in a Tenant also requires APIs for the management (creation, deletion, and operation) of the Tenant, software flavours (Chapter 5), Operating System and workload images (“Images”), Identity and Authorization (“Identity”), virtual resources, security, and the workload application (“stack”).
 
 A virtual compute resource is created as per the flavour template (specifies the compute, memory, and local storage capacity) and is launched using an image with access and security credentials; once launched, it is referred to as a virtual compute instance or just “Instance”). Instances can be launched by specifying the compute, memory, and local storage capacity parameters instead of an existing flavour; reference to flavours covers the situation where the capacity parameters are specified. IP addresses and storage volumes can be attached to a running Instance.
 
@@ -86,13 +86,13 @@ A virtual compute resource is created as per the flavour template (specifies the
 | Virtual network | +      | +    | +      | +      | +      | Create/delete by VDC users with appropriate role                                                            |
 <p align="center"><b>Table 6-2:</b> API types for a minimal set of resources.</p>
 
-**Table 6-2** specifies a minimal set of operations for a minimal set of resources that are needed to orchestrate VNF workloads. The actual APIs for the listed operations will be specified in the Reference Architectures; each listed operation could have a number of associated APIs with a different set of parameters. For example, create virtual resource using an image or a device.
+**Table 6-2** specifies a minimal set of operations for a minimal set of resources that are needed to orchestrate workloads. The actual APIs for the listed operations will be specified in the Reference Architectures; each listed operation could have a number of associated APIs with a different set of parameters. For example, create virtual resource using an image or a device.
 
 <a name="6.2.2"></a>
 ### 6.2.2 Hardware Acceleration Interfaces
 
 **Acceleration Interface Specifications**
-ETSI GS NFV-IFA 002 defines a technology and implementation independent virtual accelerator, the accelerator interface requirements and specifications that would allow a VNF to leverage a Virtual Accelerator. The virtual accelerator is modeled on extensible para-virtualised devices (EDP). ETSI GS NFV-IFA 002 specifies the architectural model in Chapter 4 and the abstract interfaces for management, configuration, monitoring, and Data exchange in Chapter 7.
+ETSI GS NFV-IFA 002 defines a technology and implementation independent virtual accelerator, the accelerator interface requirements and specifications that would allow a workload to leverage a Virtual Accelerator. The virtual accelerator is modeled on extensible para-virtualised devices (EDP). ETSI GS NFV-IFA 002 specifies the architectural model in Chapter 4 and the abstract interfaces for management, configuration, monitoring, and Data exchange in Chapter 7.
 
 ETSI ETSI (Ref: NFV IFA 019 v03101p) has defined a set of technology independent interfaces for acceleration resource life cycle management. These operations allow: allocation, release, and querying of acceleration resource, get and reset statistics, subscribe/unsubscribe (terminate) to fault notifications, notify (only used by NFVI), and get alarm information.
 
@@ -162,10 +162,10 @@ These acceleration interfaces are summarized here in Table 6.3 only for convenie
 | |||Input|accImageInfo|Information about the acceleration image. |
 | |||Input|accImage|The binary file of acceleration image. |
 
-<p align="center"><b>Table 6-3:</b> Hardware Acceleration Interfaces.</p>
+<p align="center"><b>Table 6-3:</b> Hardware Acceleration Interfaces in the ETSI NFV architecture</p>
 
 <a name="6.3"></a>
-## 6.3 Intra-NFVI Interfaces
+## 6.3 Intra-Cloud Infrastructure Interfaces
 
 <a name="6.3.1"></a>
 ### 6.3.1. Hypervisor Hardware Interface

--- a/doc/ref_model/chapters/chapter06.md
+++ b/doc/ref_model/chapters/chapter06.md
@@ -28,7 +28,7 @@ Chapter 3 introduced a model of the Cloud Infrastructure. Figure 3-1 shows an ov
 
 - Cloud Infrastructure APIs: These APIs are provided to the workloads (i.e. exposed), by the infrastructure in order for workloads to access (i.e. request, consume, control, etc.) Cloud Infrastructure resources.
 - Intra-Cloud Infrastructure APIs: These APIs are provided and consumed directly by the infrastructure. These APIs are purely internal to the Cloud Infrastructure and are not exposed to the workloads.
-- Enabler Services APIs: These APIs are provided by non-Cloud Infrastructure services and provide capabilities that are required for a majority of VNF workloads, e.g. DHCP, DNS, NTP, DBaaS, etc.
+- Enabler Services APIs: These APIs are provided by non-Cloud Infrastructure services and provide capabilities that are required for a majority of workloads, e.g. DHCP, DNS, NTP, DBaaS, etc.
 
 <a name="6.2"></a>
 ## 6.2 Cloud Infrastructure APIs


### PR DESCRIPTION
NFVI, VIM and VNF was removed from the parts of the text which is not
explicitly about the ETSI NFV architecture.

I think we should not remove the ETSI NFV terminology from the parts where they are used int the ETSI NFV context. 

Partially closes #1168 