### PR TITLE
[RA2 Ch06] Add most of sigs in RA2 chapter 6

### DIFF
--- a/doc/ref_arch/kubernetes/chapters/chapter06.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter06.md
@@ -6,6 +6,14 @@
 ## Table of Contents
 * [6.1 Introduction](#6.1)
 * [6.2 API Machinery Special Interest Group](#6.2)
+* [6.3 Apps Special Interest Group](#6.3)
+* [6.4 Auth Special Interest Group](#6.4)
+* [6.5 CLI Special Interest Group](#6.5)
+* [6.6 Cluster Lifecycle Special Interest Group](#6.6)
+* [6.7 Instrumentation Special Interest Group](#6.7)
+* [6.8 Network Special Interest Group](#6.8)
+* [6.9 Node Special Interest Group](#6.9)
+* [6.10 Scheduling Special Interest Group](#6.10)
 
 <a name="6.1"></a>
 ## 6.1 Introduction
@@ -33,3 +41,115 @@ following Features tabs defined here.
 | Feature:PodPriority                    | X             |
 | Feature:ScopeSelectors                 | X             |
 | Feature:StorageVersionAPI              |               |
+
+<a name="6.3"></a>
+## 6.3 [Apps Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-apps)
+
+| **Labels**                   | **Mandatory** |
+|------------------------------|:-------------:|
+| Conformance                  | X             |
+| None                         | X             |
+| Feature:DaemonSetUpdateSurge |               |
+| Feature:IndexedJob           |               |
+| Feature:StatefulSet          |               |
+| Feature:StatefulUpgrade      |               |
+| Feature:SuspendJob           |               |
+| Feature:TaintEviction        |               |
+| Feature:TTLAfterFinished     | X             |
+
+<a name="6.4"></a>
+## 6.4 [Auth Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-auth)
+
+| **Labels**                             | **Mandatory** |
+|----------------------------------------|:-------------:|
+| Conformance                            | X             |
+| None                                   | X             |
+| Feature:BoundServiceAccountTokenVolume |               |
+| Feature:NodeAuthenticator              | X             |
+| Feature:NodeAuthorizer                 | X             |
+| Feature:PodSecurityPolicy              |               |
+| NodeFeature:FSGroup                    | X             |
+
+<a name="6.5"></a>
+## 6.5 [CLI Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-cli)
+
+| **Labels**  | **Mandatory** |
+|-------------|:-------------:|
+| Conformance | X             |
+| None        | X             |
+
+<a name="6.6"></a>
+## 6.6 [Cluster Lifecycle Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle)
+
+| **Labels**              | **Mandatory** |
+|-------------------------|:-------------:|
+| Conformance             | X             |
+| None                    | X             |
+| Feature:BootstrapTokens | X             |
+
+<a name="6.7"></a>
+## 6.7 [Instrumentation Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-instrumentation)
+
+| **Labels**                               | **Mandatory** |
+|------------------------------------------|:-------------:|
+| Conformance                              | X             |
+| None                                     | X             |
+| Feature:Elasticsearch                    |               |
+| Feature:StackdriverAcceleratorMonitoring |               |
+| Feature:StackdriverCustomMetrics         |               |
+| Feature:StackdriverExternalMetrics       |               |
+| Feature:StackdriverMetadataAgent         |               |
+| Feature:StackdriverMonitoring            |               |
+
+<a name="6.8"></a>
+## 6.8 [Network Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-network)
+
+| **Labels**                          | **Mandatory** |
+|-------------------------------------|:-------------:|
+| Conformance                         | X             |
+| None                                | X             |
+| Feature:Example                     |               |
+| Feature:Ingress                     |               |
+| Feature:IPv6DualStack               |               |
+| Feature:kubemci                     |               |
+| Feature:KubeProxyDaemonSetMigration |               |
+| Feature:KubeProxyDaemonSetUpgrade   |               |
+| Feature:NEG                         |               |
+| Feature:NoSNAT                      | X             |
+| Feature:Networking-IPv4             | X             |
+| Feature:Networking-IPv6             |               |
+| Feature:Networking-Performance      | X             |
+| Feature:NetworkPolicy               |               |
+| Feature:PerformanceDNS              | X             |
+| Feature:SCTP                        |               |
+| Feature:SCTPConnectivity            |               |
+
+<a name="6.9"></a>
+## 6.9 [Node Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-node)
+
+| **Labels**                                | **Mandatory** |
+|-------------------------------------------|:-------------:|
+| Conformance                               | X             |
+| None                                      | X             |
+| Feature:Example                           | X             |
+| Feature:ExperimentalResourceUsageTracking |               |
+| Feature:GPUUpgrade                        |               |
+| Feature:PodGarbageCollector               |               |
+| Feature:RegularResourceUsageTracking      |               |
+| Feature:ProbeTerminationGracePeriod       | X             |
+| NodeFeature:DownwardAPIHugePages          |               |
+| NodeFeature:PodReadinessGate              | X             |
+| NodeFeature:RuntimeHandler                |               |
+| NodeFeature:Sysctls                       | X             |
+
+
+<a name="6.10"></a>
+## 6.10 [Scheduling Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-scheduling)
+
+| **Labels**                            | **Mandatory** |
+|---------------------------------------|:-------------:|
+| Conformance                           | X             |
+| None                                  | X             |
+| Feature:GPUDevicePlugin               |               |
+| Feature:LocalStorageCapacityIsolation | X             |
+| Feature:Recreate                      |               |


### PR DESCRIPTION
It remains sig-storage which asks for a deep dive on both features
and drivers. As starting point, the features list conforms with the
upstream K8s gates (kind).

It allows RA2 team to update the mandatory choices which RC2 will
conform. It's worth mentioning that a few related test could be still
skipped in RC2 (only for gce, disruptive, alpha, etc.).

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>