### PR TITLE
[RM Ch07] Securiry requirements: tables modifs

### DIFF
--- a/doc/ref_model/chapters/chapter07.md
+++ b/doc/ref_model/chapters/chapter07.md
@@ -487,143 +487,143 @@ Table 7-2 shows security capabilities
 <a name="7.11.1"></a>
 ### 7.11.1. System Hardening
 
-|  Ref | Requirement  |  Unit  | Definition  |
-|-------|------|------|-------|
-| sec.gen.001 | The Platform **must** maintain the state to what it is specified to be and does not change unless through change management process. |   |  |
-| sec.gen.002 | All systems part of Cloud Infrastructure **must** support password hardening (strength and rules for updates (process), storage and transmission, etc.) |  | Hardening: NIST SP 800-63B |
-| sec.gen.003 | All servers part of Cloud Infrastructure **must** support a root of trust and secure boot |  |  |
-| sec.gen.004 | The Operating Systems of all the servers part of Cloud Infrastructure **must** be hardened |  | NIST SP 800-123 |
-| sec.gen.005 | The Platform **must** support Operating System level access control |  | Details on OS |
-| sec.gen.006 | The Platform **must** support Secure logging |  | Details |
-| sec.gen.007 | All servers part of Cloud Infrastructure **must** be Time synchronized with authenticated Time service |  | |
-| sec.gen.008 | All servers part of Cloud Infrastructure **must** be regularly updated to address security vulnerabilities |  | |
-| sec.gen.009 | The Platform **must** support Software integrity protection and verification |  | |
-| sec.gen.010 | The Cloud Infrastructure **must** support Secure storage (all types) |  | Expand/Delete based on other requirements |
-| sec.gen.011 | The Cloud Infrastructure **should** support Read and Write only storage partitions (write only permission to one or more authorized actors) |  | |
-| sec.gen.012 | The Operator **must** ensure that only authorized actors have physical access to the underlying infrastructure. |  | |
-| sec.gen.013 | The Platform **must** ensure that only authorized actors have logical access to the underlying infrastructure. |  | |
-| sec.gen.014 | All servers part of Cloud Infrastructure **should** support measured boot and an attestation server that monitors the measurements of the servers. |  | |
+|  Ref | Requirement  | Definition/Note  |
+|-------|------|-------|
+| req.sec.gen.001 | The Platform **must** maintain the state to what it is specified to be and does not change unless through change management process |  |
+| req.sec.gen.002 | All systems part of Cloud Infrastructure **must** support password hardening (strength and rules for updates (process), storage and transmission, etc.) | Hardening: NIST SP 800-63B |
+| req.sec.gen.003 | All servers part of Cloud Infrastructure **must** support a root of trust and secure boot |  |
+| req.sec.gen.004 | The Operating Systems of all the servers part of Cloud Infrastructure **must** be hardened | NIST SP 800-123 |
+| req.sec.gen.005 | The Platform **must** support Operating System level access control | Details on OS |
+| req.sec.gen.006 | The Platform **must** support Secure logging | Details |
+| req.sec.gen.007 | All servers part of Cloud Infrastructure **must** be Time synchronized with authenticated Time service | |
+| req.sec.gen.008 | All servers part of Cloud Infrastructure **must** be regularly updated to address security vulnerabilities | |
+| req.sec.gen.009 | The Platform **must** support Software integrity protection and verification | |
+| req.sec.gen.010 | The Cloud Infrastructure **must** support Secure storage (all types) | Expand/Delete based on other requirements |
+| req.sec.gen.011 | The Cloud Infrastructure **should** support Read and Write only storage partitions (write only permission to one or more authorized actors) | |
+| req.sec.gen.012 | The Operator **must** ensure that only authorized actors have physical access to the underlying infrastructure | |
+| req.sec.gen.013 | The Platform **must** ensure that only authorized actors have logical access to the underlying infrastructure | |
+| req.sec.gen.014 | All servers part of Cloud Infrastructure **should** support measured boot and an attestation server that monitors the measurements of the servers | |
 
 <a name="7.11.21"></a>
 ###  7.11.2. Platform and Access
 
