### PR TITLE
[TSC Common] Common Abbreviations

### DIFF
--- a/doc/common/abbreviations.md
+++ b/doc/common/abbreviations.md
@@ -56,7 +56,7 @@
 | RC             | Reference Conformance                 |
 | RI             | Reference Implementation              |
 | RM             | Reference Model                       |
-| SDN            | Software Define Networking            |
+| SDN            | Software-Defined Networking            |
 | SDS            | Software-Defined Storage              |
 | SFC            | Service Function Chaining             |
 | SMT            | Simultaneous multithreading           |

--- a/doc/common/abbreviations.md
+++ b/doc/common/abbreviations.md
@@ -2,7 +2,7 @@
 
 # Abbreviations
 
-<p align="right"><img src="./figures/bogo_lsf.png" alt="scope" title="baldy" width="35%"/></p>
+<p align="right"><img src="./figures/bogo_sdc.png" alt="scope" title="baldy" width="35%"/></p>
 
 
 ## Table of Contents
@@ -17,9 +17,60 @@
 
 | Term           | Description                           |
 |----------------|-------------                          |
-| CNTT           | Cloud iNfrastructure Telco Taskforce  |  
-| PRD            | Permanent Reference Document          |
+| AI             | Artificial Intelligence               |
+| API            | Application Programming Interface     |
+| CaaS           | Container as a Service                |
+| CI/CD          | Continuous Integration / Continuous Deployment |
+| CNF            | Cloud native Network Functio          |
+| CNI            | Container Network Interface           |
+| CNTT           | Cloud iNfrastructure Telco Taskforce  |
+| CPU            | Central Processing Unit               |
+| DPDK           | Data Plane Development Kit            |
+| DMA            | Direct Memory Access                  |
+| EPA            | Enhanced Platform Awareness           |
+| ETSI           | European Telecommunications Standards Institute |
+| EVPN           | Ethernet Virtual Private Network      |
+| FPGA           | Field Programmable Gate Array         |
+| GW             | Gateway                               |
+| GPU            | Graphics Processing Unit              |
+| GSMA           | Groupe Speciale Mobile Association    |
+| HW             | Hardware                              |
+| IaaS           | Infrastructure as a Service           |
+| IO             | Input/Output                          |
+| IOMMU          | Input/Ouput Memory Management Unit    |
+| IP             | Internet Protocol                     |
+| IT             | Information Technology                |
+| K8s            | Kubernetes                            |
+| LAN            | Local Area Network                    |
+| MANO           | Management and Orchestration          |
+| NFV            | Network Funciton Virtualisation       |
+| NFVI           | Network Funciton Virtualisation Infrastructure |
+| NFVO           | Network Funciton Virtualisation Orchestrator |
+| NIC            | Network Interface Card                |
+| ONAP           | Open Network Automation Platform      |
+| OPNFV          | Open Platform for NFV                 |
+| OVP            | OPNFV Verified Program                |
+| PCI-PT         | PCIe PassThrough                      |
+| PF             | Physical Function                     |
+| RA             | Reference Architecture                |
+| RC             | Reference Conformance                 |
+| RI             | Reference Implementation              |
 | RM             | Reference Model                       |
+| SDN            | Software Define Networking            |
+| SDS            | Software-Defined Storage              |
+| SFC            | Service Function Chaining             |
+| SMT            | Simultaneous multithreading           |
+| SR-IOV         | Single Root Input Output Virtualisation |
+| SW             | Software                              |
+| VF             | Virtual Function                      |
+| VIM            | Virtualised Infrastructure Manager    |
+| VLAN           | Virtual LAN                           |
+| VM             | Virtual Machine                       |
+| VNF            | Virtual Network Function              |
+| VNFC           | Virtual Network Function Component    |
+| VxLAN          | Virtual Extensible LAN                |
+| vXYZ           | virual XYZ, e.g., as in vNIC          |
+
 
 <a name="1.2"></a>
 ## RM Abbreviations

--- a/doc/common/abbreviations.md
+++ b/doc/common/abbreviations.md
@@ -43,9 +43,9 @@
 | K8s            | Kubernetes                            |
 | LAN            | Local Area Network                    |
 | MANO           | Management and Orchestration          |
-| NFV            | Network Funciton Virtualisation       |
-| NFVI           | Network Funciton Virtualisation Infrastructure |
-| NFVO           | Network Funciton Virtualisation Orchestrator |
+| NFV            | Network Function Virtualisation       |
+| NFVI           | Network Function Virtualisation Infrastructure |
+| NFVO           | Network Function Virtualisation Orchestrator |
 | NIC            | Network Interface Card                |
 | ONAP           | Open Network Automation Platform      |
 | OPNFV          | Open Platform for NFV                 |

--- a/doc/common/abbreviations.md
+++ b/doc/common/abbreviations.md
@@ -21,7 +21,7 @@
 | API            | Application Programming Interface     |
 | CaaS           | Container as a Service                |
 | CI/CD          | Continuous Integration / Continuous Deployment |
-| CNF            | Cloud native Network Functio          |
+| CNF            | Cloud native Network Function          |
 | CNI            | Container Network Interface           |
 | CNTT           | Cloud iNfrastructure Telco Taskforce  |
 | CPU            | Central Processing Unit               |


### PR DESCRIPTION
Fixes #1803 

List of abbreviations of terms used in the Common and README documents.

PS although CNI is a Kuberntes related terms and used more in RA-2, it is sued without explanation in a "common" document