### PR TITLE
[RM Ch05] Fix missing info from Section 5.2.3

### DIFF
--- a/doc/ref_model/chapters/chapter05.md
+++ b/doc/ref_model/chapters/chapter05.md
@@ -222,7 +222,7 @@ This section will detail Cloud Infrastructure Software Profiles and associated c
 | Reference         | Feature                   | Type              | Basic                           | Network Intensive |
 |-------------------|-----------------------------|-------------------|-------------------------------|-------------------|
 | infra.net.cfg.001 | Connection Point interface | IO virtualisation | virtio1.1                     | virtio1.1*        |
-| infra.net.cfg.002 | Overlay protocol          | Protocols         | VXLAN, MPLSoUDP, GENEVE, other |                   |
+| infra.net.cfg.002 | Overlay protocol          | Protocols         | VXLAN, MPLSoUDP, GENEVE, other | VXLAN, MPLSoUDP, GENEVE, other |
 | infra.net.cfg.003 | NAT                       | Yes/No            | Y                              | Y                 |
 | infra.net.cfg.004 | Security Group            | Yes/No            | Y                              | Y                 |
 | infra.net.cfg.005 | Service Function Chaining | Yes/No            | N                              | Y                 |


### PR DESCRIPTION
Fixes #2186 

infra.net.cfg.002 should have the same info for Basic as well as Network Intensive; this was present before the Table was edited