### PR TITLE
Revert "[RA1]RC1] Skip manage_snapshot in CNTT"

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter05.md
+++ b/doc/ref_arch/openstack/chapters/chapter05.md
@@ -72,7 +72,7 @@ Image Service Versions: https://docs.openstack.org/api-ref/image/versions/index.
 | clone                  | X             |
 | consistency_group      |               |
 | extend_attached_volume |               |
-| manage_snapshot        |               |
+| manage_snapshot        | X             |
 | manage_volume          | X             |
 | multi_backend          |               |
 | snapshot               | X             |

--- a/doc/ref_cert/lfn/chapters/chapter03.md
+++ b/doc/ref_cert/lfn/chapters/chapter03.md
@@ -274,7 +274,6 @@ the following test names must not be executed:
 | .\*test_volumes_backup.VolumesBackupsTest.test_volume_backup_create_get_detailed_list_restore_delete | ceph                                  |
 | .\*test_volumes_extend.VolumesExtendAttachedTest.test_extend_attached_volume                         | extend_attached_volume                |
 | .\*tempest.scenario.test_volume_migrate_attached                                                     | multi-backend                         |
-| .\*test_snapshot_manage                                                                              | manage_snapshot                       |
 
 Cinder API is also covered by [Rally](https://opendev.org/openstack/rally).
 


### PR DESCRIPTION
Reverts cntt-n/CNTT#1628

Approved without having WSL approval. 

I suggest to discuss in upcoming RA-1 call.