### PR TITLE
[RC2][RI1] Fix CNTT RC2 and RI1 versions

### DIFF
--- a/doc/ref_cert/RC2/README.md
+++ b/doc/ref_cert/RC2/README.md
@@ -16,7 +16,7 @@ This is the Kubernetes Based Reference Conformance (RC-2)
 | Bundle.Version    | Date          | Note
 | ---               | ---           | ---                   |
 | 0.0               | 15th May 2020 | First Initial Draft   |
-| 4.0-alpha         | 25th Sep 2020 | Baraque Release       |
+| 4.0               | 25th Sep 2020 | Baraque Release       |
 
 
 ## Overall Status

--- a/doc/ref_impl/cntt-ri/README.md
+++ b/doc/ref_impl/cntt-ri/README.md
@@ -17,7 +17,7 @@ This is the OPNFV based Reference Implementation (RI-1)
 | ---               | ---               | ---               |
 | 1.0-alpha         | 10th January 2020 | Snezka Release    |
 | 3.0-alpha         | 15th May 2020     | Baldy Release     |
-| 3.0               | 25th Sep 2020     | Baraque Release   |
+| 3.0-alpha         | 25th Sep 2020     | Baraque Release   |
 
 ## Overall Status
 


### PR DESCRIPTION
CNTT RC2 works well and is already in-use in Orange RFP [1].
-alpha is falsy misleading the endusers about its quality.

CNTT RI1 has never been executed in OPNFV since Jun 9, 2020.
The last run deploys OpenStack Ocata which is far from Train as
expected by CNTT RA1 (it should be noted that RI1 was alpha in Baldy
for the same OpenStack version.

[1] http://testresults.opnfv.org/functest/rfp/

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>