### PR TITLE
[RC1] Select upstream create_and_list_trunks

### DIFF
--- a/doc/ref_cert/lfn/chapters/chapter03.md
+++ b/doc/ref_cert/lfn/chapters/chapter03.md
@@ -634,22 +634,22 @@ of 0%) proposed in
 
 [Functest rally_jobs](http://artifacts.opnfv.org/functest/IR6NYE2BYC8W/functest-opnfv-functest-benchmarking-hunter-rally_jobs-run-328/rally_jobs/rally_jobs.html):
 
-| Scenarios                                    | Iterations |
-|----------------------------------------------|:----------:|
-| NeutronNetworks.create_and_delete_networks   | 40         |
-| NeutronNetworks.create_and_delete_ports      | 40         |
-| NeutronNetworks.create_and_delete_routers    | 40         |
-| NeutronNetworks.create_and_delete_subnets    | 40         |
-| NeutronNetworks.create_and_list_networks     | 100        |
-| NeutronNetworks.create_and_list_ports        | 8          |
-| NeutronNetworks.create_and_list_routers      | 40         |
-| NeutronNetworks.create_and_list_subnets      | 40         |
-| NeutronNetworks.create_and_update_networks   | 40         |
-| NeutronNetworks.create_and_update_ports      | 40         |
-| NeutronNetworks.create_and_update_routers    | 40         |
-| NeutronNetworks.create_and_update_subnets    | 100        |
-| NeutronTrunks.create_and_list_trunk_subports | 4          |
-| Quotas.neutron_update                        | 40         |
+| Scenarios                                  | Iterations |
+|--------------------------------------------|:----------:|
+| NeutronNetworks.create_and_delete_networks | 40         |
+| NeutronNetworks.create_and_delete_ports    | 40         |
+| NeutronNetworks.create_and_delete_routers  | 40         |
+| NeutronNetworks.create_and_delete_subnets  | 40         |
+| NeutronNetworks.create_and_list_networks   | 100        |
+| NeutronNetworks.create_and_list_ports      | 8          |
+| NeutronNetworks.create_and_list_routers    | 40         |
+| NeutronNetworks.create_and_list_subnets    | 40         |
+| NeutronNetworks.create_and_update_networks | 40         |
+| NeutronNetworks.create_and_update_ports    | 40         |
+| NeutronNetworks.create_and_update_routers  | 40         |
+| NeutronNetworks.create_and_update_subnets  | 100        |
+| NeutronTrunks.create_and_list_trunks       | 4          |
+| Quotas.neutron_update                      | 40         |
 
 #### 3.3.6.6 Compute - Nova
 


### PR DESCRIPTION
Neutron leverages on the upstream Rally task in Stein and newer.
Leveraging on the upstream task fill better the CNTT model.
Then it stops leveraging on specific neutron plugins and extra.

[1] https://build.opnfv.org/ci/view/functest/job/functest-hunter-daily/574/

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>
(cherry picked from commit 00f5f8b7766672c433e535e9801b16caed29531e)