### PR TITLE
[docs] Bumping version of commonmark to work with python3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ docutils==0.14
 mock==1.0.1
 pillow>=7.1.0
 alabaster>=0.7,<0.8,!=0.7.5
-commonmark==0.8.1
+commonmark==0.9.1
 recommonmark==0.6.0
 sphinx<2
 readthedocs-sphinx-ext<1.1


### PR DESCRIPTION
Bumping the version of commonmark to the lastest 0.9.1 to allow for
building the docs with python3.9

Signed-off-by: Georg Kunz <georg.kunz@ericsson.com>