### PR TITLE
[RC2] Add SIG Testing traceability

### DIFF
--- a/doc/ref_cert/RC2/chapters/chapter02.md
+++ b/doc/ref_cert/RC2/chapters/chapter02.md
@@ -139,6 +139,33 @@ The following software versions are considered to benchmark Kubernetes v1.20
 | Functest                | leguer      |
 | xrally-kubernetes       | 1.1.1.dev12 |
 
+### SIG Testing
+
+The Reference Conformance suites must be stable and can be executed on real
+deployments. Then all the following labels are defacto skipped in
+[End-to-End Testing](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md):
+  - Disruptive
+  - Flaky
+  - alpha
+
+[End-to-End Testing](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md)
+basically respectivelly asks focus and fix regexes to select or to blacklist
+single tests:
+  - focus basically matches SIG
+  - skip matches the mandatory SIG labels listed in
+    [Reference Architecture-2 (RA-2)](../../../ref_arch/kubernetes/README.md)
+
+#### [API Machinery Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-api-machinery)
+
+focus: [sig-api-machinery]
+
+skip:
+  - [Disruptive]
+  - [Flaky]
+  - [alpha]
+  - [Feature:CrossNamespacePodAffinity]
+  - [Feature:StorageVersionAPI]
+
 ### Security testing
 
 There are a couple of opensource tools that help securing the Kubernetes stack.

--- a/doc/ref_cert/RC2/chapters/chapter02.md
+++ b/doc/ref_cert/RC2/chapters/chapter02.md
@@ -149,7 +149,7 @@ deployments. Then all the following labels are defacto skipped in
   - alpha
 
 [End-to-End Testing](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md)
-basically respectivelly asks focus and fix regexes to select or to blacklist
+basically respectively asks focus and fix regexes to select or to blacklist
 single tests:
   - focus basically matches SIG
   - skip matches the mandatory SIG labels listed in


### PR DESCRIPTION
It's the conterpart of "[RA2] Add Special Interest Group level
requirements" [1].

The other SIGS will be completed by additional pull requests.

[1] https://github.com/cntt-n/CNTT/pull/2332

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>