### PR TITLE
Add CNTT RCX as mandatory pipeline steps.

### DIFF
--- a/doc/ref_model/chapters/chapter09.md
+++ b/doc/ref_model/chapters/chapter09.md
@@ -193,14 +193,14 @@ For software deployment, as far as Cloud Infrastructure services or workloads ar
 - Build, package, test application/software
 - Store environment's parameters and configurations
 - Automate the delivery and deployment
- 
+
 The CI/CD pipeline is used to deploy, test and update the Cloud Infrastructure services, and also to onboard workloads hosted on the infrastructure. Typically, this business process consists of the following key phases:
 1. Tenant Engagement and Software Evaluation:
     - In this phase the request from the tenant to host a workload on the Cloud Infrastructure platform is assessed and a decision made on whether to proceed with the hosting request.
-    - If the Cloud infrastructure software needs to be updated or installed, an evaluation is made of the impacts (including to tenants) and if it is OK to proceed 
+    - If the Cloud infrastructure software needs to be updated or installed, an evaluation is made of the impacts (including to tenants) and if it is OK to proceed
     - This phase may also involve the tenant accessing a pre-staging environment to perform their own evaluation and/or pre-staging activities in preparation for later onboarding phases.
 2. Software Packaging:
-    - The main outcome of this phase is to produce the software deployable image and the deployment manifests (such as TOSCA blueprints or HEAT templates or Helm charts) that will define the Cloud Infrastructure service attributes. 
+    - The main outcome of this phase is to produce the software deployable image and the deployment manifests (such as TOSCA blueprints or HEAT templates or Helm charts) that will define the Cloud Infrastructure service attributes.
     - The software packaging can be automated or performed by designated personnel, through self-service capabilities (for tenants) or by the Cloud Infrastructure Operations team.
 3. Software Validation and Certification:
     - In this phase the software is deployed and tested to validate it against the service design and other Operator specific acceptance criteria, as required.
@@ -208,7 +208,7 @@ The CI/CD pipeline is used to deploy, test and update the Cloud Infrastructure s
 4. Publish Software:
     - Tenant Workloads: After the software is certified the final onboarding process phase is for it to be published to the Cloud Infrastructure production catalogue from where it can be instantiated on the Cloud Infrastructure platform by the tenant.
     - Cloud Infrastructure software: After the software is certified, it is scheduled for deployment inconcurrence with the user community.
-    
+
 All phases described above can be automated using technology specific toolsets and procedures.  Hence, details of such automation are left for the technology specific Reference Architecture and Reference Implementation specifications.
 
 <a name="9.5.2.2"></a>
@@ -218,19 +218,21 @@ The requirements including for CI/CD for ensuring software security scans, image
 Ref # | Description | Comments/Notes
 ---|---|---
 auto.cicd.001 | The CI/CD pipeline must support deployment on any cloud and cloud infrastructures including different hardware accelerators. | CI/CD pipelines automate CI/CD best practices into repeatable workflows for integrating code and configurations into builds, testing builds including validation against design and operator specific criteria, and delivery of the product onto a runtime environment.<br>Example of an open-source cloud native CI/CD framework is the Tekton project (https://tekton.dev/)
-auto.cicd.002 | The CI/CD pipelines must use event-driven task automation | 
-auto.cicd.003 | The CI/CD pipelines should avoid scheduling tasks | 
+auto.cicd.002 | The CI/CD pipelines must use event-driven task automation |
+auto.cicd.003 | The CI/CD pipelines should avoid scheduling tasks |
 auto.cicd.004 | The CI/CD pipeline is triggered by a new or updated software release being loaded into a repository | The software release cane be source code files, configuration files, images, manifests.<br>Operators may support a single or multiple repositories and may, thus, specify which repository is to be used for these release.<br>An example, of an open source repository is the CNCF Harbor (https://goharbor.io/)
-auto.cicd.005 | The CI pipeline must scan source code and manifests to validate for compliance with design and coding best practices. | 
-auto.cicd.006 | The CI pipeline must support build and packaging of images and deployment manifests from source code and configuration files. | 
+auto.cicd.005 | The CI pipeline must scan source code and manifests to validate for compliance with design and coding best practices. |
+auto.cicd.006 | The CI pipeline must support build and packaging of images and deployment manifests from source code and configuration files. |
 auto.cicd.007 | The CI pipeline must scan images and manifests to validate for compliance with security requirements.  | Refer to RM Chapter 07 (https://github.com/cntt-n/CNTT/blob/master/doc/ref_model/chapters/chapter07.md#79-consolidated-security-requirements).<br>Examples of such security requirements include only ingesting images, source code, configuration files, etc. only form trusted sources.
 auto.cicd.008 | The CI pipeline must validate images and manifests | Example, different tests
-auto.cicd.009 | The CI pipeline must validate with all hardware offload permutations and without hardware offload | 
+auto.cicd.009 | The CI pipeline must validate with all hardware offload permutations and without hardware offload |
 auto.cicd.010 | The CI pipeline must promote validated images and manifests to be deployable. | Example, promote from a development repository to a production repository
 auto.cicd.011 | The CD pipeline must verify and validate the tenant request | Example, RBAC, request is within quota limits, affinity/anti-affinity, …
 auto.cicd.012 | The CD pipeline after all validations must turn over control to orchestration of the software | |
 auto.cicd.013 | The CD pipeline must be able to deploy into Development, Test and Production environments | |
 auto.cicd.014 | The CD pipeline must be able to automatically promote software from Development to Test and Production environments | |
+auto.cicd.015 | The CI pipeline must run all relevant Reference Conformance test suites | |
+auto.cicd.016 | The CD pipeline must run all relevant Reference Conformance test suites | |
 
 <p align="center"><b>Table 9-4:</b> Automation CI/CD</p>
 
@@ -242,4 +244,3 @@ auto.cicd.014 | The CD pipeline must be able to automatically promote software f
 
 <a name="9.5.3.2"></a>
 #### 9.5.3.2. Tenant Networking Automation
-


### PR DESCRIPTION
In context of CNTT, we must expect CNTT RC1 and RC2 to pass to promote
software or to verify deployment.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>