### PR TITLE
[RC1][RC2] Move test case integration requirements to a common place

### DIFF
--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -25,10 +25,10 @@ runs the OPNFV gating test cases and then publishes all test results in the
 and all artifacts (reports, logs, etc.) to
 [an S3 compatible storage service](http://artifacts.opnfv.org/).
 
-The CNTT verification and conformance processes will leverage existing OPNFV
-testing knowledge (projects) and experience (history) and then will conform
-to the overall toolchain design already in-place. The RC toolchain only
-requires for the local deployment of the components instead of leveraging
+The CNTT verification, validation and conformance processes will leverage
+existing OPNFV testing knowledge (projects) and experience (history) and then
+will conform to the overall toolchain design already in-place. The RC toolchain
+only requires for the local deployment of the components instead of leveraging
 the common OPNFV centralized services. But the interfaces remain unchanged
 mainly leveraging test jobs, the common test case execution, the test
 result database and the S3 protocol to publish the artifacts. It's worth

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -37,7 +37,7 @@ mentioning that dumping all results and logs required for conformance is already
 in place in CIRV (see
 [cntt-latest-zip](https://build.opnfv.org/ci/job/cntt-latest-zip/)) and
 Functest daily jobs (see
-[functest-hunter-zip](https://build.opnfv.org/ci/job/functest-hunter-zip/3/console))
+[functest-hunter-zip](https://build.opnfv.org/ci/job/functest-hunter-zip/3/console)).
 
 It should be noted that
 [Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) supports both

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -94,7 +94,7 @@ projects:
 common test case execution proposed by Xtesting. Thanks to a simple test case
 list, this tool deploys plug-and-play
 [CI/CD toolchains in a few commands](https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004).
-In addition of this teaching capability needed by the Network Automation
+In addition, 
 it supports multiple components such as Jenkins and Gitlab CI (test
 schedulers) and
 [multiple deployment models](https://lists.opnfv.org/g/opnfv-tsc/message/5702)

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -58,7 +58,7 @@ simplify the CI toolchain setups:
   conformance)
 
 For their parts, the Docker containers simply enforce that the test cases are
-delivered with all runtime dependencies. Then it prevents lots of manual
+delivered with all runtime dependencies. This prevents lots of manual
 operations when configuring the server running the test cases and prevent
 conflicts between all test case dependencies.
 

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -63,7 +63,7 @@ conflicts between the test cases due to any dependencies.
 
 It's worth mentioning that current
 [test cases selected by CNTT](./chapter03.md)
-already leverages [Xtesting](https://xtesting.readthedocs.io/en/latest/)
+already leverage [Xtesting](https://xtesting.readthedocs.io/en/latest/)
 which is a simple framework to assemble sparse test cases and to accelerate the
 adoption of CI/CD best practices. By managing all the interactions with the
 CI/CD components (test scheduler, test results database, artifact repository),

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -26,7 +26,7 @@ test results in the
 and all artifacts (reports, logs, etc.) to
 [an S3 compatible storage service](http://artifacts.opnfv.org/).
 
-The CNTT verification and conformance processes will leverage on existing OPNFV
+The CNTT verification and conformance processes will leverage existing OPNFV
 testing knowledge (projects) and experience (history) and then will conform
 to the overall toolchain design already in-place. The RC toolchain only
 requires for the local deployment of the components instead of leveraging on

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -2,7 +2,7 @@
 
 # CNTT Reference Conformance
 
-All CNTT conformance suites fulfill to the next couple of test case integration
+All CNTT conformance suites fulfill the following test case integration
 requirements to guarantee a smooth overall integration, the same end user
 actions and a unique test result format (e.g. OPNFV test result database)
 needed by the end users and the test case result verification programs (e.g.

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -31,7 +31,7 @@ testing knowledge (projects) and experience (history) and then will conform
 to the overall toolchain design already in-place. The RC toolchain only
 requires for the local deployment of the components instead of leveraging
 the common OPNFV centralized services. But the interfaces remain unchanged
-mainly leveraging on jenkins jobs, the common test case execution, the test
+mainly leveraging jenkins jobs, the common test case execution, the test
 result database and the S3 protocol to publish the artifacts. It's worth
 mentioning that dumping all results and logs required by conformance is already
 in place in CIRV (see

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -33,7 +33,7 @@ requires for the local deployment of the components instead of leveraging
 the common OPNFV centralized services. But the interfaces remain unchanged
 mainly leveraging jenkins jobs, the common test case execution, the test
 result database and the S3 protocol to publish the artifacts. It's worth
-mentioning that dumping all results and logs required by conformance is already
+mentioning that dumping all results and logs required for conformance is already
 in place in CIRV (see
 [cntt-latest-zip](https://build.opnfv.org/ci/job/cntt-latest-zip/)) and
 Functest daily jobs (see

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -59,7 +59,7 @@ simplify the CI toolchain setups:
 For their part, the Docker containers simply enforce that the test cases are
 delivered with all runtime dependencies. This prevents lots of manual
 operations when configuring the servers running the test cases and prevents
-conflicts between all test case dependencies.
+conflicts between the test cases due to any dependencies.
 
 It's worth mentioning that current
 [test cases selected by CNTT](./chapter03.md)

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -29,7 +29,7 @@ and all artifacts (reports, logs, etc.) to
 The CNTT verification and conformance processes will leverage existing OPNFV
 testing knowledge (projects) and experience (history) and then will conform
 to the overall toolchain design already in-place. The RC toolchain only
-requires for the local deployment of the components instead of leveraging on
+requires for the local deployment of the components instead of leveraging
 the common OPNFV centralized services. But the interfaces remain unchanged
 mainly leveraging on jenkins jobs, the common test case execution, the test
 result database and the S3 protocol to publish the artifacts. It's worth

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -47,7 +47,7 @@ via Functest.
 <a name="testing-integration-requirements"></a>
 ## Test case integration requirements
 
-To reach all goals (verification, validation, compliance and conformance)
+To reach all goals (verification, validation, compliance, and conformance)
 expected by CNTT, all test cases must be delivered as
 [Docker containers](https://www.docker.com/) and meet the requirements to
 simplify the CI toolchain setups:

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -92,7 +92,7 @@ projects:
 
 [Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) leverages the
 common test case execution proposed by Xtesting. Thanks to a simple test case
-list, this tool deploys anywhere plug-and-play
+list, this tool deploys plug-and-play
 [CI/CD toolchains in a few commands](https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004).
 In addition of this teaching capability needed by the Network Automation
 it supports multiple components such as Jenkins and Gitlab CI (test

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -2,8 +2,137 @@
 
 # CNTT Reference Conformance
 
-<a name="available-cr"></a>
+All CNTT conformance suites fulfill to the next couple of test case integration
+requirements to guarantee a smooth overall integration, the same end user
+actions and a unique test result format (e.g. OPNFV test result database)
+needed by the end users and the test case result verification programs (e.g.
+[OVP](https://www.opnfv.org/verification)). Historically, these rules were
+agreed by RC1 team and have been applied since
+[CNTT Snezka](https://github.com/cntt-n/CNTT/wiki/Snezka). The new RC2 stream
+asks to move them in this common place applicable to all CNTT conformance
+suites.
 
+<a name="ri-rc-toolchaings"></a>
+## CNTT RI and RC toolchains
+
+[OPNFV](https://www.opnfv.org/) has built a complete CI/CD toolchain
+continuously deploying and testing NFVI.
+
+As for all OPNFV installer projects,
+[Jenkins](https://build.opnfv.org/ci/view/cntt/) triggers scenario deployments,
+runs the OPNFV gating test cases and then publishes all
+test results in the
+[centralized test database](https://docs.opnfv.org/en/stable-hunter/_images/OPNFV_testing_working_group.png)
+and all artifacts (reports, logs, etc.) to
+[an S3 compatible storage service](http://artifacts.opnfv.org/).
+
+The CNTT verification and conformance processes will leverage on existing OPNFV
+testing knowledge (projects) and experience (history) and then will conform
+to the overall toolchain design already in-place. The RC toolchain only
+requires for the local deployment of the components instead of leveraging on
+the common OPNFV centralized services. But the interfaces remain unchanged
+mainly leveraging on jenkins jobs, the common test case execution, the test
+result database and the S3 protocol to publish the artifacts. It's worth
+mentioning that dumping all results and logs required by conformance is already
+in place in CIRV (see
+[cntt-latest-zip](https://build.opnfv.org/ci/job/cntt-latest-zip/)) and
+Functest daily jobs (see
+[functest-hunter-zip](https://build.opnfv.org/ci/job/functest-hunter-zip/3/console))
+
+It should be noted that
+[Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) supports both
+centralized and distributed deployment models as described below. It has
+deployed the full toolchain in one small virtual machine to verify ONAP Openlab
+via Functest.
+
+<a name="testing-integration-requirements"></a>
+## Test case integration requirements
+
+To reach all goals (verification, compliance and conformance) expected by
+CNTT, all test cases must be delivered as
+[Docker containers](https://www.docker.com/) and meet the requirements to
+simplify the CI toolchain setups:
+- the common test case execution
+- the unified way to manage all the interactions with the CI/CD components and
+  with third-parties (e.g. dump all test case logs and results for
+  conformance)
+
+For their parts, the Docker containers simply enforce that the test cases are
+delivered with all runtime dependencies. Then it prevents lots of manual
+operations when configuring the server running the test cases and prevent
+conflicts between all test case dependencies.
+
+It's worth mentioning that current
+[test cases selected by CNTT](./chapter03.md)
+already leverages on [Xtesting](https://xtesting.readthedocs.io/en/latest/)
+which is a simple framework to assemble sparse test cases and to accelerate the
+adoption of CI/CD best practices. By managing all the interactions with the
+CI/CD components (test scheduler, test results database, artifact repository),
+it allows the developer to work only on the test suites without diving into
+CI/CD integration. Even more, it brings the capability to run heterogeneous
+test cases in the same CI toolchains thanks to a few low constraints
+[quickly achievable](https://www.sdxcentral.com/articles/news/opnfvs-6th-release-brings-testing-capabilities-that-orange-is-already-using/2018/05/).
+
+Following the design in use, the Docker containers proposed by the test
+projects must also embed
+[the Xtesting Python package](https://pypi.org/project/xtesting/) and
+[the related test case execution description files](https://git.opnfv.org/functest-xtesting/tree/docker/testcases.yaml)
+as required by Xtesting.
+
+Here are the issues tracking the updates of the existing OPNFV test
+projects:
+- Bottlenecks: https://github.com/cntt-n/CNTT/issues/510
+- NFVBench: https://github.com/cntt-n/CNTT/issues/865
+- StorPerf: https://github.com/cntt-n/CNTT/issues/673
+- VSPERF: https://github.com/cntt-n/CNTT/issues/511
+- YardStick: https://github.com/cntt-n/CNTT/issues/509
+
+<a name="testing-cookbooks"></a>
+## Testing Cookbooks
+
+[Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) leverages on the
+common test case execution proposed by Xtesting. Thanks to a simple test case
+list, this tool deploys anywhere plug-and-play
+[CI/CD toolchains in a few commands](https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004).
+In addition of this teaching capability needed by the Network Automation
+journey, it supports multiple components such as Jenkins and Gitlab CI (test
+schedulers) and
+[multiple deployment models](https://lists.opnfv.org/g/opnfv-tsc/message/5702)
+such as all-in-one or centralized services.
+
+[Xtesting](https://xtesting.readthedocs.io/en/latest/) and
+[Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) combined meet the
+CNTT requirements about verification, compliance and conformance:
+- smoothly assemble multiple heterogeneous test cases
+- generate the Jenkins jobs in
+  [OPNFV Releng](https://git.opnfv.org/releng/tree/jjb/airship/cntt.yaml) to
+  verify CNTT RI
+- deploy local CI/CD toolchains everywhere to check compliance with CNTT
+- [dump all test case results and logs](http://artifacts.opnfv.org/functest/9ID39XK47PMZ.zip)
+  for third-party conformance review
+
+Here are a couple of playbooks publically available:
+- [Xtesting samples](https://git.opnfv.org/functest-xtesting/plain/ansible/site.yml?h=stable/kali)
+- [OpenStack verification](https://git.opnfv.org/functest/plain/ansible/site.yml?h=stable/kali)
+- [CNTT RC1](https://git.opnfv.org/functest/plain/ansible/site.cntt.yml?h=stable/hunter)
+- [Kubernetes verification](https://git.opnfv.org/functest-kubernetes/plain/ansible/site.yml?h=stable/kali)
+
+[Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) only requires
+GNU/Linux as Operating System and asks for a few dependencies as described in
+[Deploy your own Xtesting CI/CD toolchains](https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004):
+- python-virtualenv
+- docker.io
+- git
+
+Please note the next two points depending on the GNU/Linux distributions and
+the network settings:
+- SELinux: you may have to add -\-system-site-packages when creating the
+  virtualenv ("Aborting, target uses selinux but python bindings
+  (libselinux-python) aren't installed!")
+- Proxy: you may set your proxy in env for Ansible and in systemd for Docker
+  https://docs.docker.com/config/daemon/systemd/#httphttps-proxy
+
+<a name="available-cr"></a>
 ## Available Programs
 * [RC1 - LFN Based](lfn)
 * [RC2 - Kubernetes Based](RC2)

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -70,7 +70,7 @@ adoption of CI/CD best practices. By managing all the interactions with the
 CI/CD components (test scheduler, test results database, artifact repository),
 it allows the developer to work only on the test suites without diving into
 CI/CD integration. Even more, it brings the capability to run heterogeneous
-test cases in the same CI toolchains thanks to a few low constraints
+test cases in the same CI toolchains thanks to a few, [quickly achievable](https://www.sdxcentral.com/articles/news/opnfvs-6th-release-brings-testing-capabilities-that-orange-is-already-using/2018/05/), constraints.
 [quickly achievable](https://www.sdxcentral.com/articles/news/opnfvs-6th-release-brings-testing-capabilities-that-orange-is-already-using/2018/05/).
 
 Following the design in use, the Docker containers proposed by the test

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -57,7 +57,7 @@ simplify the CI toolchain setups:
   with third-parties (e.g. dump all test case logs and results for
   conformance)
 
-For their parts, the Docker containers simply enforce that the test cases are
+For their part, the Docker containers simply enforce that the test cases are
 delivered with all runtime dependencies. This prevents lots of manual
 operations when configuring the servers running the test cases and prevents
 conflicts between all test case dependencies.

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -1,6 +1,6 @@
 [<< Back](../)
 
-# CNTT Reference Conformance
+# CNTT Reference Conformance (RC) Test Case Integration
 
 All CNTT conformance suites fulfill the following test case integration
 requirements to guarantee a smooth overall integration, the same end user

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -100,7 +100,7 @@ such as all-in-one or centralized services.
 
 [Xtesting](https://xtesting.readthedocs.io/en/latest/) and
 [Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) combined meet the
-CNTT requirements about verification, validation, compliance and conformance:
+CNTT requirements about verification, validation, compliance, and conformance:
 - smoothly assemble multiple heterogeneous test cases
 - generate the Jenkins jobs in
   [OPNFV Releng](https://git.opnfv.org/releng/tree/jjb/airship/cntt.yaml) to

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -2,7 +2,7 @@
 
 # CNTT Reference Conformance (RC) Test Case Integration
 
-All CNTT conformance suites fulfill the following test case integration
+All CNTT conformance suites must fulfill the following test case integration
 requirements to guarantee a smooth overall integration, the same end user
 actions and a unique test result format (e.g. OPNFV test result database)
 needed by the end users and the test case result verification programs (e.g.

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -111,7 +111,7 @@ CNTT requirements about verification, validation, compliance and conformance:
 - [dump all test case results and logs](http://artifacts.opnfv.org/functest/9ID39XK47PMZ.zip)
   for third-party conformance review
 
-Here are a couple of playbooks publically available:
+Here are a couple of publicly available playbooks :
 - [Xtesting samples](https://git.opnfv.org/functest-xtesting/plain/ansible/site.yml?h=stable/kali)
 - [OpenStack verification](https://git.opnfv.org/functest/plain/ansible/site.yml?h=stable/kali)
 - [CNTT RC1](https://git.opnfv.org/functest/plain/ansible/site.cntt.yml?h=stable/hunter)

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -90,7 +90,7 @@ projects:
 <a name="testing-cookbooks"></a>
 ## Testing Cookbooks
 
-[Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) leverages on the
+[Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) leverages the
 common test case execution proposed by Xtesting. Thanks to a simple test case
 list, this tool deploys anywhere plug-and-play
 [CI/CD toolchains in a few commands](https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004).

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -20,8 +20,7 @@ for continuously deploying and testing cloud infrastructure.
 
 As for all OPNFV installer projects,
 [Jenkins](https://build.opnfv.org/ci/view/cntt/) triggers scenario deployments,
-runs the OPNFV gating test cases and then publishes all
-test results in the
+runs the OPNFV gating test cases and then publishes all test results in the
 [centralized test database](https://docs.opnfv.org/en/stable-hunter/_images/OPNFV_testing_working_group.png)
 and all artifacts (reports, logs, etc.) to
 [an S3 compatible storage service](http://artifacts.opnfv.org/).
@@ -31,25 +30,25 @@ testing knowledge (projects) and experience (history) and then will conform
 to the overall toolchain design already in-place. The RC toolchain only
 requires for the local deployment of the components instead of leveraging
 the common OPNFV centralized services. But the interfaces remain unchanged
-mainly leveraging jenkins jobs, the common test case execution, the test
+mainly leveraging test jobs, the common test case execution, the test
 result database and the S3 protocol to publish the artifacts. It's worth
-mentioning that dumping all results and logs required for conformance is already
-in place in CIRV (see
+mentioning that dumping all results and logs required for conformance is
+already in place in CIRV (see
 [cntt-latest-zip](https://build.opnfv.org/ci/job/cntt-latest-zip/)) and
 Functest daily jobs (see
 [functest-hunter-zip](https://build.opnfv.org/ci/job/functest-hunter-zip/3/console)).
 
 It should be noted that
 [Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) supports both
-centralized and distributed deployment models as described below. It has
+centralized and distributed deployment models as described before. It has
 deployed the full toolchain in one small virtual machine to verify ONAP Openlab
 via Functest.
 
 <a name="testing-integration-requirements"></a>
 ## Test case integration requirements
 
-To reach all goals (verification, validation, compliance and conformance) expected by
-CNTT, all test cases must be delivered as
+To reach all goals (verification, validation, compliance and conformance)
+expected by CNTT, all test cases must be delivered as
 [Docker containers](https://www.docker.com/) and meet the requirements to
 simplify the CI toolchain setups:
 - the common test case execution
@@ -70,11 +69,11 @@ adoption of CI/CD best practices. By managing all the interactions with the
 CI/CD components (test scheduler, test results database, artifact repository),
 it allows the developer to work only on the test suites without diving into
 CI/CD integration. Even more, it brings the capability to run heterogeneous
-test cases in the same CI toolchains thanks to a few, [quickly achievable](https://www.sdxcentral.com/articles/news/opnfvs-6th-release-brings-testing-capabilities-that-orange-is-already-using/2018/05/), constraints.
-[quickly achievable](https://www.sdxcentral.com/articles/news/opnfvs-6th-release-brings-testing-capabilities-that-orange-is-already-using/2018/05/).
+test cases in the same CI toolchains thanks to a few,
+[quickly achievable](https://www.sdxcentral.com/articles/news/opnfvs-6th-release-brings-testing-capabilities-that-orange-is-already-using/2018/05/),
+constraints.
 
-Following the design in use, the Docker containers proposed by the test
-projects must also embed
+The Docker containers proposed by the test projects must also embed
 [the Xtesting Python package](https://pypi.org/project/xtesting/) and
 [the related test case execution description files](https://git.opnfv.org/functest-xtesting/tree/docker/testcases.yaml)
 as required by Xtesting.
@@ -94,9 +93,8 @@ projects:
 common test case execution proposed by Xtesting. Thanks to a simple test case
 list, this tool deploys plug-and-play
 [CI/CD toolchains in a few commands](https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004).
-In addition, 
-it supports multiple components such as Jenkins and Gitlab CI (test
-schedulers) and
+In addition, it supports multiple components such as Jenkins and Gitlab CI
+(test schedulers) and
 [multiple deployment models](https://lists.opnfv.org/g/opnfv-tsc/message/5702)
 such as all-in-one or centralized services.
 

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -102,7 +102,7 @@ such as all-in-one or centralized services.
 
 [Xtesting](https://xtesting.readthedocs.io/en/latest/) and
 [Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) combined meet the
-CNTT requirements about verification, compliance and conformance:
+CNTT requirements about verification, validation, compliance and conformance:
 - smoothly assemble multiple heterogeneous test cases
 - generate the Jenkins jobs in
   [OPNFV Releng](https://git.opnfv.org/releng/tree/jjb/airship/cntt.yaml) to

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -25,9 +25,9 @@ runs the OPNFV gating test cases and then publishes all test results in the
 and all artifacts (reports, logs, etc.) to
 [an S3 compatible storage service](http://artifacts.opnfv.org/).
 
-The CNTT verification, validation, and conformance processes will leverage
+The CNTT verification, validation, and conformance processes leverage
 existing OPNFV testing knowledge (projects) and experience (history) and then
-will conform to the overall toolchain design already in-place. The RC toolchain
+conform to the overall toolchain design already in-place. The RC toolchain
 only requires for the local deployment of the components instead of leveraging
 the common OPNFV centralized services. But the interfaces remain unchanged
 mainly leveraging test jobs, the common test case execution, the test

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -95,7 +95,7 @@ common test case execution proposed by Xtesting. Thanks to a simple test case
 list, this tool deploys anywhere plug-and-play
 [CI/CD toolchains in a few commands](https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004).
 In addition of this teaching capability needed by the Network Automation
-journey, it supports multiple components such as Jenkins and Gitlab CI (test
+it supports multiple components such as Jenkins and Gitlab CI (test
 schedulers) and
 [multiple deployment models](https://lists.opnfv.org/g/opnfv-tsc/message/5702)
 such as all-in-one or centralized services.

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -16,7 +16,7 @@ suites.
 ## CNTT RI and RC toolchains
 
 [OPNFV](https://www.opnfv.org/) has built a complete CI/CD toolchain
-continuously deploying and testing NFVI.
+for continuously deploying and testing cloud infrastructure.
 
 As for all OPNFV installer projects,
 [Jenkins](https://build.opnfv.org/ci/view/cntt/) triggers scenario deployments,

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -48,7 +48,7 @@ via Functest.
 <a name="testing-integration-requirements"></a>
 ## Test case integration requirements
 
-To reach all goals (verification, compliance and conformance) expected by
+To reach all goals (verification, validation, compliance and conformance) expected by
 CNTT, all test cases must be delivered as
 [Docker containers](https://www.docker.com/) and meet the requirements to
 simplify the CI toolchain setups:

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -64,7 +64,7 @@ conflicts between all test case dependencies.
 
 It's worth mentioning that current
 [test cases selected by CNTT](./chapter03.md)
-already leverages on [Xtesting](https://xtesting.readthedocs.io/en/latest/)
+already leverages [Xtesting](https://xtesting.readthedocs.io/en/latest/)
 which is a simple framework to assemble sparse test cases and to accelerate the
 adoption of CI/CD best practices. By managing all the interactions with the
 CI/CD components (test scheduler, test results database, artifact repository),

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -59,7 +59,7 @@ simplify the CI toolchain setups:
 
 For their parts, the Docker containers simply enforce that the test cases are
 delivered with all runtime dependencies. This prevents lots of manual
-operations when configuring the server running the test cases and prevent
+operations when configuring the servers running the test cases and prevents
 conflicts between all test case dependencies.
 
 It's worth mentioning that current

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -25,7 +25,7 @@ runs the OPNFV gating test cases and then publishes all test results in the
 and all artifacts (reports, logs, etc.) to
 [an S3 compatible storage service](http://artifacts.opnfv.org/).
 
-The CNTT verification, validation and conformance processes will leverage
+The CNTT verification, validation, and conformance processes will leverage
 existing OPNFV testing knowledge (projects) and experience (history) and then
 will conform to the overall toolchain design already in-place. The RC toolchain
 only requires for the local deployment of the components instead of leveraging

--- a/doc/ref_cert/lfn/chapters/chapter02.md
+++ b/doc/ref_cert/lfn/chapters/chapter02.md
@@ -5,7 +5,6 @@
 
 ## Table of Contents
 * [2.1 Introduction](#2.1)
-  * [2.1.1 RI and RC CI/CD toolchains](#2.1.1)
 * [2.2 Methodology](#2.2)
 * [2.3 Conformance Strategy & Vehicle](#2.3)
 * [2.4 Profiles Reference](#2.4)
@@ -13,12 +12,11 @@
 * [2.6 Entry & Exit Criteria](#2.6)
 * [2.7 Framework Requirements](#2.7)
   * [2.7.1 Best Practices (General)](#2.7.1)
-  * [2.7.2 Test case integration requirements](#2.7.2)
-  * [2.7.3 Testing](#2.7.3)
-    * [2.7.3.1 Test Categories](#2.7.3.1)
-    * [2.7.3.2 Test Harnessess](#2.7.3.2)
-    * [2.7.3.3 Test Results](#2.7.3.3)
-  * [2.7.4 Badging](#2.7.4)
+  * [2.7.2 Testing](#2.7.2)
+    * [2.7.2.1 Test Categories](#2.7.2.1)
+    * [2.7.2.2 Test Harnessess](#2.7.2.2)
+    * [2.7.2.3 Test Results](#2.7.2.3)
+  * [2.7.3 Badging](#2.7.3)
 * [2.8 NFVI Test Cases Requirements](#2.7)
   * [2.8.1 Generic Requirements](#2.8.1)
   * [2.8.2 Requirement Types](#2.8.2)
@@ -48,39 +46,6 @@ NFVI (Network Functions Virtualization Infrastructure) refers to the physical an
 In the meantime, CNTT RC also provides conformance test for VNF. The intention is to make sure VNF that passes RC test cases can be deployed on any NFVI which also passes RC without any conformance and interoperability issue.
 <!---As such, the performance of a VNF depends on the underlying NFVI over which it is hosted. A certain VNF may perform good in one hardware and may perform worst in another. Thus, a need arises to certify NFVI that can help in onboarding VNFs onto a hardware with an acceptable level of VNF performance. Certain frameworks like [yardstick](https://github.com/opnfv/yardstick), [vsperf](https://github.com/opnfv/vswitchperf) etc. provide a set of tests that can be run on a hardware to obtain Key Performance Indicators (KPIs) which give a measurable output of the NFVI's performance. With these KPIs, a decision can be made on the VNFs that can offer an acceptable level of performance when on-boarded on the NFVI.--->
 
-<a name="2.1.1"></a>
-### 2.1.1 CNTT RI and RC toolchains
-
-[OPNFV](https://www.opnfv.org/) has built a complete CI/CD toolchain
-continuously deploying and testing NFVI.
-
-As for all OPNFV installer projects,
-[Jenkins](https://build.opnfv.org/ci/view/cntt/) triggers scenario deployments,
-runs the OPNFV gating test cases and then publishes all
-test results in the
-[centralized test database](https://docs.opnfv.org/en/stable-hunter/_images/OPNFV_testing_working_group.png)
-and all artifacts (reports, logs, etc.) to
-[an S3 compatible storage service](http://artifacts.opnfv.org/).
-
-The CNTT compliance and conformance processes will leverage on existing OPNFV
-testing knowledge (projects) and experience (history) and then will conform
-to the overall toolchain design already in-place. The RC toolchain only
-requires for the local deployment of the components instead of leveraging on
-the common OPNFV centralized services. But the interfaces remain unchanged
-mainly leveraging on jenkins jobs, the common test case execution, the test
-result DB and the S3 protocol to publish the artifacts. It's worth mentioning
-that dumping all results and logs required by conformance is already in place
-in CIRV (see
-[cntt-latest-zip](https://build.opnfv.org/ci/job/cntt-latest-zip/)) and
-Functest daily jobs (see
-[functest-hunter-zip](https://build.opnfv.org/ci/job/functest-hunter-zip/3/console))
-
-It should be noted that
-[Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) supports both
-centralized and distributed deployment models as described below. It has
-deployed the full toolchain in one small virtual machine to verify ONAP Openlab
-via Functest.
-
 <a name="2.2"></a>
 ## 2.2 Methodology
 The NFVI is consumed or used by VNFs via APIs exposed by Virtualised Infrastructure Manager (VIM). The resources created by VIM on the NFVI use the underlying physical hardware (compute, storage and network) either directly or indirectly. CNTT recommends RA1 to be used as a reference architecture for NFVI conformance. This  would provide a set of standard interfaces to create resources on NFVI. Below step by step process illustrates the NFVI conformance methodology:
@@ -91,7 +56,7 @@ The NFVI is consumed or used by VNFs via APIs exposed by Virtualised Infrastruct
 * KPIs obtained from the SUT are collected and submitted to conformance portal.
 * The SUT KPIs are reviewed and compared with Golden KPIs to determine if the conformance badge is to be provided to SUT or not.
 
-Based on a NFVI passing RC test and getting the conformance badge, VNF conformance test can be further conducted. Such test will leverage existing OPNFV Intake Process. Upstream projects will define features/capabilities, test scenarios, and test cases to augment existing OVP test harnesses to be executed via the OVP Ecosystem. 
+Based on a NFVI passing RC test and getting the conformance badge, VNF conformance test can be further conducted. Such test will leverage existing OPNFV Intake Process. Upstream projects will define features/capabilities, test scenarios, and test cases to augment existing OVP test harnesses to be executed via the OVP Ecosystem.
 
 <p align="center"><img src="../figures/RC_CertificationMethodology.jpg" alt="conformance Methodology" title="Conformance Methodology" width="100%"/></p>
 <p align="center"><b>Figure 2-1:</b> Conformance Methodology</p>
@@ -223,53 +188,11 @@ The NFVI Conformance framework will be guided by the following core principles:
 -   Add test cases from operators, which operators already tested in their environment
 
 <a name="2.7.2"></a>
-### 2.7.2 Test case integration requirements
-
-To reach all goals (verification, compliance and Conformance) expected by
-CNTT, all test cases must be delivered as
-[Docker containers](https://www.docker.com/) and meet the requirements to
-simplify the CI toolchain setups:
-- the common test case execution
-- the unified way to manage all the interactions with the CI/CD components and
-  with third-parties (e.g. dump all test case logs and results for
-  Conformance)
-
-For their parts, the Docker containers simply enforce that the test cases are
-delivered with all runtime dependencies. Then it prevents lots of manual
-operations when configuring the server running the test cases and prevent
-conflicts between all test case dependencies.
-
-It's worth mentioning that current
-[test cases selected by CNTT](./chapter03.md)
-already leverages on [Xtesting](https://xtesting.readthedocs.io/en/latest/)
-which is a simple framework to assemble sparse test cases and to accelerate the
-adoption of CI/CD best practices. By managing all the interactions with the
-CI/CD components (test scheduler, test results database, artifact repository),
-it allows the developer to work only on the test suites without diving into
-CI/CD integration. Even more, it brings the capability to run heterogeneous
-test cases in the same CI toolchains thanks to a few low constraints
-[quickly achievable](https://www.sdxcentral.com/articles/news/opnfvs-6th-release-brings-testing-capabilities-that-orange-is-already-using/2018/05/).
-
-Following the design in use, the Docker containers proposed by the test
-projects must also embed
-[the Xtesting Python package](https://pypi.org/project/xtesting/) and
-[the related test case execution description files](https://git.opnfv.org/functest-xtesting/tree/docker/testcases.yaml)
-as required by Xtesting.
-
-Here are the issues tracking the updates of the existing OPNFV test
-projects:
-- Bottlenecks: https://github.com/cntt-n/CNTT/issues/510
-- NFVBench: https://github.com/cntt-n/CNTT/issues/865
-- StorPerf: https://github.com/cntt-n/CNTT/issues/673
-- VSPERF: https://github.com/cntt-n/CNTT/issues/511
-- YardStick: https://github.com/cntt-n/CNTT/issues/509
-
-<a name="2.7.3"></a>
-### 2.7.3 Testing
+### 2.7.2 Testing
 Testing for NFVI Conformance falls under three broad categories - Compliance, Validation and Performance. Target NFVI for Conformance needs to pass all these tests in order to obtain the Conformance badge.
 
-<a name="2.7.3.1"></a>
-#### 2.7.3.1 Test Categories
+<a name="2.7.2.1"></a>
+#### 2.7.2.1 Test Categories
 The following five test categories have been identified as **minimal testing required** to verify NFVI interoperability to satisfy the needs of VNF developer teams.
  1. Baremetal validation: To validate control and compute nodes hardware
  2. VNF Interoperability: After VNFs are on-boarded, Openstack resources like Tenant, Network (L2/L3), CPU Pining, security policies, Affinity anti-affinity roles and flavors etc. would be validated.
@@ -292,8 +215,8 @@ The following **Optional Test Categories** which can be considered by the Operat
  - Fault Recovery Testing
  - PM/KPI/Service Assurance Testing
 
-<a name="2.7.3.2"></a>
-#### 2.7.3.2 Test Harnesses
+<a name="2.7.2.2"></a>
+#### 2.7.2.2 Test Harnesses
 In addition to General Best Practices for NFVI Conformance, the following Quality Engineering (QE) standards will be applied when defining and delivering test scenarios for Conformance:  
 1.  Standardized test methodologies / flows capturing requirements from RA's, goals and scenarios for test execution, and normalizing test results.
 2.  Establishing, and leveraging, working test-beds which can be referenced in subsequent test scenario designs.  
@@ -303,8 +226,8 @@ In addition to General Best Practices for NFVI Conformance, the following Qualit
 6.  Documentation needs to be dynamic, and consumable.
 7.  Harnesses need to apply a “Just add Water” deployment strategy, enabling test teams to readily implement test harnesses which promotes Conformance scalability.
 
-<a name="2.7.3.3"></a>
-#### 2.7.3.3 Test Results
+<a name="2.7.2.3"></a>
+#### 2.7.2.3 Test Results
 
 **Categorization**.  Test suites will be categorized as Functional or Performance based.  
 
@@ -325,8 +248,8 @@ In addition to General Best Practices for NFVI Conformance, the following Qualit
  - Summarized conclusion if conditions warrant test Conformance (see Badging Section).
  - Portal contains links to Conformance badge(s) received.
 
-<a name="2.7.4"></a>
-### 2.7.4 Badging
+<a name="2.7.3"></a>
+### 2.7.3 Badging
 **Defined**.  _Badging_ refers to the granting of a Conformance badge by the OVP to Suppliers/Testers of CNTT NFVI upon demonstration the testing performed confirms:
 
  - NFVI adheres to CNTT RA/RM requirements.
@@ -672,4 +595,3 @@ Main OPNFV test tool candidate: Yardstick (TC014)
 
 <a name="2.8.7.2"></a>
 #### 2.8.7.2 Resiliency Measurements
-

--- a/doc/ref_cert/lfn/chapters/chapter04.md
+++ b/doc/ref_cert/lfn/chapters/chapter04.md
@@ -187,38 +187,10 @@ SDF's will contain, but not limited to, the following Metadata, Components, Depl
 <a name="4.3"></a>
 ## 4.3 NFVI Testing Cookbook
 
-> using existing testing framework, proposal of an E2E integrated one to be used fir NFVI testing.
-
-<p align="center"><img src="../figures/rc1_cookbook_nfvi.png" alt="nfvi_cookbook" title="NFVI Cookbook" width="60%"/></p>
-<p align="center"><b>Figure 1-2:</b> NFVI Testing Integrated Framework.</p>
-
-[Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) leverages on the
-common test case execution proposed by Xtesting. Thanks to a simple test case
-list, this tool deploys anywhere plug-and-play
-[CI/CD toolchains in a few commands](https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004).
-In addition of this teaching capability needed by the Network Automation
-journey, it supports multiple components such as Jenkins and Gitlab CI (test
-schedulers) and
-[multiple deployment models](https://lists.opnfv.org/g/opnfv-tsc/message/5702)
-such as all-in-one or centralized services.
-
-[Xtesting](https://xtesting.readthedocs.io/en/latest/) and
-[Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) combined meet the
-CNTT requirements about verification, compliance and Conformance:
-- smoothly assemble multiple heterogeneous test cases
-- generate the Jenkins jobs in
-  [OPNFV Releng](https://git.opnfv.org/releng/tree/jjb/airship/cntt.yaml) to
-  verify CNTT RI
-- deploy local CI/CD toolchains everywhere to check compliance with CNTT
-- [dump all test case results and logs](http://artifacts.opnfv.org/functest/9ID39XK47PMZ.zip)
-  for third-party Conformance review
-
-[Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) only requires
-GNU/Linux as Operating System and asks for a few dependencies as described in
-[Deploy your own Xtesting CI/CD toolchains](https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004):
-- python-virtualenv
-- docker.io
-- git
+At the time of writing, the CI description file is hosted in Functest and only
+runs the containers listed in RM/RA-1 Requirements. It will be completed by the
+next CNTT mandatory test cases and then a new CI description file will be
+proposed in CIRV tree.
 
 Please note the next two points depending on the GNU/Linux distributions and
 the network settings:
@@ -227,11 +199,6 @@ the network settings:
   (libselinux-python) aren't installed!")
 - Proxy: you may set your proxy in env for Ansible and in systemd for Docker
   https://docs.docker.com/config/daemon/systemd/#httphttps-proxy
-
-At the time of writing, the CI description file is hosted in Functest and only
-runs the containers listed in RM/RA-1 Requirements. It will be completed by the
-next CNTT mandatory test cases and then a new CI description file will be
-proposed in CIRV tree.
 
 To deploy your own CI toolchain running CNTT Compliance:
 ```bash


### PR DESCRIPTION
All CNTT conformance suites fulfill to the next couple of test case integration
requirements to guarantee a smooth overall integration, the same end user
actions and a unique test result format (e.g. OPNFV test database) needed by
the end users and the test case result verification programs (e.g.
[OVP](https://www.opnfv.org/verification)). Historically, these rules were
agreed by RC1 team and have been applied since
[CNTT Snezka](https://github.com/cntt-n/CNTT/wiki/Snezka). The new RC2 stream
asks to move them in this common place applicable to all CNTT conformance
suites.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>