-Ref | Requirement | Unit | Definition |
-|-------|-------|-------|---------|
-| sec.sys.001 | The Platform **must** support authenticated and secure APIs, API endpoints |  | |
-| | The Platform **must** implement authenticated and secure access to GUI |  | |
-| sec.sys.002 | The Platform **must** support Traffic Filtering for workloads (for example, Fire Wall) |  | |
-| sec.sys.003 | The Platform **must** support Secure and encrypted communications, and confidentiality and integrity of network traffic |  | |
-| sec.sys.004 | The Cloud Infrastructure **must** support Secure network channels |  | A secure channel enables transferring of data that is resistant to overhearing and tampering |
-| sec.sys.005 | The Cloud Infrastructure **must** segregate the underlay and overlay networks |  | |
-| sec.sys.006 | The Cloud Infrastructure must be able to utilize the Cloud Infrastructure Manager identity management capabilities |  | |
-| sec.sys.007 | The Platform **must** implement controls enforcing separation of duties and privileges, least privilege use and least common mechanism (Role-Based Access Control) |  | |
-| sec.sys.008 | The Platform **must** be able to assign the Entities that comprise the tenant networks to different trust domains. |  | Communication between different trust domains is not allowed, by default.  |
-| sec.sys.009 | The Platform **must** support creation of Trust Relationships between trust domains |  | These maybe uni-directional relationships where the trusting domain trusts anther domain (the “trusted domain”) to authenticate users for them or to allow access to its resources from the trusted domain.  In a bidirectional relationship both domain are “trusting” and “trusted” |
-| sec.sys.010 | For two or more domains without existing trust relationships, the Platform **must not** allow the effect of an attack on one domain to impact the other domains either directly or indirectly |  | |
-| sec.sys.011 | The Platform **must not** reuse the same authentication key-pair (for example, on different hosts, for different services) |  | |
-| sec.sys.012 | The Platform **must** only use secrets encrypted using strong encryption techniques, and stored externally from the component |  | e.g., Barbican (OpenStack) |
-| sec.sys.013 | The Platform **must** provide secrets dynamically as and when needed |  | |
+Ref | Requirement | Definition/Note |
+|-------|-------|---------|
+| req.sec.sys.001 | The Platform **must** support authenticated and secure APIs, API endpoints | |
+| | The Platform **must** implement authenticated and secure access to GUI | |
+| req.sec.sys.002 | The Platform **must** support Traffic Filtering for workloads (for example, Fire Wall) | |
+| req.sec.sys.003 | The Platform **must** support Secure and encrypted communications, and confidentiality and integrity of network traffic | |
+| req.sec.sys.004 | The Cloud Infrastructure **must** support Secure network channels | A secure channel enables transferring of data that is resistant to overhearing and tampering |
+| req.sec.sys.005 | The Cloud Infrastructure **must** segregate the underlay and overlay networks | |
+| req.sec.sys.006 | The Cloud Infrastructure must be able to utilize the Cloud Infrastructure Manager identity management capabilities | |
+| req.sec.sys.007 | The Platform **must** implement controls enforcing separation of duties and privileges, least privilege use and least common mechanism (Role-Based Access Control) | |
+| req.sec.sys.008 | The Platform **must** be able to assign the Entities that comprise the tenant networks to different trust domains. | Communication between different trust domains is not allowed, by default  |
+| req.sec.sys.009 | The Platform **must** support creation of Trust Relationships between trust domains | These maybe uni-directional relationships where the trusting domain trusts anther domain (the “trusted domain”) to authenticate users for them or to allow access to its resources from the trusted domain.  In a bidirectional relationship both domain are “trusting” and “trusted” |
+| req.sec.sys.010 | For two or more domains without existing trust relationships, the Platform **must not** allow the effect of an attack on one domain to impact the other domains either directly or indirectly | |
+| req.sec.sys.011 | The Platform **must not** reuse the same authentication key-pair (for example, on different hosts, for different services) | |
+| req.sec.sys.012 | The Platform **must** only use secrets encrypted using strong encryption techniques, and stored externally from the component | e.g., Barbican (OpenStack) |
+| req.sec.sys.013 | The Platform **must** provide secrets dynamically as and when needed | |
 
 <a name="7.11.3"></a>
 ### 7.11.3. Confidentiality and Integrity
 
