### PR TITLE
[GOV common]: Moving content to H2 chapters

### DIFF
--- a/doc/common/README.md
+++ b/doc/common/README.md
@@ -18,35 +18,35 @@
 * [Vendor Implementations](../ven_impl)
 
 <a name="1.0"></a>
-# Introduction
+## Introduction
 
 Cloud iNfrastructure Telco Taskforce [Introduction](chapter00.md). 
 
 <a name="4.0"></a>
-# Approach
+## Approach
 Different specification types within CNTT are related to each other and requires alignments between different parts. The Approach CNTT is taking to tackle those issues is described in [here](./approach.md).
 
 <a name="5.0"></a>
-# Use Cases
+## Use Cases
 CNTT Addresses wide range of use cases from Core all the way to the Edge of the Network. Different use cases supported by CNTT specifications are described in [here](./usecases.md).
 
 <a name="6.0"></a>
-# Roadmap and Releases
+## Roadmap and Releases
 
 * [CNTT Releases](./release_notes)
 * [CNTT Roadmap](./roadmap.md)
 
 <a name="7.0"></a>
-# CNTT Technical Policies and Transition Plan
+## CNTT Technical Policies and Transition Plan
 
 There are multiple situations where a [policy](./policies.md), comprised of one or more compromises and/or transitions is required to address technology that does not presently conform to CNTT mandates or strategy, and hence requires explicit direction to prescribe how the situation will be treated in the present, as well as in the future. This informs application designers how RC will react when encountering such technologies during the qualification process, including flagging warnings and potentially errors which could prevent issuance of a conformance badge.
 
 <a name="8.0"></a>
-# Other Policies
+## Other Policies
 
 * [OpenStack Release selection](./openstack-release.md)
 
 <a name="9.0"></a>
-# Relevant Technologies
+## Relevant Technologies
 
 There are different technologies used and specified by CNTT specifications. This [section](./technologies.md) describes the relevant technologies for CNTT and clarifies CNTT position about them.


### PR DESCRIPTION
Having all content in H1 chapters makes the generated ToC in readthedocs "unbalanced".