### PR TITLE
[RA2 Ch3+Ch7] Add Memory Manager

### DIFF
--- a/doc/ref_arch/kubernetes/chapters/chapter03.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter03.md
@@ -189,8 +189,7 @@ For proper mapping of Huge Pages to scheduled pods, both need to have Huge Pages
 
 For some applications, Huge Pages
 should be allocated to account for consideration of the underlying HW topology.
-This newer feature is missing from Kubernetes, therefore a gap has been
-identified and added to [Chapter 6.2.8](./chapter06.md#628-hw-topology-aware-hugepages).
+[The Memory Manager](https://kubernetes.io/docs/tasks/administer-cluster/memory-manager/) (added to Kubernetes v1.21 as alpha feature) enables the feature of guaranteed memory and Huge Pages allocation for pods in the Guaranteed QoS class. The Memory Manager feeds the Topology Manager with hints for most suitable NUMA affinity.
 
 
 #### 3.2.1.4 Hardware Topology Management
@@ -199,7 +198,7 @@ Scheduling pods across NUMA boundaries can result in lower performance and highe
 
 Kubernetes supports Topology policy per node as beta feature ([documentation](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/)) and not per pod. The Topology Manager receives Topology information from Hint Providers which identify NUMA nodes (defined as server system architecture divisions of CPU sockets) and preferred scheduling. In the case of the pod with Guaranteed QoS class having integer CPU requests, the static CPU Manager policy would return topology hints relating to the exclusive CPU and the Device Manager would provide hints for the requested device.
 
-Memory or Huge Pages are not considered by the Topology Manager. This can be done by the operating system providing best-effort local page allocation for containers as long as there is sufficient free local memory on the node, or with Control Groups (cgroups) cpuset subsystem that can isolate memory to single NUMA node.
+If case that memory or Huge Pages are not considered by the Topology Manager, it can be done by the operating system providing best-effort local page allocation for containers as long as there is sufficient free local memory on the node, or with Control Groups (cgroups) cpuset subsystem that can isolate memory to single NUMA node.
 
 
 #### 3.2.1.5 Node Feature Discovery

--- a/doc/ref_arch/kubernetes/chapters/chapter07.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter07.md
@@ -106,7 +106,7 @@ Note: with an underlying IaaS this is possible, but then it introduces (undesira
 
 **Baseline project:** _Kubernetes v1.21_
 
-**Gap description:** Memory Manager was added in v1.21 as alpha feature, more in [3.2.1.3 Memory and Huge Pages Resources Management](chapter03.md#3213-memory-and-huge-pages-resources-management).
+**Gap description:** Memory Manager was added in v1.21 as alpha feature. More in [3.2.1.3 Memory and Huge Pages Resources Management](chapter03.md#3213-memory-and-huge-pages-resources-management).
 
 <a name="7.2.9"></a>
 ### 7.2.9 User namespaces in Kubernetes

--- a/doc/ref_arch/kubernetes/chapters/chapter07.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter07.md
@@ -102,11 +102,11 @@ Note: with an underlying IaaS this is possible, but then it introduces (undesira
 <a name="7.2.8"></a>
 ### 7.2.8 HW topology aware hugepages
 
-> **Related requirements:** `nfvi.com.cfg.004` and `nfvi.com.cfg.002`
+**Related requirements:** `nfvi.com.cfg.004` and `nfvi.com.cfg.002`
 
-> **Baseline project:** _Kubernetes v1.17_
+**Baseline project:** _Kubernetes v1.21_
 
-> **Gap description:** Allocation of hugepages from the same NUMA node as other resources of a Pod. To support this [cAdvisor needed a change to support NUMA](https://github.com/google/cadvisor/pull/2304). Changes in Kubernetes are planned to be implemented in the [Node Topology Manager](https://github.com/kubernetes/enhancements/issues/693).
+**Gap description:** Memory Manager was added in v1.21 as alpha feature, more in [3.2.1.3 Memory and Huge Pages Resources Management](chapter03.md#3213-memory-and-huge-pages-resources-management).
 
 <a name="7.2.9"></a>
 ### 7.2.9 User namespaces in Kubernetes


### PR DESCRIPTION
[Memory Manager](https://kubernetes.io/docs/tasks/administer-cluster/memory-manager/) was added in v1.21 (as alpha feature). Updated [3.2.1.3 Memory and Huge Pages Resources Management](https://github.com/cntt-n/CNTT/blob/master/doc/ref_arch/kubernetes/chapters/chapter03.md#3213-memory-and-huge-pages-resources-management), [3.2.1.4 Hardware Topology Management](https://github.com/cntt-n/CNTT/blob/master/doc/ref_arch/kubernetes/chapters/chapter03.md#3214-hardware-topology-management) and [7.2.8 HW topology aware hugepages](https://github.com/cntt-n/CNTT/blob/master/doc/ref_arch/kubernetes/chapters/chapter07.md#728-hw-topology-aware-hugepages).
Any guidance on alpha-level feature - please let me know.
Closes #2423 .