### PR TITLE
[RA1]RC1] Skip manage_snapshot in CNTT

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter05.md
+++ b/doc/ref_arch/openstack/chapters/chapter05.md
@@ -72,7 +72,7 @@ Image Service Versions: https://docs.openstack.org/api-ref/image/versions/index.
 | clone                  | X             |
 | consistency_group      |               |
 | extend_attached_volume |               |
-| manage_snapshot        | X             |
+| manage_snapshot        |               |
 | manage_volume          | X             |
 | multi_backend          |               |
 | snapshot               | X             |

--- a/doc/ref_cert/lfn/chapters/chapter03.md
+++ b/doc/ref_cert/lfn/chapters/chapter03.md
@@ -274,6 +274,7 @@ the following test names must not be executed:
 | .\*test_volumes_backup.VolumesBackupsTest.test_volume_backup_create_get_detailed_list_restore_delete | ceph                                  |
 | .\*test_volumes_extend.VolumesExtendAttachedTest.test_extend_attached_volume                         | extend_attached_volume                |
 | .\*tempest.scenario.test_volume_migrate_attached                                                     | multi-backend                         |
+| .\*test_snapshot_manage                                                                              | manage_snapshot                       |
 
 Cinder API is also covered by [Rally](https://opendev.org/openstack/rally).
 


### PR DESCRIPTION
As detected by Orange's RC Field trial, Ceph doesn't support this
feature before Rocky [1].
"AttributeError: 'RBDDriver' object has no attribute 'unmanage_snapshot'"

manage_snapshot testing is fully passing in Functest SUT because CNTT
is verified vs OpenStack Rocky and newer.

Ceph is selected by RI as backend and is widely reused by the ecosystem.
It's similar to [2].

manage_snapshot will be mandatory back once CNTT selects Rocky or newer.

[1] https://bugs.launchpad.net/cinder/+bug/1645288
[2] https://gerrit.opnfv.org/gerrit/c/functest/+/69888

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>