### PR TITLE
[RI1][RC1][RC2] Get the Ansible collections when calling RC cookbooks.

### DIFF
--- a/doc/ref_cert/RC1/chapters/chapter04.md
+++ b/doc/ref_cert/RC1/chapters/chapter04.md
@@ -206,6 +206,7 @@ virtualenv functest
 . functest/bin/activate
 pip install ansible
 ansible-galaxy install collivier.xtesting
+ansible-galaxy collection install ansible.posix community.general community.grafana community.kubernetes
 git clone https://gerrit.opnfv.org/gerrit/functest functest-src
 (cd functest-src && git checkout -b stable/jerma origin/stable/jerma)
 ansible-playbook functest-src/ansible/site.cntt.yml

--- a/doc/ref_cert/RC2/chapters/chapter03.md
+++ b/doc/ref_cert/RC2/chapters/chapter03.md
@@ -37,6 +37,7 @@ virtualenv functest-kubernetes
 . functest-kubernetes/bin/activate
 pip install ansible
 ansible-galaxy install collivier.xtesting
+ansible-galaxy collection install ansible.posix community.general community.grafana community.kubernetes
 git clone https://gerrit.opnfv.org/gerrit/functest-kubernetes functest-kubernetes-src
 (cd functest-kubernetes-src && git checkout -b stable/kali origin/stable/kali)
 ansible-playbook functest-kubernetes-src/ansible/site.cntt.yml

--- a/doc/ref_impl/cntt-ri/chapters/chapter08.md
+++ b/doc/ref_impl/cntt-ri/chapters/chapter08.md
@@ -401,6 +401,7 @@ virtualenv functest
 . functest/bin/activate
 pip install ansible
 ansible-galaxy install collivier.xtesting
+ansible-galaxy collection install ansible.posix community.general community.grafana community.kubernetes
 git clone https://gerrit.opnfv.org/gerrit/functest functest-src
 (cd functest-src && git checkout -b stable/hunter origin/stable/hunter)
 ansible-playbook functest-src/ansible/site.yml
@@ -414,6 +415,7 @@ virtualenv functest
 . functest/bin/activate
 pip install ansible
 ansible-galaxy install collivier.xtesting
+ansible-galaxy collection install ansible.posix community.general community.grafana community.kubernetes
 git clone https://gerrit.opnfv.org/gerrit/functest functest-src
 (cd functest-src && git checkout -b stable/hunter origin/stable/hunter)
 ansible-playbook functest-src/ansible/site.cntt.yml


### PR DESCRIPTION
It's asked by latest Ansible versions as supported by the main
GNU/Linux distributions (>=2.9).

Please see https://github.com/ansible-collections/community.general

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>