### PR TITLE
[RM Appendix]: Correcting exception table formatting

### DIFF
--- a/doc/ref_model/chapters/appendix-a.md
+++ b/doc/ref_model/chapters/appendix-a.md
@@ -55,11 +55,10 @@ Relevant for sizing infrastructure and application operations (which often is an
 
 As Part of the [Transition Plan](../../gov/chapters/chapter09.md#9.2) described in the adoption strategy, following table explains the exceptions allowed in this RM release. The list of Exceptions described here are considered to be against CNTT principles and will be removed in future releases as soon as an alternative technology that is aligned with CNTT principles develops and matures.
 
-| Ref        	| Type       	| Name               	| Description                                                           	|
-|------------	|------------	|--------------------	|-----------------------------------------------------------------------	|
-| rm.exc.001 	| Technology 	| SRIOV 	| This exception allows workloads (VNF/CNF) to rely on SR-IOV over PCI-PassThrough technology. 	|
-| rm.exc.002 	|            	|                    	|                                                                       	|
-| rm.exc.003 	|            	|                    	|                                                                       	|
+| Ref        | Type       | Name       | Description                                                           |
+|------------|------------|------------|-----------------------------------------------------------------------|
+| rm.exc.001 | Technology | SRIOV      | This exception allows workloads (VNF/CNF) to rely on SR-IOV over PCI-PassThrough technology. |
+
 
 <p align="center"><b>Table A-1:</b> Exceptions allowed in this RM release</p>
 


### PR DESCRIPTION
The readthedocs compilation toolchain does not compile tables with tabs,
therefore the exception table is reformatted not to have tabs.

Also the not used rows are deleted.

