### PR TITLE
[RC1] Add Horizon testing in CNTT RC1

### DIFF
--- a/doc/ref_cert/lfn/chapters/chapter03.md
+++ b/doc/ref_cert/lfn/chapters/chapter03.md
@@ -11,15 +11,16 @@
   * [3.3.2 Infrastructure](#3.3.2)
   * [3.3.3 VIM](#3.3.3)
   * [3.3.4 Interfaces & APIs](#3.3.4)
-  * [3.3.5 OpenStack API benchmarking](#3.3.5)
-  * [3.3.6 Dataplane Benchmarking](#3.3.6)
-  * [3.3.7 Opensource VNF onboarding and testing](#3.3.7)
-  * [3.3.8 Tenants](#3.3.8)
-  * [3.3.9 LCM](#3.3.9)
-  * [3.3.10 Assurance](#3.3.10)
-  * [3.3.11 Security](#3.3.11)
-  * [3.3.12 Resilience](#3.3.13)
-  * [3.3.13 Bare-metal validations](#3.3.14)
+  * [3.3.5 Dashboard](#3.3.5)
+  * [3.3.6 OpenStack API benchmarking](#3.3.6)
+  * [3.3.7 Dataplane Benchmarking](#3.3.7)
+  * [3.3.8 Opensource VNF onboarding and testing](#3.3.8)
+  * [3.3.9 Tenants](#3.3.9)
+  * [3.3.10 LCM](#3.3.10)
+  * [3.3.11 Assurance](#3.3.11)
+  * [3.3.12 Security](#3.3.12)
+  * [3.3.13 Resilience](#3.3.13)
+  * [3.3.14 Bare-metal validations](#3.3.14)
 * [3.4 Test Cases Traceability to Requirements](#3.4)
   * [3.4.1 Test Cases Traceability](#3.4.1)
 
@@ -197,6 +198,7 @@ versions are considered here to verify OpenStack Pike selected by CNTT:
 | software                | version |
 |-------------------------|---------|
 | Functest                | hunter  |
+| Horizon Tempest plugin  | 0.1.0   |
 | Cinder Tempest plugin   | 0.2.0   |
 | Keystone Tempest plugin | 0.1.0   |
 | Neutron                 | rocky   |
@@ -492,7 +494,14 @@ Here are the mainline tasks integrated in
 - HeatStacks.list_stacks_and_resources
 
 <a name="3.3.5"></a>
-### 3.3.5 OpenStack API benchmarking
+### 3.3.5 Dashboard
+
+Horizon is covered in the OpenStack Gates via
+[tempest-horizon](https://github.com/openstack/tempest-horizon) as integrated
+in [Functest Healthcheck](https://git.opnfv.org/functest/tree/docker/healthcheck/testcases.yaml).
+
+<a name="3.3.6"></a>
+### 3.3.6 OpenStack API benchmarking
 
 [Rally](https://opendev.org/openstack/rally) is tool and framework that allows
 to perform OpenStack API benchmarking.
@@ -510,7 +519,7 @@ which would have asked for an update of the default SLA (maximum failure rate
 of 0%) proposed in
 [Functest Benchmarking CNTT](https://git.opnfv.org/functest/tree/docker/benchmarking-cntt/testcases.yaml)
 
-#### 3.3.5.1 Identity - Keystone
+#### 3.3.6.1 Identity - Keystone
 
 [Functest rally_full](http://artifacts.opnfv.org/functest/IR6NYE2BYC8W/functest-opnfv-functest-benchmarking-hunter-rally_full-run-324/rally_full/rally_full.html):
 
@@ -529,7 +538,7 @@ of 0%) proposed in
 | KeystoneBasic.create_and_list_users           | 10         |
 | KeystoneBasic.create_tenant_with_users        | 10         |
 
-#### 3.3.5.2 Image - Glance
+#### 3.3.6.2 Image - Glance
 
 [Functest rally_full](http://artifacts.opnfv.org/functest/IR6NYE2BYC8W/functest-opnfv-functest-benchmarking-hunter-rally_full-run-324/rally_full/rally_full.html):
 
@@ -545,7 +554,7 @@ of 0%) proposed in
 | GlanceImages.create_and_get_image            | 10         |
 | GlanceImages.create_and_update_image         | 10         |
 
-#### 3.3.5.3 Block Storage - Cinder
+#### 3.3.6.3 Block Storage - Cinder
 
 [Functest rally_full](http://artifacts.opnfv.org/functest/IR6NYE2BYC8W/functest-opnfv-functest-benchmarking-hunter-rally_full-run-324/rally_full/rally_full.html):
 
@@ -575,7 +584,7 @@ of 0%) proposed in
 | Quotas.cinder_update_and_delete                               | 10         |
 | Quotas.cinder_update                                          | 10         |
 
-#### 3.3.5.4 Object Storage - Swift
+#### 3.3.6.4 Object Storage - Swift
 
 [Functest rally_full](http://artifacts.opnfv.org/functest/IR6NYE2BYC8W/functest-opnfv-functest-benchmarking-hunter-rally_full-run-324/rally_full/rally_full.html):
 
@@ -587,7 +596,7 @@ of 0%) proposed in
 | SwiftObjects.create_container_and_object_then_delete_all      | 10         |
 | SwiftObjects.list_and_download_objects_in_containers          | 10         |
 
-#### 3.3.5.5 Networking - Neutron
+#### 3.3.6.5 Networking - Neutron
 
 [Functest rally_full](http://artifacts.opnfv.org/functest/IR6NYE2BYC8W/functest-opnfv-functest-benchmarking-hunter-rally_full-run-324/rally_full/rally_full.html):
 
@@ -635,7 +644,7 @@ of 0%) proposed in
 | NeutronTrunks.create_and_list_trunk_subports | 4          |
 | Quotas.neutron_update                        | 40         |
 
-#### 3.3.5.6 Compute - Nova
+#### 3.3.6.6 Compute - Nova
 
 [Functest rally_full](http://artifacts.opnfv.org/functest/IR6NYE2BYC8W/functest-opnfv-functest-benchmarking-hunter-rally_full-run-324/rally_full/rally_full.html):
 
@@ -671,7 +680,7 @@ of 0%) proposed in
 | NovaServerGroups.create_and_list_server_groups                 | 10         |
 | Quotas.nova_update                                             | 10         |
 
-#### 3.3.5.7 Orchestration - Heat
+#### 3.3.6.7 Orchestration - Heat
 
 [Functest rally_full](http://artifacts.opnfv.org/functest/IR6NYE2BYC8W/functest-opnfv-functest-benchmarking-hunter-rally_full-run-324/rally_full/rally_full.html):
 
@@ -685,8 +694,8 @@ of 0%) proposed in
 | HeatStacks.create_suspend_resume_delete_stack | 10         |
 | HeatStacks.list_stacks_and_resources          | 10         |
 
-<a name="3.3.6"></a>
-### 3.3.6 Dataplane benchmarking
+<a name="3.3.7"></a>
+### 3.3.7 Dataplane benchmarking
 
 [Functest Benchmarking CNTT](https://git.opnfv.org/functest/tree/docker/benchmarking-cntt/testcases.yaml)
 offers two benchmarking dataplane test cases leveraging on:
@@ -710,7 +719,7 @@ asked for an update of the default SLA proposed in
 
 On top of this dataplane benchmarking described in VMTP & Shaker, we need to integrate testing as described in [ETSI GS NFV-TST 009: Specification of Networking Benchmarks and Measurement Methods for NFVI](https://www.etsi.org/deliver/etsi_gs/NFV-TST/001_099/009/03.01.01_60/gs_NFV-TST009v030101p.pdf). This type of testing is better suited to measure the networking capabilities of a compute node. The [rapid scripts](https://wiki.opnfv.org/display/SAM/Rapid+scripting) in conjunction with the [PROX tool](https://wiki.opnfv.org/pages/viewpage.action?pageId=12387840) offers an open source implementation for this type of testing.
 
-### 3.3.6.1 VMTP
+### 3.3.7.1 VMTP
 
 Here are the
 [scenarios](http://artifacts.opnfv.org/functest/IR6NYE2BYC8W/functest-opnfv-functest-benchmarking-hunter-vmtp-run-328/vmtp/vmtp.json)
@@ -748,7 +757,7 @@ Here are all results per scenario:
 | TCP      | 65536    | rtt_ms           |
 | TCP      | 65536    | throughput_kbps  |
 
-### 3.3.6.2 Shaker
+### 3.3.7.2 Shaker
 
 Here are the
 [scenarios](http://artifacts.opnfv.org/functest/IR6NYE2BYC8W/functest-opnfv-functest-benchmarking-hunter-shaker-run-329/shaker/report.json)
@@ -775,7 +784,7 @@ Here are all samples:
 | TCP            | retransmits            |
 | UDP            | packets (pps)          |
 
-### 3.3.6.3 PROX
+### 3.3.7.3 PROX
 
 The generator used with the rapid scripts is PROX with a specific generator configuration file.
 When multiple flows are requested, the generator starts randomizing bits in the source and destination UDP ports.
@@ -786,8 +795,8 @@ All throughput benchmarking is done by a generator sending packets to a reflecto
 The VMs or containers use only 1 vNIC for incoming and outgoing traffic. Multiple queues can be used.
 Multiple VMs or containers can be deployed prior to running any tests. This allows to use generator-reflector pairs on the same or different compute nodes, on the same or different NUMA nodes.
 
-<a name="3.3.7"></a>
-### 3.3.7 Opensource VNF onboarding and testing
+<a name="3.3.8"></a>
+### 3.3.8 Opensource VNF onboarding and testing
 
 Running opensource VNFs is a key technical solution to ensure that the
 platforms meet Network Functions Virtualization requirements.
@@ -807,22 +816,22 @@ The VNF are covered by upstream tests when possible (see
 [clearwater-live-test](https://github.com/Metaswitch/clearwater-live-test)) and
 by Functest VNF tests in the other cases.
 
-<a name="3.3.8"></a>
-### 3.3.8 Tenants
-
 <a name="3.3.9"></a>
-### 3.3.9 LCM
+### 3.3.9 Tenants
 
 <a name="3.3.10"></a>
-### 3.3.10 Assurance
+### 3.3.10 LCM
 
 <a name="3.3.11"></a>
-### 3.3.11 Security
+### 3.3.11 Assurance
 
 <a name="3.3.12"></a>
-### 3.3.13 Resilience
+### 3.3.12 Security
 
 <a name="3.3.13"></a>
+### 3.3.13 Resilience
+
+<a name="3.3.14"></a>
 ### 3.3.14 Bare-metal validations
 
 <a name="3.4"></a>
@@ -837,6 +846,7 @@ Conformance:
 
 | container                               | test case                       | criteria |
 |-----------------------------------------|---------------------------------|:--------:|
+| opnfv/functest-healthcheck:hunter       | tempest_horizon                 | PASS     |
 | opnfv/functest-smoke-cntt:hunter        | neutron-tempest-plugin-api-cntt | PASS     |
 | opnfv/functest-smoke-cntt:hunter        | tempest_cinder_cntt             | PASS     |
 | opnfv/functest-smoke-cntt:hunter        | tempest_keystone_cntt           | PASS     |
@@ -859,6 +869,7 @@ Conformance:
 
 | test case                       | requirements                                                             |
 |---------------------------------|--------------------------------------------------------------------------|
+| tempest_horizon                 | Dashboard testing                                                        |
 | neutron-tempest-plugin-api-cntt | Neutron API testing                                                      |
 | tempest_cinder_cntt             | Cinder API testing                                                       |
 | tempest_keystone_cntt           | Keystone API testing                                                     |


### PR DESCRIPTION
Horizon is mandatory in CNTT and then must be covered by Functest
tempest_horizon.

The test was backported to Hunter [1] and then must be listed in RC
and executed into RI.

[1] https://gerrit.opnfv.org/gerrit/c/functest/+/69932

Closes #1472

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>