### PR TITLE
[RC1] Remove RemoteStack testing from tempest_heat_cntt

### DIFF
--- a/doc/ref_cert/lfn/chapters/chapter03.md
+++ b/doc/ref_cert/lfn/chapters/chapter03.md
@@ -477,17 +477,19 @@ According to
 [RA1 Core OpenStack Services APIs]({{ "/doc/ref_arch/openstack/chapters/chapter05.html" | relative_url }})
 the following test names must not be executed:
 
-| test rejection regular expressions                         | reasons                                            |
-|------------------------------------------------------------|----------------------------------------------------|
-| .\*functional.test_lbaasv2                                 | lbaasv2                                            |
-| .\*RemoteStackTest.test_stack_create_with_cloud_credential | https://gerrit.opnfv.org/gerrit/c/functest/+/69926 |
-| .\*scenario.test_aodh_alarm                                | aodh                                               |
-| .\*tests.scenario.test_autoscaling_lb                      | lbaas                                              |
-| .\*scenario.test_autoscaling_lbv2                          | lbaasv2                                            |
-| .\*scenario.test_server_software_config                    | https://gerrit.opnfv.org/gerrit/c/functest/+/69926 |
-| .\*test_volumes.VolumeBackupRestoreIntegrationTest         | https://gerrit.opnfv.org/gerrit/c/functest/+/69931 |
-| .\*scenario.test_octavia_lbaas                             | octavia                                            |
-| .\*scenario.test_server_cfn_init                           | https://gerrit.opnfv.org/gerrit/c/functest/+/70004 |
+| test rejection regular expressions                                | reasons                                            |
+|-------------------------------------------------------------------|----------------------------------------------------|
+| .\*functional.test_lbaasv2                                        | lbaasv2                                            |
+| .\*functional.test_remote_stack.RemoteStackTest                   | https://bugs.launchpad.net/heat/+bug/1701498       |
+| .\*RemoteStackTest.test_stack_create_with_cloud_credential        | https://gerrit.opnfv.org/gerrit/c/functest/+/69926 |
+| .\*scenario.test_aodh_alarm                                       | aodh                                               |
+| .\*tests.scenario.test_autoscaling_lb                             | lbaas                                              |
+| .\*scenario.test_autoscaling_lbv2                                 | lbaasv2                                            |
+| .\*scenario.test_remote_deeply_nested.RemoteDeeplyNestedStackTest | https://bugs.launchpad.net/heat/+bug/1701498       |
+| .\*scenario.test_server_software_config                           | https://gerrit.opnfv.org/gerrit/c/functest/+/69926 |
+| .\*test_volumes.VolumeBackupRestoreIntegrationTest                | https://gerrit.opnfv.org/gerrit/c/functest/+/69931 |
+| .\*scenario.test_octavia_lbaas                                    | octavia                                            |
+| .\*scenario.test_server_cfn_init                                  | https://gerrit.opnfv.org/gerrit/c/functest/+/70004 |
 
 Heat API is also covered by [Rally](https://opendev.org/openstack/rally).
 

--- a/doc/ref_cert/lfn/chapters/chapter03.md
+++ b/doc/ref_cert/lfn/chapters/chapter03.md
@@ -480,6 +480,7 @@ the following test names must not be executed:
 | test rejection regular expressions                                | reasons                                            |
 |-------------------------------------------------------------------|----------------------------------------------------|
 | .\*functional.test_lbaasv2                                        | lbaasv2                                            |
+| .\*functional.test_encryption_vol_type                            | https://storyboard.openstack.org/#!/story/2007804  |
 | .\*functional.test_remote_stack.RemoteStackTest                   | https://bugs.launchpad.net/heat/+bug/1701498       |
 | .\*RemoteStackTest.test_stack_create_with_cloud_credential        | https://gerrit.opnfv.org/gerrit/c/functest/+/69926 |
 | .\*scenario.test_aodh_alarm                                       | aodh                                               |


### PR DESCRIPTION
Trusts redelegation is supported by Train [1][2] which forces to skip
RemoteStack as CNTT Baldy is designed for Pike (the support is
incomplete in case of trust [3]).

It will be enabled back once CNTT selects Train or newer.

[1] https://docs.openstack.org/releasenotes/heat/train.html#relnotes-13-0-0-stable-train
[2] https://github.com/openstack/heat/commit/e377658586c737150dad1bfd80b7b2267d46be51
[3] https://bugs.launchpad.net/heat/+bug/1701498

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>