-| Ref | Requirement | Unit | Definition |
-|---|----|---|----|
-| sec.ci.001 | The Platform **must** support Confidentiality and Integrity of data at rest and in-transit |  | |
-| sec.ci.002 | The Platform **should** support self-encrypting storage devices |  | |
-| sec.ci.003 | The Platform **must** support Confidentiality and Integrity of data related metadata |  | |
-| sec.ci.004 | The Platform **must** support Confidentiality of processes and restrict information sharing with only the process owner (e.g., tenant). |  | |
-| sec.ci.005 | The Platform **must** support Confidentiality and Integrity of process-related metadata and restrict information sharing with only the process owner (e.g., tenant). |  | |
-| sec.ci.006 | The Platform **must** support Confidentiality and Integrity of workload resource utilization (RAM, CPU, Storage, Network I/O, cache, hardware offload) and restrict information sharing with only the workload owner (e.g., tenant). |  | |
-| sec.ci.007 | The Platform **must not** allow Memory Inspection by any actor other than the authorized actors for the Entity to which Memory is assigned (e.g., tenants owning the workload), for Lawful Inspection, and by secure monitoring services |  | Admin access must be carefully regulated |
-| sec.ci.008 | The Cloud Infrastructure **must** support tenant networks segregation |  | |
+| Ref | Requirement | Definition/Note |
+|---|----|----|
+| req.sec.ci.001 | The Platform **must** support Confidentiality and Integrity of data at rest and in-transit | |
+| req.sec.ci.002 | The Platform **should** support self-encrypting storage devices | |
+| req.sec.ci.003 | The Platform **must** support Confidentiality and Integrity of data related metadata | |
+| req.sec.ci.004 | The Platform **must** support Confidentiality of processes and restrict information sharing with only the process owner (e.g., tenant) | |
+| req.sec.ci.005 | The Platform **must** support Confidentiality and Integrity of process-related metadata and restrict information sharing with only the process owner (e.g., tenant) | |
+| req.sec.ci.006 | The Platform **must** support Confidentiality and Integrity of workload resource utilization (RAM, CPU, Storage, Network I/O, cache, hardware offload) and restrict information sharing with only the workload owner (e.g., tenant) | |
+| req.sec.ci.007 | The Platform **must not** allow Memory Inspection by any actor other than the authorized actors for the Entity to which Memory is assigned (e.g., tenants owning the workload), for Lawful Inspection, and by secure monitoring services | Admin access must be carefully regulated |
+| req.sec.ci.008 | The Cloud Infrastructure **must** support tenant networks segregation | |
 
 <a name="7.11.4"></a>
 ### 7.11.4. Workload Security
 
-| Ref | Requirement | Unit | Definition |
-|---|----|---|----|
-| sec.wl.001 | The Platform **must** support Workload placement policy |  | |
-| sec.wl.002 | The Platform **must** support operational security |  | |
-| sec.wl.003 | The Platform **must** support secure provisioning of workloads  |  | |
-| sec.wl.004 | The Platform **must** support Location assertion (for mandated in-country or location requirements) |  | |
-| sec.wl.005 | Production workloads **must** be separated from non-production workloads |  | |
-| sec.wl.006 | Workloads **must** be separable by their categorisation (for example, payment card information, healthcare, etc.) |  | |
-| sec.wl.007 | The Operator **should** implement processes and tools to verify VNF authenticity and integrity. |  | |
+| Ref | Requirement | Definition/Note |
+|---|----|----|
+| req.sec.wl.001 | The Platform **must** support Workload placement policy | |
+| req.sec.wl.002 | The Platform **must** support operational security | |
+| req.sec.wl.003 | The Platform **must** support secure provisioning of workloads  | |
+| req.sec.wl.004 | The Platform **must** support Location assertion (for mandated in-country or location requirements) | |
+| req.sec.wl.005 | Production workloads **must** be separated from non-production workloads | |
+| req.sec.wl.006 | Workloads **must** be separable by their categorisation (for example, payment card information, healthcare, etc.) | |
+| req.sec.wl.007 | The Operator **should** implement processes and tools to verify VNF authenticity and integrity |  |
 
 <a name="7.11.5"></a>
 ### 7.11.5. Image Security
 
