### PR TITLE
[RA1][RC1] Set Swift container_sync as optional

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter05.md
+++ b/doc/ref_arch/openstack/chapters/chapter05.md
@@ -94,7 +94,7 @@ REST API Version History: https://docs.openstack.org/cinder/latest/contributor/a
 | bulk_delete        | X             |
 | bulk_upload        | X             |
 | container_quotas   | X             |
-| container_sync     | X             |
+| container_sync     |               |
 | crossdomain        | X             |
 | discoverability    | X             |
 | form_post          | X             |

--- a/doc/ref_cert/lfn/chapters/chapter03.md
+++ b/doc/ref_cert/lfn/chapters/chapter03.md
@@ -314,9 +314,10 @@ According to
 [RA1 Core OpenStack Services APIs]({{ "/doc/ref_arch/openstack/chapters/chapter05.html" | relative_url }})
 the following test names must not be executed:
 
-| test rejection regular expressions                                      | reasons                            |
-|-------------------------------------------------------------------------|------------------------------------|
-| .\*test_container_sync.ContainerSyncTest.test_container_synchronization | https://launchpad.net/bugs/1317133 |
+| test rejection regular expressions                                                           | reasons                            |
+|----------------------------------------------------------------------------------------------|------------------------------------|
+| .\*test_container_sync.ContainerSyncTest.test_container_synchronization                      | https://launchpad.net/bugs/1317133 |
+| .\*test_container_sync_middleware.ContainerSyncMiddlewareTest.test_container_synchronization | container_sync                     |
 
 Swift API is also covered by [Rally](https://opendev.org/openstack/rally).
 


### PR DESCRIPTION
It's not supported by radosgw which includes a different
synchronization model, multisite operations, for users who require
that feature [3].

From an interopability point of view it seems fine to set it as
optional. It should be noted that radosgw is used in both CNTT
reference implementations (Functest [2] and Airship [3]).

[1] https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3.2/html-single/release_notes/index
[2] http://artifacts.opnfv.org/functest/E46RCZLBRYCC/functest-opnfv-functest-smoke-hunter-tempest_slow-run-127/tempest_slow/tempest-report.html
[3] http://artifacts.opnfv.org/cntt/WKFRPQODPW34/cntt-opnfv-functest-smoke-latest-tempest_slow-run-37/tempest_slow/tempest-report.html

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>