### PR TITLE
[RM Ch07] Clean up: sections 7.3 to 7.8

### DIFF
--- a/doc/ref_model/chapters/chapter07.md
+++ b/doc/ref_model/chapters/chapter07.md
@@ -7,47 +7,37 @@
 * [7.2 Potential attack vectors](#7.2)
 * [7.3 Security Scope](#7.3)
   * [7.3.1 In-scope and Out-of-Scope definition](#7.3.1)
-  * [7.3.2 Security requirements](#7.3.2)
-* [7.4 Platform Security](#7.4)
+  * [7.3.2 High level security requirements](#7.3.2)
+* [7.4 Cloud Infrastructure Security](#7.4)
   * [7.4.1 General Platform Security](#7.4.1)
   * [7.4.2 Platform ‘back-end’ access security](#7.4.2)
   * [7.4.3 Platform ‘front-end’ access security](#7.4.3)
-  * [7.4.4 Platform Patching](#7.4.4)
 * [7.5 Workload Security - Vendor Responsibility](#7.5)
   * [7.5.1 Software Hardening](#7.5.1)
   * [7.5.2 Port Protection](#7.5.2)
-  * [7.5.3 Software Code Quality](#7.5.3)
+  * [7.5.3 Software Code Quality and Security](#7.5.3)
   * [7.5.4 Alerting and Monitoring](#7.5.4)
   * [7.5.5 Logging](#7.5.5)
   * [7.5.6 VNF images](#7.5.6)
-  * [7.5.7 Identity and Access Management](#7.5.7)
-  * [7.5.8 CVEs and Vulnerability Management](#7.5.8)
-  * [7.5.9 Encryption suite supports](#7.5.9)
-  * [7.5.10 Password complexity support](#7.5.10)
-  * [7.5.11 Customized Banner](#7.5.11)
-* [7.6 Workload Security- Operator Responsibility](#7.6)
+  * [7.5.7 CVEs and Vulnerability Management](#7.5.8)
+* [7.6 Workload Security- Cloud Infrastructure Operator Responsibility](#7.6)
   * [7.6.1 Remote Attestation/openCIT](#7.6.1)
-  * [7.6.2 VNF Image Scanning / Signing](#7.6.2)
-* [7.7 VNF Vendors responsibility](#7.7)
-* [7.8 Cloud Infrastructure Vendors responsibility](#7.8)
-  * [7.8.1 Networking Security Zoning](#7.8.1)
-  * [7.8.2 Encryption](#7.8.2)
-  * [7.8.3 Root of Trust for Measurements (RTM)](#7.8.3)
-  * [7.8.4 Static Root of Trust for Measurements (SRTM)](#7.8.4)
-  * [7.8.5 Dynamic Root of Trust for Measurements (DRTM)](#7.8.5)
-  * [7.8.6 Cloud Infrastructure & Cloud Infrastructure Manager](#7.8.6)
-* [7.9 Common security standards](#7.9)
-* [7.10 Testing & Certification](#7.10)
-* [7.11 Consolidated Security requirements](#7.11)
-  * [7.11.1 System Hardening](#7.11.1)
-  * [7.11.2 Platform Access](#7.11.2)
-  * [7.11.3 Confidentiality and Integrity](#7.11.3)
-  * [7.11.4 Workload Security](#7.11.4)
-  * [7.11.5 Image Security](#7.11.5)
-  * [7.11.6 Security LCM](#7.11.6)
-  * [7.11.7 Monitoring and Security Audit](#7.11.7)
-  * [7.11.8 Compliance with Standards](#7.11.8)
-  * [7.11.9 References](#7.11.9)
+  * [7.6.2 Workload Image Scanning / Signing](#7.6.2)
+  * [7.6.3 Networking Security Zoning](#7.6.3)
+  * [7.6.4 Encryption](#7.6.4)
+  * [7.6.5 Root of Trust for Measurements (RTM)](#7.6.5)
+* [7.7 Common security standards](#7.7)
+* [7.8 Testing & Certification](#7.8)
+* [7.9 Consolidated Security requirements](#7.9)
+  * [7.9.1 System Hardening](#7.11.1)
+  * [7.9.2 Platform Access](#7.11.2)
+  * [7.9.3 Confidentiality and Integrity](#7.11.3)
+  * [7.9.4 Workload Security](#7.11.4)
+  * [7.9.5 Image Security](#7.11.5)
+  * [7.9.6 Security LCM](#7.11.6)
+  * [7.9.7 Monitoring and Security Audit](#7.11.7)
+  * [7.9.8 Compliance with Standards](#7.11.8)
+  * [7.9.9 References](#7.11.9)
 
 
 <a name="7.1"></a>
@@ -55,7 +45,7 @@
 
 Security vulnerabilities and attack vectors are everywhere.  The telecom industry and its cloud infrastructures are even more vulnerable to potential attacks due to the ubiquitous nature of the infrastructures and services combined with the vital role Telecommunications play in the modern world.   The attack vectors are many and varied, ranging from the potential for exposure of sensitive data, both personal and corporate, to weaponized disruption to the global Telecommunications networks.  The threats can take the form of a physical attack on the locations the infrastructure hardware is housed, to network attacks such as denial of service and targeted corruption of the network service applications themselves.  Whatever the source, any Cloud Infrastructure built needs to be able to withstand attacks in whatever form they take.
 
-This chapter examines multiple aspects of security as it relates to the platform and security aspects for workloads. After discussing security attack vectors and security standards, this chapter delves into the Platform Security requirements. The chapters culminates with a consolidated set of “must” requirements and desired (should) recommendations; it is suggested that operators carefully evaluate the recommendations for possible implementation.
+This chapter examines multiple aspects of security as it relates to Cloud Infrastructure and security aspects for workloads. After discussing security attack vectors and security standards, this chapter delves into Security requirements. The chapters culminates with a consolidated set of “must” requirements and desired (should) recommendations; it is suggested that operators carefully evaluate the recommendations for possible implementation.
 
 ## 7.2 Potential attack vectors
 Previously attacks designed to place and migrate workload outside the legal boundaries were not possible using traditional infrastructure, due to the closed nature of these systems. However, using Cloud Infrastructure, violation of regulatory policies and laws becomes possible by actors diverting or moving an application from an authenticated and legal location to another potentially illegal location. The consequences of violating regulatory policies may take the form of a complete banning of service and/or an exertion of a financial penalty by a governmental agency or through SLA enforcement.  Such vectors of attack may well be the original intention of the attacker in an effort to harm the service provider. One possible attack scenario can be when an attacker exploits the insecure VNF API to dump the records of personal data from the database in an attempt to violate user privacy. Cloud Infrastructure operators should ensure that the applications APIs are secure, accessible over a secure network (TLS) under very strict set of security best practices, and RBAC policies to limit exposure of this vulnerability.
@@ -68,15 +58,10 @@ Previously attacks designed to place and migrate workload outside the legal boun
 
 The scope of the security controls requirements maps to the scope of the Reference Model architecture.
 
-The Reference Model scope is shown below (as outlined in chapter 1 of the reference model):
-
-<p align="center"><img src="../figures/ch09-etsi-nfv-architecture-mapping.png" alt="ETSI NFV architecture mapping" title="ETSI NFV architecture mapping" width="100%"/></p>
-<p align="center"><b>Figure 7-1:</b> ETSI NFV architecture mapping</p>
-
-This means that the security of the Reference Model requirements must cover the virtual resources (including the virtualisation layer), the hardware resources, and the VIM (Virtualised Infrastructure Manager).
-
+Cloud Infrastructure requirements must cover the virtual infrastructure layer and the hardware infrastructure layer, including virtual resources, hardware resources, virtual infrastructure manager and hardware infrastructure manager, as described in chapter 3.
+ 
 <a name="7.3.2"></a>
-### 7.3.2 Security Requirements
+### 7.3.2 High level security Requirements
 
 The following diagram shows the different security domains that impact the Reference Model:
 
@@ -97,7 +82,6 @@ At a high level, the following areas/requirements cover platform security for a 
 * Templated approved changes for automation where available
 * Typically well defined security framework documentation including approved deployment use cases
 * Infrastructure software update process
-* Identity Domain = platform
 
 <a name="7.3.2.2"></a>
 #### 7.3.2.2 Workload security requirements
@@ -109,11 +93,10 @@ At a high level, the following areas/requirements cover workload security for a 
 * Workload owner owns workload security certification process
 * Workload owner owns workload design change process
 * Workload owner owns workload software update process
-* Identity Domain = workload
   
 
 <a name="7.4"></a>
-## 7.4 Platform Security
+## 7.4 Cloud Infrastructure Security
 
 <a name="7.4.1"></a>
 ### 7.4.1 General Platform Security
@@ -136,7 +119,7 @@ The platform supports the workload, and in effect controls access to the workloa
 * **TENANT ACCESS CONTROLS** - Provides apropriate tenant access controls to specific platform services, and tenant workloads - including Role-Based Access Control (RBAC), authentication controls as approriate for the access arrangement, and Application Programming Interface (API) gateways for automated/script-driven processes.
 
 <a name="7.4.1.2"></a>
-#### 7.4.1.2 The following general security requirements apply to the platform
+#### 7.4.1.2 The following general security requirements apply to the Cloud Infrastructure
 
 * Restrict traffic to (and from) the workload to only traffic that is necessary, and deny all other traffic.
 * Provide protections between the Internet and any workloads including web and volumetrics attack preventions.
@@ -155,6 +138,7 @@ The platform supports the workload, and in effect controls access to the workloa
 * All production workloads must be separated from all non-production workloads including separation between non-hosted non-production external networks.
 * Where there are multiple hosting facilities used in provision of the service, network communications between facilities for the purpose of backup, management, and application communication are cryptographically protected in transit between data centre facilities.
 * Continuous cloud security compliance is mandatory.
+* Ensure that all the platform's components(including hypervisors, VMs, etc.) are kept up to date with the latest patch.
 * All data persisted to primary, replica, or backup storage is to be encrypted.
 * All platform security logs are to be time synchronised.
 * Logs are to be regularly scanned for events of interest.
@@ -183,10 +167,6 @@ The platform supports the workload, and in effect controls access to the workloa
 * Front-end network security at the application level will be the responsibility of the workload, however the platform must ensure the isolation and integrity of tenant connectivity to front-end networks.
 * The front-end network may provide (Distributed Denial Of Service) DDOS support.
 
-<a name="7.4.4"></a>
-### 7.4.4 Platform Patching
-
-Cloud Infrastructure operators should ensure that the platform including the components (hypervisors, VMs, etc.) are kept up to date with the latest patch.
 
 <a name="7.5"></a>
 ## 7.5 Workload Security - Vendor Responsibility
@@ -194,10 +174,13 @@ Cloud Infrastructure operators should ensure that the platform including the com
 <a name="7.5.1"></a>
 ### 7.5.1 Software Hardening
 
-* No hard-coded credentials/ clear text passwords
+* No hard-coded credentials or clear text passwords. Software should support configurable, or industry standard, password complexity rules
 * Software should be independent of the infrastructure platform (no OS point release dependencies to patch)
 * Software is code signed and all individual sub-components are assessed and verified for EULA violations
 * Software should have a process for discovery, classification, communication, and timely resolution of security vulnerabilities (i.e.; bug bounty, Penetration testing/scan findings, etc)
+* Software should support recognized encryption standards and encryption should be decoupled from software
+* Software should have support for configurable banners to display authorized use criteria/policy
+
 
 <a name="7.5.2"></a>
 ### 7.5.2 Port Protection
@@ -205,7 +188,7 @@ Cloud Infrastructure operators should ensure that the platform including the com
 * Unused software and unused network ports should be disabled by default
 
 <a name="7.5.3"></a>
-### 7.5.3 Software Code Quality
+### 7.5.3 Software Code Quality and Security
 
 * Vendors should use industry recognized software testing suites
   * Static and dynamic scanning
@@ -223,7 +206,7 @@ Cloud Infrastructure operators should ensure that the platform including the com
   <a name="7.5.5"></a>
 ### 7.5.5 Logging
 
-* (Logging output should support customizable Log retention and Log rotation)
+* Logging output should support customizable Log retention and Log rotation
 
   <a name="7.5.6"></a>
 ### 7.5.6 VNF images
@@ -233,9 +216,6 @@ Cloud Infrastructure operators should ensure that the platform including the com
   * Container Management
   * Immutability
 
-<a name="7.5.7"></a>
-### 7.5.7 Identity and Access Management
-
 <a name="7.5.8"></a>
 ### 7.5.8 CVEs and Vulnerability Management
 
@@ -244,24 +224,10 @@ Cloud Infrastructure operators should ensure that the platform including the com
 * Component analysis: Mechanisms to validate components of the platform stack by checking libraries and supporting code against the Common Vulnerabilities and Exposures (CVE) databases to determine whether the code contains any known vulnerabilities must be embedded into the NFVI architecture itself.  Some of the components required include:
   * Tools for checking common libraries against CVE databases integrated into the deployment and orchestration pipelines.
 
-<a name="7.5.9"></a>
-### 7.5.9 Encryption suite support
-* Software should support recognized encryption standards and encryption should be decoupled from software
-
-<a name="7.5.10"></a>
-### 7.5.10 Password complexity support
-
-* Software should support configurable, or industry standard, password complexity rules
-
- <a name="7.5.11"></a>
-### 7.5.11 Banner
-
-* Software should have support for configurable banners to display authorized use criteria/policy
-
 <a name="7.6"></a>
-## 7.6 Workload Security  - Operator Responsibility.
+## 7.6 Workload Security - Cloud Infrastructure Operator Responsibility.
 
-The Operator’s responsibility is to not only make sure that security is included in all the vendor supplied infrastructure and NFV components, but it is also responsible for the maintenance of the security functions from an operational and management perspective.   This includes but is not limited to securing the following elements:
+The Operator’s responsibility is to not only make sure that security is included in all the vendor supplied infrastructure and NFV components, but it is also responsible for the maintenance of the security functions from an operational and management perspective. This includes but is not limited to securing the following elements:
 
 * Maintaining standard security operational management methods and processes
 * Monitoring and reporting functions
@@ -274,9 +240,6 @@ The Operator’s responsibility is to not only make sure that security is includ
 
 Cloud Infrastructure operators must ensure that remote attestation methods are used to remotely verify the trust status of a given Cloud Infrastructure platform.  The basic concept is based on boot integrity measurements leveraging the Trusted Platform Module (TPM) built into the underlying hardware. Remote attestation can be provided as a service, and may be used by either the platform owner or a consumer/customer to verify that the platform has booted in a trusted manner. Practical implementations of the remote attestation service include the open cloud integrity tool (Open CIT).   Open CIT provides ‘Trust’ visibility of the cloud infrastructure and enables compliance in cloud datacenters by establishing the root of trust and builds the chain of trust across hardware, operating system, hypervisor, VM, and container.  It includes asset tagging for location and boundary control. The platform trust and asset tag attestation information is used by Orchestrators and/or Policy Compliance management to ensure workloads are launched on trusted and location/boundary compliant platforms. They provide the needed visibility and auditability of infrastructure in both public and private cloud environments.
 
-Insert diagram here:
-https://01.org/sites/default/files/users/u26957/32_architecture.png
-
 <a name="7.6.2"></a>
 ### 7.6.2 Workload Image Scanning / Signing
 
@@ -284,39 +247,23 @@ It is easy to tamper with workload images. It requires only a few seconds to ins
 
 Use of Image scanners such as OpenSCAP to determine security vulnerabilities is strongly recommended.
 
-<a name="7.7"></a>
-## 7.7 Application Vendors responsibility
-
-The application vendors need to incorporate security elements to support the highest level of security of the networks they support.  This includes but is not limited to securing the following elements:
-
-* Operating system or container
-* Application
-* Network interfaces
-* Management and controller systems used to support the VNFs directly, examples include a SIEM system or a SD WAN policy manager
-* Regulatory compliance failure as it relates to the application itself only
-
-<a name="7.8"></a>
-## 7.8 Cloud Infrastructure vendors and Cloud Infrastructure Manager vendors responsibility
-
-The Cloud Infrastructure vendors and Cloud Infrastructure Manager vendors need to ensure security of the infrastructure they support and manage. 
-
-<a name="7.8.1"></a>
-### 7.8.1 Networking Security Zoning
+<a name="7.6.3"></a>
+### 7.6.3 Networking Security Zoning
 
 Network segmentation is important to ensure that VMs can only communicate with the VMs they are supposed to. To prevent a VM from impacting other VMs or hosts, it is a good practice to separate VM traffic and management traffic. This will prevent attacks by VMs breaking into the management infrastructure. It is also best to separate the VLAN traffic into appropriate groups and disable all other VLANs that are not in use. Likewise, VMs of similar functionalities can be grouped into specific zones and their traffic isolated. Each zone can be protected using access control policies and a dedicated firewall based on the needed security level.
 
 Recommended practice to set network security policies following the principle of least privileged, only allowing approved protocol flows. For example, set 'default deny' inbound and add approved policies required for the functionality of the application running on the NFVI infrastructure.
 
-<a name="7.8.2"></a>
-### 7.8.2 Volume Encryption
+<a name="7.6.4"></a>
+### 7.6.4 Volume Encryption
 
 Virtual volume disks associated with workloads may contain sensitive data. Therefore, they need to be protected. Best practice is to secure the workload volumes by encrypting them and storing the cryptographic keys at safe locations. Be aware that the decision to encrypt the volumes might cause reduced performance, so the decision to encrypt needs to be dependent on the requirements of the given infrastructure.  The TPM module can also be used to securely store these keys. In addition, the hypervisor should be configured to securely erase the virtual volume disks in the event of application crashes or is intentionally destroyed to prevent it from unauthorized access.
 
 
-<a name="7.8.3"></a>
-### 7.8.3 Root of Trust for Measurements (RTM)
+<a name="7.6.5"></a>
+### 7.6.5 Root of Trust for Measurements (RTM)
 
-The sections that follow define mecahnisms to ensure the integrity of the infrastructure pre-boot and post-boot (running). The following defines a set of terms used in those sections.
+The sections that follow define mechanisms to ensure the integrity of the infrastructure pre-boot and post-boot (running). The following defines a set of terms used in those sections.
 
 -  The hardware root of trust helps with the pre-boot and post-boot security issues. 
 
@@ -328,12 +275,12 @@ The sections that follow define mecahnisms to ensure the integrity of the infras
 
 -  Core Root of Trust for Measurements (CRTM) is a set of instructions executed when performing RTM.
 
--  Platform Attestation provides proof of validity of the platform’s integrity measurements. Please see Section [7.7.1 Remote Attestation/openCIT](#7.7.1) 
+-  Platform Attestation provides proof of validity of the platform’s integrity measurements. Please see Section [7.6.1 Remote Attestation/openCIT](#7.6.1) 
 
 Values stored in a PCR cannot be reset (or forged) as they can only be extended. Whenever a measurement is sent to a TPM, the hash of the concatenation of the current value of the PCR and the new measurement is stored in the PCR. The PCR values are used to encrypt data.  If the proper environment is not loaded which will result in different PCR values, the TPM will be unable to decrypt the data.  
  
-<a name="7.8.4"></a>
-### 7.8.4 Static Root of Trust for Measurement (SRTM)
+<a name="7.6.5.1"></a>
+#### 7.6.5.1 Static Root of Trust for Measurement (SRTM)
 
 Static RTM (SRTM) begins with measuring and verifying the integrity of the BIOS firmware. It then measures additional firmware modules, verifies their integrity, and adds each component’s measure to an SRTM value. The final value represents the expected state of boot path loads. SRTM stores results as one or more values stored in PCR storage. In SRTM, the CRTM resets PCRs 0 to 15 only at boot.
 
@@ -350,8 +297,8 @@ Cloud Infrastructure operators should ensure that OS kernel measurements can be 
 
 The validation of the platform measurements can be performed by TPM’s launch control policy (LCP) or through the remote attestation server.
 
-<a name="7.8.5"></a>
-### 7.8.5 Dynamic Root of Trust for Measurement (DRTM)
+<a name="7.6.5.2"></a>
+#### 7.6.5.2 Dynamic Root of Trust for Measurement (DRTM)
 In Dynamic Root of Trust for Measurement (DRTM), the RTM for the running environment are stored in PCRs starting with PCR 17. 
 
 If a remote attestation server is used to monitor platform integrity, the operators should ensure that attestation is performed periodically or in a timely manner.
@@ -360,8 +307,8 @@ Additionally, platform monitoring can be extended to monitor the integrity of th
 The static filesystem includes a set of important files and folders which do not change between reboots during the lifecycle of the platform.
 This allows the attestation server to detect any tampering with the static filesystem during the runtime of the platform.
 
-<a name="7.9"></a>
-## 7.9 Common security standards
+<a name="7.7"></a>
+## 7.7 Common security standards
 
 The Cloud Infrastructure reference model and the supporting architectures are not only required to optimally support networking functions, but they must be designed with common security principles and standards from inception.  These best practices must be applied at all layers of the infrastructure stack and across all points of interconnections with outside networks, APIs and contact points with the NFV network functions overlaying or interacting with that infrastructure.
 Standards organizations with recommendations and best practices, and certifications that need to be taken into consideration include the following examples. However this is by no means an exhaustive list, just some of the more important standards in current use.
@@ -389,11 +336,11 @@ A good place to start to understand the requirements is to use the widely accept
 Additional Cloud Infrastructure security principles that need to be incorporated:
 * Authenticity – The ability to confirm the users are in fact valid users with the correct rights to access the systems or data.
 
-<a name="7.10"></a>
-## 7.10 Testing & certification
+<a name="7.8"></a>
+## 7.8 Testing & certification
 
-<a name="7.10.1"></a>
-### 7.10.1 Testing demarcation points
+<a name="7.8.1"></a>
+### 7.8.1 Testing demarcation points
 
 It is not enough to just secure all potential points of entry and hope for the best, any Cloud Infrastructure architecture must be able to be tested and validated that it is in fact protected from attack as much as possible. The ability to test the infrastructure for vulnerabilities on a continuous basis is critical for maintaining the highest level of security possible.  Testing needs to be done both from the inside and outside of the systems and networks.  Below is a small sample of some of the testing methodologies and frameworks available.
 
@@ -420,8 +367,8 @@ It is not enough to just secure all potential points of entry and hope for the b
 Insuring that the security standards and best practices are incorporated into the Cloud Infrastructure and architectures must be a shared responsibility, among the Telecommunications operators interested in building and maintaining the infrastructures in support of their services, the application vendors developing the network services that will be consumed by the operators, and the Cloud Infrastructure vendors creating the infrastructures for their Telecommunications customers.  All of the parties need to incorporate security and testing components, and maintain operational processes and procedures to address any security threats or incidents in an appropriate manner.  Each of the stakeholders need to contribute their part to create effective security for the Cloud Infrastructure.
 
 
-<a name="7.10.2"></a>
-### 7.10.2 Certification requirements (Just ideas)
+<a name="7.8.2"></a>
+### 7.8.2 Certification requirements (Just ideas)
 
 * Security test cases executed and test case results
 * Industry standard compliance achieved (NIST, ISO, PCI, FedRAMP Moderate etc.)
@@ -432,11 +379,11 @@ Insuring that the security standards and best practices are incorporated into th
 * Any additional Security and Privacy requirements implemented in the software deliverable beyond the default rules used security analysis tools
 * Resiliency tests run (such as hardware failures or power failure tests)
 
-<a name="7.11"></a>
-## 7.11 Consolidated Security Requirements
+<a name="7.9"></a>
+## 7.9 Consolidated Security Requirements
 
-<a name="7.11.1"></a>
-### 7.11.1. System Hardening
+<a name="7.9.1"></a>
+### 7.9.1. System Hardening
 
 |  Ref | Requirement  | Definition/Note  |
 |-------|------|-------|
@@ -455,8 +402,8 @@ Insuring that the security standards and best practices are incorporated into th
 | req.sec.gen.013 | The Platform **must** ensure that only authorized actors have logical access to the underlying infrastructure | |
 | req.sec.gen.014 | All servers part of Cloud Infrastructure **should** support measured boot and an attestation server that monitors the measurements of the servers | |
 
-<a name="7.11.21"></a>
-###  7.11.2. Platform and Access
+<a name="7.9.2"></a>
+###  7.9.2. Platform and Access
 
 Ref | Requirement | Definition/Note |
 |-------|-------|---------|
@@ -476,8 +423,8 @@ Ref | Requirement | Definition/Note |
 | req.sec.sys.013 | The Platform **must** provide secrets dynamically as and when needed | |
 | req.sec.sys.014 | The Platform **should** use Linux Security Modules such as SELinux to control access to resources | |
 
-<a name="7.11.3"></a>
-### 7.11.3. Confidentiality and Integrity
+<a name="7.9.3"></a>
+### 7.9.3. Confidentiality and Integrity
 
 | Ref | Requirement | Definition/Note |
 |---|----|----|
@@ -490,8 +437,8 @@ Ref | Requirement | Definition/Note |
 | req.sec.ci.007 | The Platform **must not** allow Memory Inspection by any actor other than the authorized actors for the Entity to which Memory is assigned (e.g., tenants owning the workload), for Lawful Inspection, and by secure monitoring services | Admin access must be carefully regulated |
 | req.sec.ci.008 | The Cloud Infrastructure **must** support tenant networks segregation | |
 
-<a name="7.11.4"></a>
-### 7.11.4. Workload Security
+<a name="7.9.4"></a>
+### 7.9.4. Workload Security
 
 | Ref | Requirement | Definition/Note |
 |---|----|----|
@@ -504,7 +451,7 @@ Ref | Requirement | Definition/Note |
 | req.sec.wl.007 | The Operator **should** implement processes and tools to verify VNF authenticity and integrity |  |
 
 <a name="7.11.5"></a>
-### 7.11.5. Image Security
+### 7.9.5. Image Security
 
 | Ref | Requirement | Definition/Note |
 |---|----|----|
@@ -516,8 +463,8 @@ Ref | Requirement | Definition/Note |
 | req.sec.img.006 | Image Registries **must** only be accessible over secure networks |  |
 | req.sec.img.007 | Image registries **must** be clear of vulnerable and stale (out of date) versions |  |
 
-<a name="7.11.6"></a>
-### 7.11.6. Security LCM
+<a name="7.9.6"></a>
+### 7.9.6. Security LCM
 
 | Ref | Requirement | Definition/Note |
 |---|----|----|
@@ -533,8 +480,8 @@ Ref | Requirement | Definition/Note |
 | req.sec.lcm.010 | The Platform **must** log all changes to geolocation along with the mechanisms and sources of location information (i.e. GPS, IP block, and timing) |  |
 | req.sec.lcm.011 | The Platform **must** implement Security life cycle management processes including proactively update and patch all deployed Cloud Infrastructure software | |
 
-<a name="7.11.7"></a>
-### 7.11.7. Monitoring and Security Audit
+<a name="7.9.7"></a>
+### 7.9.7. Monitoring and Security Audit
 
 The Platform is assumed to provide configurable alerting and notification capability and the operator is assumed to have automated systems, policies and procedures to act on alerts and notifications in a timely fashion. In the following the monitoring and logging capabilities can trigger alerts and notifications for appropriate action.
 
@@ -558,8 +505,8 @@ The Platform is assumed to provide configurable alerting and notification capabi
 | req.sec.mon.016 | The Platform Monitoring components should follow security best practices for auditing, including secure logging and tracing | |
 | req.sec.lcm.017 | The Platform must Audit systems for any missing security patches and take appropriate actions |  |
 
-<a name="7.11.8"></a>
-### 7.11.8. Compliance with Standards
+<a name="7.9.8"></a>
+### 7.9.8. Compliance with Standards
 
 | Ref | Requirement | Definition/Note |
 |---|----|---|
@@ -577,8 +524,8 @@ The Platform is assumed to provide configurable alerting and notification capabi
 | req.sec.std.017 | The Cloud Operator **should** conform to the ISO/IEC 27031 standard for business continuity  ISO/IEC 27031 - ISO/IEC 27031 is the international Standard for ICT readiness for business continuity |
 | req.sec.std.018 | The Public Cloud Operator **must**, and the Private Cloud Operator **may** be certified to be compliant with the International Standard on Awareness Engagements (ISAE) 3402 (in the US: SSAE 16) | International Standard on Awareness Engagements (ISAE) 3402. US Equivalent: SSAE16 |
 
-<a name="7.11.9"></a>
-### 7.11.9. References
+<a name="7.9.9"></a>
+### 7.9.9. References
 
 Network Functions Virtualisation (NFV);NFV Security; Problem Statement, ETSI GS NFV-SEC 001 V1.1.1 (2014-10)
 


### PR DESCRIPTION
Fixes #1881 
7.3.1 Alignment with terminology of chapter 3, ETSI figure removed (no longer in chapter 1)
"Platform" replaced by "Cloud Infrastructure" when possible
Merge of 'Platform Patching"section content within General security requirements
Merge of Software "Encryption, Password and Banner" content within Software Hardening
7.5.7 Identity and Access Mangament: empty section, removed
7.6 Workload security- Operator Responsability ->Workload security- Cloud Infrastructure Operator Responsability
7.7 Application vendor responsability, redundant content, section removed
Merge of content of "Cloud infra vendors and cloud infra manager vendors" ->Workload security- Cloud Infrastructure Operator Responsability