-| Ref | Requirement | Unit | Definition |
-|---|----|---|----|
-| sec.img.001 | Images from untrusted sources **must not** be used |  | |
-| sec.img.002 | Images **must** be maintained to be free from known vulnerabilities |  | |
-| sec.img.003 | Images **must not** be configured to run with privileges higher than the privileges of the actor authorized to run them |  | |
-| sec.img.004 | Images **must** only be accessible to authorized actors |  | |
-| sec.img.005 | Image Registries **must** only be accessible to authorized actors |  | |
-| sec.img.006 | Image Registries **must** only be accessible over secure networks |  | |
-| sec.img.007 | Image registries **must** be clear of vulnerable and stale (out of date) versions |  | |
+| Ref | Requirement | Definition/Note |
+|---|----|----|
+| req.sec.img.001 | Images from untrusted sources **must not** be used | |
+| req.sec.img.002 | Images **must** be maintained to be free from known vulnerabilities |  |
+| req.sec.img.003 | Images **must not** be configured to run with privileges higher than the privileges of the actor authorized to run them |  |
+| req.sec.img.004 | Images **must** only be accessible to authorized actors |  |
+| req.sec.img.005 | Image Registries **must** only be accessible to authorized actors |  |
+| req.sec.img.006 | Image Registries **must** only be accessible over secure networks |  |
+| req.sec.img.007 | Image registries **must** be clear of vulnerable and stale (out of date) versions |  |
 
 <a name="7.11.6"></a>
 ### 7.11.6. Security LCM
 
-| Ref | Requirement | Unit | Definition |
-|---|----|---|----|
-| sec.lcm.001 | The Platform **must** support Secure Provisioning, Maintaining availability, Deprovisioning (secure Clean-Up) of workload resources |  | Secure clean-up: tear-down, defending against virus or other attacks, or observing of cryptographic or user service data |
-| sec.lcm.002 | Operational **must** use management protocols limiting security risk such as SNMPv3, SSH v2, ICMP, NTP, syslog and TLS |  | |
-| sec.lcm.003 | The Cloud Operator **must** implement change management for Cloud Infrastructure, Cloud Infrastructure Manager and other components of the cloud |  | Platform change control on hardware |
-| sec.lcm.004 | The Cloud Operator **should** support automated templated approved changes |  | Templated approved changes for automation where available |
-| sec.lcm.005 | Platform **must** provide logs and these logs must be regularly scanned |  | |
-| sec.lcm.006 | The Platform **must** verify the integrity of all Resource management requests | Yes/No | |
-| sec.lcm.007 | The Platform **must** be able to update newly instantiated, suspended, hibernated, migrated and restarted images with current time information |  | |
-| sec.lcm.008 | The Platform **must** be able to update newly instantiated, suspended, hibernated, migrated and restarted images with relevant DNS information. |  | |
-| sec.lcm.009 |  The Platform **must** be able to update the tag of newly instantiated, suspended, hibernated, migrated and restarted images with relevant geolocation (geographical) information |  | |
-| sec.lcm.010 | The Platform **must** log all changes to geolocation along with the mechanisms and sources of location information (i.e. GPS, IP block, and timing). |  | |
-| sec.lcm.011 | The Platform **must** implement Security life cycle management processes including proactively update and patch all deployed Cloud Infrastructure    software. | | |
+| Ref | Requirement | Definition/Note |
+|---|----|----|
+| req.sec.lcm.001 | The Platform **must** support Secure Provisioning, Maintaining availability, Deprovisioning (secure Clean-Up) of workload resources | Secure clean-up: tear-down, defending against virus or other attacks, or observing of cryptographic or user service data |
+| req.sec.lcm.002 | Operational **must** use management protocols limiting security risk such as SNMPv3, SSH v2, ICMP, NTP, syslog and TLS | |
+| req.sec.lcm.003 | The Cloud Operator **must** implement change management for Cloud Infrastructure, Cloud Infrastructure Manager and other components of the cloud | Platform change control on hardware |
+| req.sec.lcm.004 | The Cloud Operator **should** support automated templated approved changes | Templated approved changes for automation where available |
+| req.sec.lcm.005 | Platform **must** provide logs and these logs must be regularly scanned |  |
+| req.sec.lcm.006 | The Platform **must** verify the integrity of all Resource management requests | |
+| req.sec.lcm.007 | The Platform **must** be able to update newly instantiated, suspended, hibernated, migrated and restarted images with current time information |  |
+| req.sec.lcm.008 | The Platform **must** be able to update newly instantiated, suspended, hibernated, migrated and restarted images with relevant DNS information |  |
+| req.sec.lcm.009 |  The Platform **must** be able to update the tag of newly instantiated, suspended, hibernated, migrated and restarted images with relevant geolocation (geographical) information | |
+| req.sec.lcm.010 | The Platform **must** log all changes to geolocation along with the mechanisms and sources of location information (i.e. GPS, IP block, and timing) |  |
+| req.sec.lcm.011 | The Platform **must** implement Security life cycle management processes including proactively update and patch all deployed Cloud Infrastructure software | |
 
 <a name="7.11.7"></a>
 ### 7.11.7. Monitoring and Security Audit
 
 The Platform is assumed to provide configurable alerting and notification capability and the operator is assumed to have automated systems, policies and procedures to act on alerts and notifications in a timely fashion. In the following the monitoring and logging capabilities can trigger alerts and notifications for appropriate action.
 
