### PR TITLE
[RC1] Fix english mistakes (backport)

### DIFF
--- a/doc/ref_cert/lfn/chapters/chapter02.md
+++ b/doc/ref_cert/lfn/chapters/chapter02.md
@@ -62,18 +62,18 @@ test results in the
 and all artifacts (reports, logs, etc.) to
 [an S3 compatible storage service](http://artifacts.opnfv.org/).
 
-The CNTT compliance and conformance processes will leverage on existing OPNFV
-testing knowledge (projects) and experience (history) and then will conform
-to the overall toolchain design already in-place. The RC toolchain only
-requires for the local deployment of the components instead of leveraging on
+The CNTT verification, validation, compliance, and conformance processes will
+leverage existing OPNFV testing knowledge (projects) and experience (history)
+and conform to the overall toolchain design already in-place. The RC toolchain
+only requires for the local deployment of the components instead of leveraging
 the common OPNFV centralized services. But the interfaces remain unchanged
-mainly leveraging on jenkins jobs, the common test case execution, the test
+mainly leveraging jenkins jobs, the common test case execution, the test
 result DB and the S3 protocol to publish the artifacts. It's worth mentioning
-that dumping all results and logs required by conformance is already in place
+that dumping all results and logs required for conformance is already in place
 in CIRV (see
 [cntt-latest-zip](https://build.opnfv.org/ci/job/cntt-latest-zip/)) and
 Functest daily jobs (see
-[functest-hunter-zip](https://build.opnfv.org/ci/job/functest-hunter-zip/3/console))
+[functest-hunter-zip](https://build.opnfv.org/ci/job/functest-hunter-zip/3/console)).
 
 It should be noted that
 [Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) supports both
@@ -91,7 +91,7 @@ The NFVI is consumed or used by VNFs via APIs exposed by Virtualised Infrastruct
 * KPIs obtained from the SUT are collected and submitted to conformance portal.
 * The SUT KPIs are reviewed and compared with Golden KPIs to determine if the conformance badge is to be provided to SUT or not.
 
-Based on a NFVI passing RC test and getting the conformance badge, VNF conformance test can be further conducted. Such test will leverage existing OPNFV Intake Process. Upstream projects will define features/capabilities, test scenarios, and test cases to augment existing OVP test harnesses to be executed via the OVP Ecosystem. 
+Based on a NFVI passing RC test and getting the conformance badge, VNF conformance test can be further conducted. Such test will leverage existing OPNFV Intake Process. Upstream projects will define features/capabilities, test scenarios, and test cases to augment existing OVP test harnesses to be executed via the OVP Ecosystem.
 
 <p align="center"><img src="../figures/RC_CertificationMethodology.jpg" alt="conformance Methodology" title="Conformance Methodology" width="100%"/></p>
 <p align="center"><b>Figure 2-1:</b> Conformance Methodology</p>
@@ -225,8 +225,8 @@ The NFVI Conformance framework will be guided by the following core principles:
 <a name="2.7.2"></a>
 ### 2.7.2 Test case integration requirements
 
-To reach all goals (verification, compliance and Conformance) expected by
-CNTT, all test cases must be delivered as
+To reach all goals (verification, validation, compliance, and conformance)
+expected by CNTT, all test cases must be delivered as
 [Docker containers](https://www.docker.com/) and meet the requirements to
 simplify the CI toolchain setups:
 - the common test case execution
@@ -234,20 +234,20 @@ simplify the CI toolchain setups:
   with third-parties (e.g. dump all test case logs and results for
   Conformance)
 
-For their parts, the Docker containers simply enforce that the test cases are
-delivered with all runtime dependencies. Then it prevents lots of manual
-operations when configuring the server running the test cases and prevent
-conflicts between all test case dependencies.
+For their part, the Docker containers simply enforce that the test cases are
+delivered with all runtime dependencies. This prevents lots of manual
+operations when configuring the servers running the test cases and prevents
+conflicts between the test cases due to any dependencies.
 
 It's worth mentioning that current
 [test cases selected by CNTT](./chapter03.md)
-already leverages on [Xtesting](https://xtesting.readthedocs.io/en/latest/)
+already leverage [Xtesting](https://xtesting.readthedocs.io/en/latest/)
 which is a simple framework to assemble sparse test cases and to accelerate the
 adoption of CI/CD best practices. By managing all the interactions with the
 CI/CD components (test scheduler, test results database, artifact repository),
 it allows the developer to work only on the test suites without diving into
 CI/CD integration. Even more, it brings the capability to run heterogeneous
-test cases in the same CI toolchains thanks to a few low constraints
+test cases in the same CI toolchains thanks to a few constraints
 [quickly achievable](https://www.sdxcentral.com/articles/news/opnfvs-6th-release-brings-testing-capabilities-that-orange-is-already-using/2018/05/).
 
 Following the design in use, the Docker containers proposed by the test
@@ -672,4 +672,3 @@ Main OPNFV test tool candidate: Yardstick (TC014)
 
 <a name="2.8.7.2"></a>
 #### 2.8.7.2 Resiliency Measurements
-

--- a/doc/ref_cert/lfn/chapters/chapter03.md
+++ b/doc/ref_cert/lfn/chapters/chapter03.md
@@ -708,7 +708,7 @@ of 0%) proposed in
 ### 3.3.7 Dataplane benchmarking
 
 [Functest Benchmarking CNTT](https://git.opnfv.org/functest/tree/docker/benchmarking-cntt/testcases.yaml)
-offers two benchmarking dataplane test cases leveraging on:
+offers two benchmarking dataplane test cases leveraging:
 - [VMTP](http://vmtp.readthedocs.io/en/latest)
 - [Shaker](http://pyshaker.readthedocs.io/en/latest/)
 

--- a/doc/ref_cert/lfn/chapters/chapter04.md
+++ b/doc/ref_cert/lfn/chapters/chapter04.md
@@ -66,7 +66,7 @@ Functest also integrates
 [Kubernetes End-to-end tests](https://kubernetes.io/blog/2019/03/22/kubernetes-end-to-end-testing-for-everyone/) and allows verifying Kubernetes Conformance (see
 [k8s-conformance](https://build.opnfv.org/ci/job/functest-kubernetes-opnfv-functest-kubernetes-smoke-iruya-k8s_conformance-run/206/console)).
 
-Dovetail (OVP) mostly leverages on Functest but only runs a small part of
+Dovetail (OVP) mostly leverages Functest but only runs a small part of
 Functest (~15% of all functional tests, no benchmarking tests, no VNF
 deployment and testing). It's worth mentioning that Functest is patched to
 [disable API verification](https://github.com/opnfv/dovetail/tree/master/etc/patches/functest/disable-api-validation) which has differed from OpenStack rules for
@@ -82,7 +82,7 @@ integration of tests developed upstream (and the Functest team directly
 contributes in these projects:
 [Rally](https://github.com/openstack/rally-openstack),
 [Tempest](https://github.com/openstack/tempest), etc.).
-It's worth mentioning that, as opposed to the OpenStack Gates leveraging on
+It's worth mentioning that, as opposed to the OpenStack Gates leveraging
 [DevStack](https://docs.openstack.org/devstack/latest/), it can check the same
 already deployed SUT over and over even from a
 [Raspberry PI](https://www.raspberrypi.org/). Here the testcases can be
@@ -192,19 +192,19 @@ SDF's will contain, but not limited to, the following Metadata, Components, Depl
 <p align="center"><img src="../figures/rc1_cookbook_nfvi.png" alt="nfvi_cookbook" title="NFVI Cookbook" width="60%"/></p>
 <p align="center"><b>Figure 1-2:</b> NFVI Testing Integrated Framework.</p>
 
-[Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) leverages on the
+[Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) leverages the
 common test case execution proposed by Xtesting. Thanks to a simple test case
-list, this tool deploys anywhere plug-and-play
+list, this tool deploys plug-and-play
 [CI/CD toolchains in a few commands](https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004).
-In addition of this teaching capability needed by the Network Automation
-journey, it supports multiple components such as Jenkins and Gitlab CI (test
-schedulers) and
+In addition, it supports multiple components such as Jenkins and Gitlab CI
+(test schedulers) and
 [multiple deployment models](https://lists.opnfv.org/g/opnfv-tsc/message/5702)
 such as all-in-one or centralized services.
 
 [Xtesting](https://xtesting.readthedocs.io/en/latest/) and
 [Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) combined meet the
-CNTT requirements about verification, compliance and Conformance:
+CNTT requirements about CNTT requirements about verification, validation,
+compliance, and conformance:
 - smoothly assemble multiple heterogeneous test cases
 - generate the Jenkins jobs in
   [OPNFV Releng](https://git.opnfv.org/releng/tree/jjb/airship/cntt.yaml) to


### PR DESCRIPTION
It backports the mistakes detected when reviewing the test case
integration requirements [1]

[1] https://github.com/cntt-n/CNTT/pull/1725

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>