### PR TITLE
[RC1][RC2] Add --system-site-packages in virtualenv calls

### DIFF
--- a/doc/ref_cert/RC1/chapters/chapter04.md
+++ b/doc/ref_cert/RC1/chapters/chapter04.md
@@ -202,7 +202,7 @@ the network settings:
 
 To deploy your own CI toolchain running CNTT Compliance:
 ```bash
-virtualenv functest
+virtualenv functest --system-site-packages
 . functest/bin/activate
 pip install ansible
 ansible-galaxy install collivier.xtesting

--- a/doc/ref_cert/RC2/chapters/chapter03.md
+++ b/doc/ref_cert/RC2/chapters/chapter03.md
@@ -20,7 +20,6 @@ internet access, GNU/Linux as Operating System and asks for a few
 dependencies as described in
 [Deploy your own Xtesting CI/CD toolchains](https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004):
 - python-virtualenv
-- docker.io
 - git
 
 Please note the next two points depending on the GNU/Linux distributions and
@@ -33,13 +32,13 @@ the network settings:
 
 To deploy your own CI toolchain running CNTT Compliance:
 ```bash
-virtualenv functest-kubernetes
+virtualenv functest-kubernetes --system-site-packages
 . functest-kubernetes/bin/activate
 pip install ansible
 ansible-galaxy install collivier.xtesting
 ansible-galaxy collection install ansible.posix community.general community.grafana community.kubernetes community.docker community.postgresql
 git clone https://gerrit.opnfv.org/gerrit/functest-kubernetes functest-kubernetes-src
-(cd functest-kubernetes-src && git checkout -b stable/leguer origin/stable/leguer)
+(cd functest-kubernetes-src && git checkout -b stable/v1.21 origin/stable/v1.21)
 ansible-playbook functest-kubernetes-src/ansible/site.cntt.yml
 ```
 

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -153,7 +153,6 @@ Here are a couple of publicly available playbooks :
 GNU/Linux as Operating System and asks for a few dependencies as described in
 [Deploy your own Xtesting CI/CD toolchains](https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004):
 - python-virtualenv
-- docker.io
 - git
 
 Please note the next two points depending on the GNU/Linux distributions and

--- a/doc/ref_impl/cntt-ri/chapters/chapter08.md
+++ b/doc/ref_impl/cntt-ri/chapters/chapter08.md
@@ -397,13 +397,13 @@ toolchains in a few commands via
 
 To deploy the CI toolchain verifying OpenStack:
 ```bash
-virtualenv functest
+virtualenv functest --system-site-packages
 . functest/bin/activate
 pip install ansible
 ansible-galaxy install collivier.xtesting
 ansible-galaxy collection install ansible.posix community.general community.grafana community.kubernetes community.docker community.postgresql
 git clone https://gerrit.opnfv.org/gerrit/functest functest-src
-(cd functest-src && git checkout -b stable/hunter origin/stable/hunter)
+(cd functest-src && git checkout -b stable/jerma origin/stable/jerma)
 ansible-playbook functest-src/ansible/site.yml
 deactivate
 rm -rf functest-src functest
@@ -411,13 +411,13 @@ rm -rf functest-src functest
 
 To deploy the CI toolchain running CNTT Compliance:
 ```bash
-virtualenv functest
+virtualenv functest --system-site-packages
 . functest/bin/activate
 pip install ansible
 ansible-galaxy install collivier.xtesting
 ansible-galaxy collection install ansible.posix community.general community.grafana community.kubernetes community.docker community.postgresql
 git clone https://gerrit.opnfv.org/gerrit/functest functest-src
-(cd functest-src && git checkout -b stable/hunter origin/stable/hunter)
+(cd functest-src && git checkout -b stable/jerma origin/stable/jerma)
 ansible-playbook functest-src/ansible/site.cntt.yml
 deactivate
 rm -rf functest-src functest


### PR DESCRIPTION
It's now also manadatory in all Debian derivated distributions.

It also removes docker as dependendy (it's installed by the role) and
updates RC2 to leverage K8s stable/v1.21 branch (June release).

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>