-| Ref | Requirement | Unit | Definition |
-|---|----|---|----|
-| sec.mon.001 | Platform must provide logs and these logs must be regularly scanned for events of interest |  | |
-| sec.mon.002 | Security logs must be time synchronised |  | |
-| sec.mon.003 | The Platform must log all changes to time server source, time, date and time zones |  | |
-| sec.mon.004 | The Platform must secure and protect Audit logs (contain sensitive information) both in-transit and at rest |  | |
-| sec.mon.005 | The Platform must Monitor and Audit various behaviours of connection and login attempts to detect access attacks and potential access attempts and take corrective actions accordingly |  | |
-| sec.mon.006 | The Platform must Monitor and Audit operations by authorized account access after login to detect malicious operational activity and take corrective actions accordingly |  | |
-| sec.mon.007 | The Platform must Monitor and Audit security parameter configurations for compliance with defined security policies |  | |
-| sec.mon.008 | The Platform must Monitor and Audit externally exposed interfaces for illegal access (attacks) and take corrective security hardening measures |  | |
-| sec.mon.009 | The Platform must Monitor and Audit service handling for various attacks (malformed messages, signalling flooding and replaying, etc.) and take corrective actions accordingly |  | |
-| sec.mon.010 | The Platform must Monitor and Audit running processes to detect unexpected or unauthorized processes and take corrective actions accordingly |  | |
-| sec.mon.011 | The Platform must Monitor and Audit logs from infrastructure elements and workloads to detected anomalies in the system components and take corrective actions accordingly |  | |
-| sec.mon.012 | The Platform must Monitor and Audit Traffic patterns and volumes to prevent malware download attempts |  | |
-| sec.mon.013 | The monitoring system must not affect the security (integrity and confidentiality) of the infrastructure, workloads, or the user data (through back door entries). |  | |
-| sec.mon.014 | The Monitoring systems should not impact IAAS, PAAS, and SAAS SLAs including availability SLAs |  | |
-| sec.mon.015 | The Platform must ensure that the Monitoring systems are never starved of resources |  | |
-| sec.mon.016 | The Platform Monitoring components should follow security best practices for auditing, including secure logging and tracing |  | |
-| sec.lcm.017 | The Platform must Audit systems for any missing security patches and take appropriate actions |  | |
+| Ref | Requirement | Definition/Note |
+|---|----|---|
+| req.sec.mon.001 | Platform must provide logs and these logs must be regularly scanned for events of interest | |
+| req.sec.mon.002 | Security logs must be time synchronised |  |
+| req.sec.mon.003 | The Platform must log all changes to time server source, time, date and time zones |  |
+| req.sec.mon.004 | The Platform must secure and protect Audit logs (contain sensitive information) both in-transit and at rest |  |
+| req.sec.mon.005 | The Platform must Monitor and Audit various behaviours of connection and login attempts to detect access attacks and potential access attempts and take corrective actions accordingly | |
+| req.sec.mon.006 | The Platform must Monitor and Audit operations by authorized account access after login to detect malicious operational activity and take corrective actions accordingly |  |
+| req.sec.mon.007 | The Platform must Monitor and Audit security parameter configurations for compliance with defined security policies | |
+| req.sec.mon.008 | The Platform must Monitor and Audit externally exposed interfaces for illegal access (attacks) and take corrective security hardening measures | |
+| req.sec.mon.009 | The Platform must Monitor and Audit service handling for various attacks (malformed messages, signalling flooding and replaying, etc.) and take corrective actions accordingly | |
+| req.sec.mon.010 | The Platform must Monitor and Audit running processes to detect unexpected or unauthorized processes and take corrective actions accordingly |  |
+| req.sec.mon.011 | The Platform must Monitor and Audit logs from infrastructure elements and workloads to detected anomalies in the system components and take corrective actions accordingly | |
+| req.sec.mon.012 | The Platform must Monitor and Audit Traffic patterns and volumes to prevent malware download attempts | |
+| req.sec.mon.013 | The monitoring system must not affect the security (integrity and confidentiality) of the infrastructure, workloads, or the user data (through back door entries) |  |
+| req.sec.mon.014 | The Monitoring systems should not impact IAAS, PAAS, and SAAS SLAs including availability SLAs |  |
+| req.sec.mon.015 | The Platform must ensure that the Monitoring systems are never starved of resources |  |
+| req.sec.mon.016 | The Platform Monitoring components should follow security best practices for auditing, including secure logging and tracing | |
+| req.sec.lcm.017 | The Platform must Audit systems for any missing security patches and take appropriate actions |  |
 
 <a name="7.11.8"></a>
 ### 7.11.8. Compliance with Standards
 
