### PR TITLE
[RM Ch07] Secure Logging, root login

### DIFF
--- a/doc/ref_model/chapters/chapter07.md
+++ b/doc/ref_model/chapters/chapter07.md
@@ -227,7 +227,7 @@ The platform supports the workload, and in effect controls access to the workloa
 * A platform change management process that is documented, well communicated to staff and tenants, and rigourously followed.
 * A process to check change management adherence that is implemented, and rigourously followed.
 * Processes for managing platform access control filters that are documented, followed, and monitored.
-* No login to root on any platform systems (platform systems are those that are associated with the platform and include systems that directly or indirectly affect the viability of the platform).
+* No login to root on any platform systems (platform systems are those that are associated with the platform and include systems that directly or indirectly affect the viability of the platform) when root privileges are not required.
 * Role-Based Access Control (RBAC) must apply for all platform systems access.
 * An approved system or process for last resort access must exist for the platform.
 * All API access must use TLS protocol.
@@ -249,7 +249,7 @@ The platform supports the workload, and in effect controls access to the workloa
 * A platform change management process that is documented, well communicated to staff and tenants, and rigourously followed.
 * A process to check change management adherence that is implemented, and rigourously followed.
 * Processes for managing platform access control filters that are documented, followed, and monitored.
-* No login to root on any platform systems.
+* No login to root on any platform systems, when root privileges are not required.
 * Role-Based Access Control (RBAC) must apply for all systems access.
 * An approved system or process for last resort access must exist for the platform.
 * All back-end API access must use TLS.
@@ -494,7 +494,7 @@ Table 7-2 shows security capabilities
 | req.sec.gen.003 | All servers part of Cloud Infrastructure **must** support a root of trust and secure boot |  |
 | req.sec.gen.004 | The Operating Systems of all the servers part of Cloud Infrastructure **must** be hardened | NIST SP 800-123 |
 | req.sec.gen.005 | The Platform **must** support Operating System level access control | Details on OS |
-| req.sec.gen.006 | The Platform **must** support Secure logging | Details |
+| req.sec.gen.006 | The Platform **must** support Secure logging. Logging with root account must be prohibited when root privileges are not required | Details |
 | req.sec.gen.007 | All servers part of Cloud Infrastructure **must** be Time synchronized with authenticated Time service | |
 | req.sec.gen.008 | All servers part of Cloud Infrastructure **must** be regularly updated to address security vulnerabilities | |
 | req.sec.gen.009 | The Platform **must** support Software integrity protection and verification | |


### PR DESCRIPTION
Fixes #1506 and #1508

Per the comment from issues1506 and 1508, we can not completely prohibit root login, but restrict root login only when it is mandatory.
Modifications made to 7.5.1.2 and 7.5.2 and addition made to req.sec.gen.006