### PR TITLE
[RI-1 Ch06] Change the requirement level from must to may in req.gen.ins.01

### DIFF
--- a/doc/ref_impl/cntt-ri/chapters/chapter06.md
+++ b/doc/ref_impl/cntt-ri/chapters/chapter06.md
@@ -47,7 +47,7 @@ Thanks to the descriptor file, the NFVi infrastructure deployment could be compl
 
 | Ref #            | sub-category | Description                                                                              |
 |------------------|--------------|------------------------------------------------------------------------------------------|
-| `req.gen.ins.01` | Installer    | Installer **must** accept a descriptor file to finish deployment.                        |
+| `req.gen.ins.01` | Installer    | Installer **should** accept a descriptor file to finish deployment.                        |
 | `req.gen.ins.02` | Installer    | Installer implementation **must** validate the descriptor file with schema.              |
 | `req.gen.ins.03` | Installer    | Any existing installer implementation **may** need adaption for the descriptor file.     |
 | `req.gen.ins.04` | Installer    | Installer **may** support reporting the deployment progress status.                      |

--- a/doc/ref_impl/cntt-ri/chapters/chapter06.md
+++ b/doc/ref_impl/cntt-ri/chapters/chapter06.md
@@ -47,7 +47,7 @@ Thanks to the descriptor file, the NFVi infrastructure deployment could be compl
 
 | Ref #            | sub-category | Description                                                                              |
 |------------------|--------------|------------------------------------------------------------------------------------------|
-| `req.gen.ins.01` | Installer    | Installer **should** accept a descriptor file to finish deployment.                        |
+| `req.gen.ins.01` | Installer    | Installer **may** accept a descriptor file to finish deployment.                        |
 | `req.gen.ins.02` | Installer    | Installer implementation **must** validate the descriptor file with schema.              |
 | `req.gen.ins.03` | Installer    | Any existing installer implementation **may** need adaption for the descriptor file.     |
 | `req.gen.ins.04` | Installer    | Installer **may** support reporting the deployment progress status.                      |


### PR DESCRIPTION
Based on the feedback, most installers except one is not interested to support another format of descript files beyongs its own native format. The one that supports PDF incurred loss of functionality. Openstack Airship community also has no interest to support PDF. The estimate from Sridhar to implement such conversion tool is 3 developers/2months for the initial implementation based on Airship Treasuremap 1.7, then needs a redo when AS 2.0 is released late this year. PDF/IDF also needs to be drastically expanded to support the Airship supported configurations. So after discussion with Sridhar and Al, I am proposing to change this requirement from "must" to "may".