### PR TITLE
Remove definition of PVP

### DIFF
--- a/doc/common/glossary.md
+++ b/doc/common/glossary.md
@@ -210,6 +210,4 @@ A **Container** provides operating-system-level virtualisation by abstracting th
 
 - **PM / Performance Measurement / Measurement:** The procedure or set of operations having the object of determining a Measured Value or Measurement Result. In this context, PMs reflect data generated and collected within the cloud infrastructure, that reflects the performance of the infrastructure. For example, a count of frames or packets traversing an interface, memory usage information, other resource usage and availability, etc. These data may be instantaneous or accumulated, and made available (i.e. exposed) based on permissions and contexts (e.g., workload vs. infra).
 
-- **PVP: Physical-Virtual-Physical:** PVP represents a workload test topology where a measurement is taken across two physical test points (e.g., physical NICs on a host), with traffic traversing a virtualized workload that is logically connected between the physical points. PVP is an ETSI term, defined in ETSI GS NFV-TST 009 [14].
-
 - **Virtualised Infrastructure Manager (VIM):** Responsible for controlling and managing the **Network Function Virtualisation Infrastructure** compute, storage and network resources.


### PR DESCRIPTION
PVP is one of the data-path topologies specified in TST009 for testing data-plane performance. Suggest the terminology section in this glossary either be comprehensive for all terms used in RM/RA/RI/RC ... OR ... to have more general terminology defined here and define/reference narrow terms such as PVP in the relevant Anuket spec (either in the text or in a "sub" glossary).  