### PR TITLE
[RA1 Ch03 ch04] Barbican description

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter03.md
+++ b/doc/ref_arch/openstack/chapters/chapter03.md
@@ -182,6 +182,7 @@ The following OpenStack components are deployed on the Infrastructure. Some of t
 | Compute Resources Manager| Ironic| the Bare Metal Provisioning service| Optional| X| X |
 | (Tool that utilizes APIs)| Heat| the orchestration service| Required| X|  |
 | UI| Horizon| the WEB UI service| Required| X|  |
+| Key Manager| Barbican| the secret data management service| Optional| X|  |
 <!--
 | Acceleration Resources Manager| Cyborg| the acceleration resources management| Optional| X| X |
 -->

--- a/doc/ref_arch/openstack/chapters/chapter04.md
+++ b/doc/ref_arch/openstack/chapters/chapter04.md
@@ -422,6 +422,10 @@ The OpenStack Placement service enables tracking (or accounting) and scheduling 
     
 <p>Allocation candidates is the collection of resource providers that can satisfy an allocation request.</p>
 
+#### 4.3.1.11 Barbican
+Barbican is the OpenStack Key Manager service. It is an optional service hosted on controller nodes. It provides secure storage, provisioning and management of secrets as passwords, encryption keys and X.509 Certificates. Barbican API is used to centrally manage secrets used by OpenStack services, e.g. symmetric encryption keys used for Block storage encryption or Object Storage encryption or asymmetric keys and certificates used for Glance image signing and verification. 
+
+Barbican usage provides a means to fulfill security requirements such as req.sec.zon.02 “The Architecture must support password encryption” and req.sec.zon.03 “The Architecture must support data, at-rest and in-flight, encryption”.
 
 <a name="4.3.2"></a>
 ### 4.3.2. Containerised OpenStack Services 

--- a/doc/ref_arch/openstack/chapters/chapter04.md
+++ b/doc/ref_arch/openstack/chapters/chapter04.md
@@ -423,7 +423,7 @@ The OpenStack Placement service enables tracking (or accounting) and scheduling 
 <p>Allocation candidates is the collection of resource providers that can satisfy an allocation request.</p>
 
 #### 4.3.1.11 Barbican
-Barbican is the OpenStack Key Manager service. It is an optional service hosted on controller nodes. It provides secure storage, provisioning and management of secrets as passwords, encryption keys and X.509 Certificates. Barbican API is used to centrally manage secrets used by OpenStack services, e.g. symmetric encryption keys used for Block storage encryption or Object Storage encryption or asymmetric keys and certificates used for Glance image signing and verification. 
+[Barbican](https://docs.openstack.org/barbican/pike/admin/index.html) is the OpenStack Key Manager service. It is an optional service hosted on controller nodes. It provides secure storage, provisioning and management of secrets as passwords, encryption keys and X.509 Certificates. Barbican API is used to centrally manage secrets used by OpenStack services, e.g. symmetric encryption keys used for Block storage encryption or Object Storage encryption or asymmetric keys and certificates used for Glance image signing and verification. 
 
 Barbican usage provides a means to fulfill security requirements such as req.sec.zon.02 “The Architecture must support password encryption” and req.sec.zon.03 “The Architecture must support data, at-rest and in-flight, encryption”.
 


### PR DESCRIPTION
Fixes #1453 
The Barbican OpenStack service described in Chapter5 is not described in Chapter 3 and 4.

Text added in Chapter 3 and 4