### PR TITLE
[RA1] Add instance_password in Nova capabilities

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter05.md
+++ b/doc/ref_arch/openstack/chapters/chapter05.md
@@ -217,6 +217,7 @@ The exhaustive list of extensions is available at https://docs.openstack.org/api
 | cold_migration           | X             |
 | console_output           | X             |
 | disk_config              | X             |
+| instance_password        | X             |
 | interface_attach         | X             |
 | live_migration           | X             |
 | metadata_service         | X             |


### PR DESCRIPTION
The data is missing and it's currently verified by CNTT RC.
enable_instance_password is set to true as default value in both
Nova [1] and Tempest configurations [2].

It must be cherry-picked to Baldy to sync RA1 and RC1.

[1] https://docs.openstack.org/nova/pike/configuration/config.html
[2] https://docs.openstack.org/tempest/latest/sampleconf.html

Fixes #1608

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>
(cherry picked from commit 0211c1e73fcae25861a1d96f258e781494f6cfc1)