### PR TITLE
[RM Ch05] Section 5.1.4 content

### DIFF
--- a/doc/ref_model/chapters/chapter05.md
+++ b/doc/ref_model/chapters/chapter05.md
@@ -111,7 +111,7 @@ The following sections detail the Cloud Infrastructure Software Profile features
 
 <a name="5.1.4"></a>
 ### 5.1.4 Security
-_**Comment:** To be worked on._
+Please see the [RM Security Chapter](./chapter07.md) and, in particular, the [Consolidated Requirements](./chapter07.md#711-consolidated-security-requirements) section.
 
 <a name="5.1.5"></a>
 ### 5.1.5 Platform Services


### PR DESCRIPTION
Replaced "content to be developed" by "Please see the [RM Security Chapter](./chapter07.md) and, in particular, the [Consolidated Requirements](./chapter07.md#711-consolidated-security-requirements) section."

Same fix would be performed for Baldy release.

Fixes #1669