### PR TITLE
[RI1][RC1] Remove neutron_trunk refs

### DIFF
--- a/doc/ref_cert/lfn/chapters/chapter04.md
+++ b/doc/ref_cert/lfn/chapters/chapter04.md
@@ -105,7 +105,7 @@ for more details):
 | tempest_slow      | General            |
 | tempest_scenario  | General            |
 | patrole           | Patrole            |
-| barbican          | Barbican           |
+| tempest_barbican  | Barbican           |
 | networking-bgpvpn | Networking BGP VPN |
 | networking-sfc    | Networking SFC     |
 

--- a/doc/ref_cert/lfn/chapters/chapter04.md
+++ b/doc/ref_cert/lfn/chapters/chapter04.md
@@ -104,7 +104,6 @@ for more details):
 | tempest_full      | General            |
 | tempest_slow      | General            |
 | tempest_scenario  | General            |
-| neutron_trunk     | Neutron            |
 | patrole           | Patrole            |
 | barbican          | Barbican           |
 | networking-bgpvpn | Networking BGP VPN |

--- a/doc/ref_impl/cntt-ri/chapters/chapter08.md
+++ b/doc/ref_impl/cntt-ri/chapters/chapter08.md
@@ -460,7 +460,6 @@ missing.
 | opnfv/functest-smoke:hunter | tempest_scenario  | Success            |
 | opnfv/functest-smoke:hunter | tempest_slow      | Success            |
 | opnfv/functest-smoke:hunter | patrole           | Success            |
-| opnfv/functest-smoke:hunter | neutron_trunk     | Success            |
 | opnfv/functest-smoke:hunter | networking-bgpvpn | Success            |
 | opnfv/functest-smoke:hunter | networking-sfc    | Success            |
 | opnfv/functest-smoke:hunter | barbican          | Success            |

--- a/doc/ref_impl/cntt-ri/chapters/chapter08.md
+++ b/doc/ref_impl/cntt-ri/chapters/chapter08.md
@@ -462,7 +462,7 @@ missing.
 | opnfv/functest-smoke:hunter | patrole           | Success            |
 | opnfv/functest-smoke:hunter | networking-bgpvpn | Success            |
 | opnfv/functest-smoke:hunter | networking-sfc    | Success            |
-| opnfv/functest-smoke:hunter | barbican          | Success            |
+| opnfv/functest-smoke:hunter | tempest_barbican  | Success            |
 
 According to [RA1 Core OpenStack Services APIs]({{ "/doc/ref_arch/openstack/chapters/chapter05.html" | relative_url }})
 and [RC1 TC Requirements]({{ "doc/ref_cert/lfn/chapters/chapter09.html" | relative_url }})
@@ -523,7 +523,7 @@ cannot be executed successfully.
 | opnfv/functest-smoke:hunter             | tempest_scenario  | Success            |
 | opnfv/functest-smoke:hunter             | networking-bgpvpn | Success            |
 | opnfv/functest-smoke:hunter             | networking-sfc    | Success            |
-| opnfv/functest-smoke:hunter             | barbican          | Success            |
+| opnfv/functest-smoke:hunter             | tempest_barbican  | Success            |
 | opnfv/functest-benchmarking-cntt:hunter | vmtp              | Success            |
 | opnfv/functest-benchmarking-cntt:hunter | shaker            | Success            |
 | opnfv/functest-vnf:hunter               | cloudify          | Success            |


### PR DESCRIPTION
It duplicated tempest_neutron and then were removed.
It follow the upstream changes in Functest.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>