### PR TITLE
[RA2 Ch4]: Clarifications of differences between CNI multiplexers

### DIFF
--- a/doc/ref_arch/kubernetes/chapters/chapter04.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter04.md
@@ -162,19 +162,19 @@ Architecture they must be implemented as per the following specifications:
 | Requirement | Support in Multus | Support in DANM |
 |-------------|-------------------|-----------------|
 | The overlay network encapsulation protocol needs to enable ECMP in the underlay (`infra.net.cfg.002`) | Supported via another CNI plugin | Supported via another CNI plugin |
-| NAT (`infra.net.cfg.003`) | Supported via another CNI plugin | Supported |
+| NAT less connectivity (`infra.net.cfg.003`) | Supported via another CNI plugin | Supported |
 | Security Groups (`infra.net.cfg.004`) | Not supported | Not supported <sub>1)<sub> |
 | SFC support (`infra.net.cfg.005`) | Not relevant | Not relevant |
 | Traffic patterns symmetry (`infra.net.cfg.006`) | Not relevant | Not relevant |
 | Network resiliency (`req.inf.ntw.01`) | Supported | Supported |
 | Centrally administrated and configured (`req.inf.ntw.03`) | Not supported | Partially suported |
-| Dual stack IPv4 and IPv6 for Kubernetes workloads (`req.inf.ntw.04`) | Supported via another CNI plugin | Suported |
+| Dual stack IPv4 and IPv6 for Kubernetes workloads (`req.inf.ntw.04`) | Automatic management of the IP allocation of IPv4 and IPv6 addresses requires additional components | Suported |
 | Integrating SDN controllers (`req.inf.ntw.05`) | Supported via another CNI plugin | Supported via another CNI plugin |
 | More than one networking solution (`req.inf.ntw.06`) | Supported | Supported |
 | Choose whether or not to deploy more than one networking solution (`req.inf.ntw.07`) | Supported | Supported |
 | Kubernetes network model (`req.inf.ntw.08`) | Supported via another CNI plugin | Supported via another CNI plugin |
 | Do not interfere with or cause interference to any interface or network it does not own (`req.inf.ntw.09`) | Supported | Supported |
-| Cluster wide coordination of IP address assignment (`req.inf.ntw.10`) | Supported via another CNI plugin | Supported |
+| Cluster wide coordination of IP address assignment (`req.inf.ntw.10`) | Automatic management of the IP allocation of IPv4 and IPv6 addresses requires additional components | Supported |
 
 <p align="center"><b>Table 4-5:</b> Comparision of CNI multiplexers/metaplugins</p>
 


### PR DESCRIPTION
Partially closes #1911 
As I propose in #1912 the differences between Multus and DANM should be more explained if we would like to allow the usage of both Multiplexers. 
I also think that we should list the gaps of Multus in the gaps chapter. 