-| Ref | Requirement | Unit | Definition |
-|---------|---------------|----------------|------------|
-| sec.std.001 | The Cloud Operator **should** comply with Center for Internet Security CIS Controls ([https://www.cisecurity.org/](https://www.cisecurity.org/)) | | Center for Internet Security - [https://www.cisecurity.org/](https://www.cisecurity.org/) |
-| | [Q: Are we going to verify compliance w Controls? If not, then why a “must” – but making it a “should” implies only guidance and not a control.] |  |  |
-| sec.std.002 | The Cloud Operator, Platform and Workloads **should** follow the guidance in the CSA Security Guidance for Critical Areas of Focus in Cloud Computing (latest version) [https://cloudsecurityalliance.org/](https://cloudsecurityalliance.org/) |  | Cloud Security Alliance - [https://cloudsecurityalliance.org/](https://cloudsecurityalliance.org/) |
-| sec.std.003 | The Platform and Workloads **should** follow the guidance in the OWASP Cheat Sheet Series (OCSS) https://github.com/OWASP/CheatSheetSeries |  | Open Web Application Security Project [https://www.owasp.org](https://www.owasp.org) |
-| sec.std.004 | The Cloud Operator, Platform and Workloads **should** ensure that their code is not vulnerable to the OWASP Top Ten Security Risks [https://owasp.org/www-project-top-ten/](https://owasp.org/www-project-top-ten/) |  |
-| sec.std.005 | The Cloud Operator, Platform and Workloads **should** strive to improve their maturity on the OWASP Software Maturity Model (SAMM) https://owaspsamm.org/blog/2019/12/20/version2-community-release/ |  | |
-| <Testing> | The Cloud Operator, Platform and Workloads **should** utilize the OWASP Web Security Testing Guide https://github.com/OWASP/wstg/tree/master/document |  | |
-| sec.std.013 | The Cloud Operator, and Platform **should** satisfy the requirements for Information Management Systems specified in ISO/IEC 27001  https://www.iso.org/obp/ui/#iso:std:iso-iec:27001:ed-2:v1:en |  | ISO/IEC 27002:2013 - ISO/IEC 27001 is the international Standard for best-practice information security management systems (ISMSs) |
-| sec.std.014 | The Cloud Operator, and Platform **should** implement the Code of practice for Security Controls specified ISO/IEC 27002:2013 (or latest)  https://www.iso.org/obp/ui/#iso:std:iso-iec:27002:ed-2:v1:en | | |
-| sec.std.015 | The Cloud Operator, and Platform **should** implement the ISO/IEC 27032:2012 (or latest) Guidelines for Cybersecurity techniques  https://www.iso.org/obp/ui/#iso:std:iso-iec:27032:ed-1:v1:en |  | ISO/IEC 27032 - ISO/IEC 27032is the international Standard focusing explicitly on cybersecurity |
-| sec.std.016 | The Cloud Operator **should** conform to the ISO/IEC 27035 standard for incidence management |  | ISO/IEC 27035 - ISO/IEC 27035 is the international Standard for incident management |
-| sec.std.017 | The Cloud Operator **should** conform to the ISO/IEC 27031 standard for business continuity |  | ISO/IEC 27031 - ISO/IEC 27031 is the international Standard for ICT readiness for business continuity |
-| sec.std.018 | The Public Cloud Operator **must**, and the Private Cloud Operator **may** be certified to be compliant with the International Standard on Awareness Engagements (ISAE) 3402 (in the US: SSAE 16) |  | International Standard on Awareness Engagements (ISAE) 3402. US Equivalent: SSAE16 |
+| Ref | Requirement | Definition/Note |
+|---|----|---|
+| req.sec.std.001 | The Cloud Operator **should** comply with Center for Internet Security CIS Controls ([https://www.cisecurity.org/](https://www.cisecurity.org/)) | Center for Internet Security - [https://www.cisecurity.org/](https://www.cisecurity.org/) |
+| | [Q: Are we going to verify compliance w Controls? If not, then why a “must” – but making it a “should” implies only guidance and not a control.] |  |
+| req.sec.std.002 | The Cloud Operator, Platform and Workloads **should** follow the guidance in the CSA Security Guidance for Critical Areas of Focus in Cloud Computing (latest version) [https://cloudsecurityalliance.org/](https://cloudsecurityalliance.org/)  | Cloud Security Alliance - [https://cloudsecurityalliance.org/](https://cloudsecurityalliance.org/) |
+| req.sec.std.003 | The Platform and Workloads **should** follow the guidance in the OWASP Cheat Sheet Series (OCSS) https://github.com/OWASP/CheatSheetSeries  | Open Web Application Security Project [https://www.owasp.org](https://www.owasp.org) |
+| req.sec.std.004 | The Cloud Operator, Platform and Workloads **should** ensure that their code is not vulnerable to the OWASP Top Ten Security Risks [https://owasp.org/www-project-top-ten/](https://owasp.org/www-project-top-ten/) |
+| req.sec.std.005 | The Cloud Operator, Platform and Workloads **should** strive to improve their maturity on the OWASP Software Maturity Model (SAMM) https://owaspsamm.org/blog/2019/12/20/version2-community-release/ |  |
+| <Testing> | The Cloud Operator, Platform and Workloads **should** utilize the OWASP Web Security Testing Guide https://github.com/OWASP/wstg/tree/master/document |  |
+| req.sec.std.013 | The Cloud Operator, and Platform **should** satisfy the requirements for Information Management Systems specified in ISO/IEC 27001  https://www.iso.org/obp/ui/#iso:std:iso-iec:27001:ed-2:v1:en | ISO/IEC 27002:2013 - ISO/IEC 27001 is the international Standard for best-practice information security management systems (ISMSs) |
+| req.sec.std.014 | The Cloud Operator, and Platform **should** implement the Code of practice for Security Controls specified ISO/IEC 27002:2013 (or latest)  https://www.iso.org/obp/ui/#iso:std:iso-iec:27002:ed-2:v1:en | |
+| req.sec.std.015 | The Cloud Operator, and Platform **should** implement the ISO/IEC 27032:2012 (or latest) Guidelines for Cybersecurity techniques  https://www.iso.org/obp/ui/#iso:std:iso-iec:27032:ed-1:v1:en | ISO/IEC 27032 - ISO/IEC 27032is the international Standard focusing explicitly on cybersecurity |
+| req.sec.std.016 | The Cloud Operator **should** conform to the ISO/IEC 27035 standard for incidence management | ISO/IEC 27035 - ISO/IEC 27035 is the international Standard for incident management |
+| req.sec.std.017 | The Cloud Operator **should** conform to the ISO/IEC 27031 standard for business continuity  ISO/IEC 27031 - ISO/IEC 27031 is the international Standard for ICT readiness for business continuity |
+| req.sec.std.018 | The Public Cloud Operator **must**, and the Private Cloud Operator **may** be certified to be compliant with the International Standard on Awareness Engagements (ISAE) 3402 (in the US: SSAE 16) | International Standard on Awareness Engagements (ISAE) 3402. US Equivalent: SSAE16 |
 
 <a name="7.11.9"></a>
 ### 7.11.9. References


### PR DESCRIPTION
Fixes #1758 
Tables modifications in section 7.11 :
 "Unit" column removed 
"Definition" column replaced by "Definition/Note"
To be consistent with the convention adopted within RA1 for requirements reference, the prefix "req" is added