### PR TITLE
Update RC2 to v1.20 and to Functest Leguer

### DIFF
--- a/doc/ref_cert/RC2/chapters/chapter02.md
+++ b/doc/ref_cert/RC2/chapters/chapter02.md
@@ -41,7 +41,7 @@ run by the Kubernetes community (under the aegis of the CNCF).
 CNTT shares the same goal to give end users the confidence that when they use
 a certified product they can rely on a high level of common functionality.
 Then CNTT RC2 starts with
-[the test case list](https://git.opnfv.org/functest-kubernetes/tree/docker/smoke/testcases.yaml?h=stable/kali#n23)
+[the test case list](https://git.opnfv.org/functest-kubernetes/tree/docker/smoke/testcases.yaml?h=stable/leguer#n23)
 defined by [K8s Conformance](https://github.com/cncf/k8s-conformance) which is
 expected to grow according to the ongoing requirement traceability:
 - focus: \[Conformance\]
@@ -51,7 +51,7 @@ expected to grow according to the ongoing requirement traceability:
 allows to perform Kubernetes API testing by iterating once the mainline
 [xrally-kubernetes](https://github.com/xrally/xrally-kubernetes) scenarios:
 
-[Functest xrally_kubernetes](http://artifacts.opnfv.org/functest-kubernetes/HTJLR3AVHUN6/functest-kubernetes-opnfv-functest-kubernetes-smoke-kali-xrally_kubernetes-run-153/xrally_kubernetes/xrally_kubernetes.html):
+[Functest xrally_kubernetes](http://artifacts.opnfv.org/functest-kubernetes/D8LBWLN718M8/functest-kubernetes-opnfv-functest-kubernetes-benchmarking-leguer-xrally_kubernetes_full-run-20/xrally_kubernetes_full/xrally_kubernetes_full.html):
 
 | Scenarios                                                          |
 |--------------------------------------------------------------------|
@@ -78,13 +78,13 @@ allows to perform Kubernetes API testing by iterating once the mainline
 | Kubernetes.create_scale_and_delete_statefulset                     |
 | Kubernetes.list_namespaces                                         |
 
-The following software versions are considered to verify Kubernetes v1.19
+The following software versions are considered to verify Kubernetes v1.20
 (latest stable release) selected by CNTT:
 
 | software                | version     |
 |-------------------------|-------------|
-| Functest                | kali        |
-| Kubernetes              | v1.19       |
+| Functest                | leguer      |
+| Kubernetes              | v1.20       |
 | xrally-kubernetes       | 1.1.1.dev12 |
 
 ### Kubernetes API benchmarking
@@ -92,9 +92,9 @@ The following software versions are considered to verify Kubernetes v1.19
 [Rally](https://github.com/openstack/rally) is a tool and framework that
 performs Kubernetes API benchmarking.
 
-[Functest Kubernetes Benchmarking](https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking/testcases.yaml?h=stable%2Fkali)
+[Functest Kubernetes Benchmarking](https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking/testcases.yaml?h=stable%2Fleguer)
 proposed a Rally-based test case,
-[xrally_kubernetes_full](http://artifacts.opnfv.org/functest-kubernetes/LCY61RV15EX7/functest-kubernetes-opnfv-functest-kubernetes-benchmarking-kali-xrally_kubernetes_full-run-4/xrally_kubernetes_full/xrally_kubernetes_full.html),
+[xrally_kubernetes_full](http://artifacts.opnfv.org/functest-kubernetes/D8LBWLN718M8/functest-kubernetes-opnfv-functest-kubernetes-benchmarking-leguer-xrally_kubernetes_full-run-20/xrally_kubernetes_full/xrally_kubernetes_full.html),
 which iterates 10 times the mainline
 [xrally-kubernetes](https://github.com/xrally/xrally-kubernetes) scenarios.
 
@@ -102,9 +102,9 @@ At the time of writing, no KPI is defined in
 [Kubernetes based Reference Architecture](../../../ref_arch/kubernetes/chapters/chapter02.md)
 which would have asked for an update of the default SLA (maximum failure rate
 of 0%) proposed in
-[Functest Kubernetes Benchmarking](https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking/testcases.yaml?h=stable%2Fkali)
+[Functest Kubernetes Benchmarking](https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking/testcases.yaml?h=stable%2Fleguer)
 
-[Functest xrally_kubernetes_full](http://artifacts.opnfv.org/functest-kubernetes/LCY61RV15EX7/functest-kubernetes-opnfv-functest-kubernetes-benchmarking-kali-xrally_kubernetes_full-run-4/xrally_kubernetes_full/xrally_kubernetes_full.html):
+[Functest xrally_kubernetes_full](http://artifacts.opnfv.org/functest-kubernetes/D8LBWLN718M8/functest-kubernetes-opnfv-functest-kubernetes-benchmarking-leguer-xrally_kubernetes_full-run-20/xrally_kubernetes_full/xrally_kubernetes_full.html):
 
 | Scenarios                                                          | Iterations |
 |--------------------------------------------------------------------|:----------:|
@@ -131,19 +131,19 @@ of 0%) proposed in
 | Kubernetes.create_scale_and_delete_statefulset                     | 10         |
 | Kubernetes.list_namespaces                                         | 10         |
 
-The following software versions are considered to benchmark Kubernetes v1.19
+The following software versions are considered to benchmark Kubernetes v1.20
 (latest stable release) selected by CNTT:
 
 | software                | version     |
 |-------------------------|-------------|
-| Functest                | kali        |
+| Functest                | leguer      |
 | xrally-kubernetes       | 1.1.1.dev12 |
 
 ### Security testing
 
 There are a couple of opensource tools that help securing the Kubernetes stack.
 Amongst them,
-[Functest Kubernetes Security](https://git.opnfv.org/functest-kubernetes/tree/docker/security/testcases.yaml?h=stable%2Fkali)
+[Functest Kubernetes Security](https://git.opnfv.org/functest-kubernetes/tree/docker/security/testcases.yaml?h=stable%2Fleguer)
 offers two test cases based on
 [kube-hunter](https://github.com/aquasecurity/kube-hunter) and
 [kube-bench](https://github.com/aquasecurity/kube-bench).
@@ -172,14 +172,14 @@ are defined as mandatory (e.g. sec.std.001: The Cloud Operator **should**
 comply with Center for Internet Security CIS Controls) else it would have
 required an update of the default kube-bench behavior (all failures and
 warnings are only printed) as integrated in
-[Functest Kubernetes Security](https://git.opnfv.org/functest-kubernetes/tree/docker/security/testcases.yaml?h=stable%2Fkali).
+[Functest Kubernetes Security](https://git.opnfv.org/functest-kubernetes/tree/docker/security/testcases.yaml?h=stable%2Fleguer).
 
-The following software versions are considered to verify Kubernetes v1.19
+The following software versions are considered to verify Kubernetes v1.20
 (latest stable release) selected by CNTT:
 
 | software                | version     |
 |-------------------------|-------------|
-| Functest                | kali        |
+| Functest                | leguer      |
 | kube-hunter             | 0.3.1       |
 | kube-bench              | 0.3.1       |
 
@@ -195,12 +195,12 @@ via kubecltl and Helm. It's worth mentioning that this CNF is covered by the
 upstream tests (see
 [clearwater-live-test](https://github.com/Metaswitch/clearwater-live-test)).
 
-The following software versions are considered to verify Kubernetes v1.19
+The following software versions are considered to verify Kubernetes v1.20
 (latest stable release) selected by CNTT:
 
 | software                | version     |
 |-------------------------|-------------|
-| Functest                | kali        |
+| Functest                | leguer      |
 | clearwater              | release-130 |
 | Helm                    | v3.3.1      |
 
@@ -208,13 +208,13 @@ The following software versions are considered to verify Kubernetes v1.19
 
 The following test case must pass as they are for Reference Conformance:
 
-| container                                   | test case              | criteria | requirements                          |
-|---------------------------------------------|------------------------|:--------:|---------------------------------------|
-| opnfv/functest-kubernetes-smoke:kali        | k8s_conformance        | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:kali        | xrally_kubernetes      | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-security:kali     | kube_hunter            | PASS     | Security testing                      |
-| opnfv/functest-kubernetes-security:kali     | kube_bench_master      | PASS     | Security testing                      |
-| opnfv/functest-kubernetes-security:kali     | kube_bench_node        | PASS     | Security testing                      |
-| opnfv/functest-kubernetes-benchmarking:kali | xrally_kubernetes_full | PASS     | Kubernetes API benchmarking           |
-| opnfv/functest-kubernetes-cnf:kali          | k8s_vims               | PASS     | Opensource CNF onboarding and testing |
-| opnfv/functest-kubernetes-cnf:kali          | helm_vims              | PASS     | Opensource CNF onboarding and testing |
+| container                                     | test case              | criteria | requirements                          |
+|-----------------------------------------------|------------------------|:--------:|---------------------------------------|
+| opnfv/functest-kubernetes-smoke:leguer        | k8s_conformance        | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-smoke:leguer        | xrally_kubernetes      | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-security:leguer     | kube_hunter            | PASS     | Security testing                      |
+| opnfv/functest-kubernetes-security:leguer     | kube_bench_master      | PASS     | Security testing                      |
+| opnfv/functest-kubernetes-security:leguer     | kube_bench_node        | PASS     | Security testing                      |
+| opnfv/functest-kubernetes-benchmarking:leguer | xrally_kubernetes_full | PASS     | Kubernetes API benchmarking           |
+| opnfv/functest-kubernetes-cnf:leguer          | k8s_vims               | PASS     | Opensource CNF onboarding and testing |
+| opnfv/functest-kubernetes-cnf:leguer          | helm_vims              | PASS     | Opensource CNF onboarding and testing |

--- a/doc/ref_cert/RC2/chapters/chapter03.md
+++ b/doc/ref_cert/RC2/chapters/chapter03.md
@@ -39,7 +39,7 @@ pip install ansible
 ansible-galaxy install collivier.xtesting
 ansible-galaxy collection install ansible.posix community.general community.grafana community.kubernetes
 git clone https://gerrit.opnfv.org/gerrit/functest-kubernetes functest-kubernetes-src
-(cd functest-kubernetes-src && git checkout -b stable/kali origin/stable/kali)
+(cd functest-kubernetes-src && git checkout -b stable/leguer origin/stable/leguer)
 ansible-playbook functest-kubernetes-src/ansible/site.cntt.yml
 ```
 
@@ -55,13 +55,13 @@ under test in the following location on the machine running the cookbook:
 <a name="3.3"></a>
 ### 3.3 Run Kubernetes conformance suite
 
-Open http://127.0.0.1:8080/job/functest-kubernetes-kali-daily/ in a web
+Open http://127.0.0.1:8080/job/functest-kubernetes-leguer-daily/ in a web
 browser, login as admin/admin and click on "Build with Parameters" (keep the
 default values).
 
 If the System under test (SUT) is CNTT compliant, a link to the full archive
 containing all test results and artifacts will be printed in
-functest-kubernetes-kali-zip's console. Be free to download it and then to send
+functest-kubernetes-leguer-zip's console. Be free to download it and then to send
 it to any reviewer committee.
 
 To clean your working dir:

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -142,10 +142,10 @@ CNTT requirements about verification, validation, compliance, and conformance:
   for third-party conformance review
 
 Here are a couple of publicly available playbooks :
-- [Xtesting samples](https://git.opnfv.org/functest-xtesting/plain/ansible/site.yml?h=stable/kali)
-- [OpenStack verification](https://git.opnfv.org/functest/plain/ansible/site.yml?h=stable/kali)
+- [Xtesting samples](https://git.opnfv.org/functest-xtesting/plain/ansible/site.yml?h=stable/leguer)
+- [OpenStack verification](https://git.opnfv.org/functest/plain/ansible/site.yml?h=stable/leguer)
 - [CNTT RC1](https://git.opnfv.org/functest/plain/ansible/site.cntt.yml?h=stable/hunter)
-- [Kubernetes verification](https://git.opnfv.org/functest-kubernetes/plain/ansible/site.yml?h=stable/kali)
+- [Kubernetes verification](https://git.opnfv.org/functest-kubernetes/plain/ansible/site.yml?h=stable/leguer)
 
 [Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) only requires
 GNU/Linux as Operating System and asks for a few dependencies as described in


### PR DESCRIPTION
It's the last Kubernetes release before the CNTT release.
Functest Leguer is selected now according to k8s v1.20.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>