### PR TITLE
[RC2] changing CNTT to Anuket

### DIFF
--- a/doc/ref_cert/RC2/chapters/chapter01.md
+++ b/doc/ref_cert/RC2/chapters/chapter01.md
@@ -14,7 +14,7 @@
 
 ## Executive Summary
 
-The Reference Conformance for the Kubernetes-based workstream (RC2) was established to ensure implementations of the CNTT Reference Architecture 2 (RA2), such as the Reference Implementation 2 (RI2), meet functional and performance requirements specified in RA2 and the CNTT Reference Model (RM). Cloud infrastructure and workload verification and validation will be utilised to evaluate **Conformance** (i.e. adherence) to the RA2 and RM requirements. Conformance scope includes:
+The Reference Conformance for the Kubernetes-based workstream (RC2) was established to ensure implementations of the Anuket Reference Architecture 2 (RA2), such as the Reference Implementation 2 (RI2), meet functional and performance requirements specified in RA2 and the Anuket Reference Model (RM). Cloud infrastructure and workload verification and validation will be utilised to evaluate **Conformance** (i.e. adherence) to the RA2 and RM requirements. Conformance scope includes:
 
  - Test cases, with traceability to requirements, to validate that the cloud infrastructure implementation meets the expected capabilities specified in RA-2 and that the workloads consume compliant cloud infrastructure resources
  - Verify, with requirements traceability, that the installation cookbooks (manifests) of RI-2 are in conformance with the RA-2 specifications (for example, software versions, plugins, and configurations)

--- a/doc/ref_cert/RC2/chapters/chapter02.md
+++ b/doc/ref_cert/RC2/chapters/chapter02.md
@@ -13,7 +13,7 @@ All of the requirements for RC2 have been defined in the Reference Model (RM) an
 - Enable clear traceability of the coverage of requirements across consecutive releases of this document
 - Clickable links from test cases to requirements
 - One or more tests for every MUST requirement
-- A set of test cases to serve as a template for Cloud Native OVP
+- A set of test cases to serve as a template for Anuket Assured
 
 ### Non-Goals
 - Defining any requirements
@@ -38,9 +38,9 @@ are insufficient. They are partially selected for the
 [Software Conformance Certification program](https://github.com/cncf/k8s-conformance)
 run by the Kubernetes community (under the aegis of the CNCF).
 
-CNTT shares the same goal to give end users the confidence that when they use
+Anuket shares the same goal to give end users the confidence that when they use
 a certified product they can rely on a high level of common functionality.
-Then CNTT RC2 starts with the test list defined by
+Then Anuket RC2 starts with the test list defined by
 [K8s Conformance](https://github.com/cncf/k8s-conformance) which is expected to
 grow according to the ongoing requirement traceability.
 
@@ -67,7 +67,7 @@ Conformance as per the rules.
 
 It must be noted that the default
 [K8s Conformance](https://github.com/cncf/k8s-conformance) testing is
-disruptive thus CNTT RC2 rather picks
+disruptive thus Anuket RC2 rather picks
 [non-disruptive-conformance](https://sonobuoy.io/docs/master/e2eplugin/)
 testing as defined by [Sonobuoy](https://sonobuoy.io/).
 
@@ -177,7 +177,7 @@ Network.should.set.TCP.CLOSE_WAIT.timeout are currently skipped because they
 haven't been covered successfully neither by
 [sig-release-1.21-blocking](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml)
 nor by
-[CNTT RC2 verification](https://build.opnfv.org/ci/view/functest-kubernetes/job/functest-kubernetes-v1.21-daily/22/)
+[Anuket RC2 verification](https://build.opnfv.org/ci/view/functest-kubernetes/job/functest-kubernetes-v1.21-daily/22/)
 
 focus: [sig-network]
 
@@ -304,7 +304,7 @@ of 0%) proposed in
 | Kubernetes.list_namespaces                                         | 10         |
 
 The following software versions are considered to benchmark Kubernetes v1.21
-(latest stable release) selected by CNTT:
+(latest stable release) selected by Anuket:
 
 | software                | version     |
 |-------------------------|-------------|
@@ -333,7 +333,7 @@ It should be noted that
 leverages [iperf](https://github.com/esnet/iperf) (both TCP and UDP modes) and
 [Netperf](https://github.com/HewlettPackard/netperf/).
 
-At the time of writing, no KPI is defined in CNTT chapters which would have
+At the time of writing, no KPI is defined in Anuket chapters which would have
 asked for an update of the default SLA proposed in
 [Functest Kubernetes Benchmarking](https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking?h=stable/v1.21).
 
@@ -373,7 +373,7 @@ warnings are only printed) as integrated in
 [Functest Kubernetes Security](https://git.opnfv.org/functest-kubernetes/tree/docker/security/testcases.yaml?h=stable%2Fv1.21).
 
 The following software versions are considered to verify Kubernetes v1.21
-(latest stable release) selected by CNTT:
+(latest stable release) selected by Anuket:
 
 | software                | version     |
 |-------------------------|-------------|
@@ -394,7 +394,7 @@ upstream tests (see
 [clearwater-live-test](https://github.com/Metaswitch/clearwater-live-test)).
 
 The following software versions are considered to verify Kubernetes v1.21
-(latest stable release) selected by CNTT:
+(latest stable release) selected by Anuket:
 
 | software                | version     |
 |-------------------------|-------------|

--- a/doc/ref_cert/RC2/chapters/chapter03.md
+++ b/doc/ref_cert/RC2/chapters/chapter03.md
@@ -11,8 +11,8 @@
 ## 3.1 Deploy your own conformance toolchain
 
 At the time of writing, the CI description file is hosted in Functest and only
-runs the containers selected by CNTT RC2. It will be completed by the
-next CNTT mandatory test cases and then a new CI description file will be
+runs the containers selected by Anuket RC2. It will be completed by the
+next Anuket mandatory test cases and then a new CI description file will be
 proposed in a shared tree.
 
 [Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) only requires
@@ -30,7 +30,7 @@ the network settings:
 - Proxy: you may set your proxy in env for Ansible and in systemd for Docker
   https://docs.docker.com/config/daemon/systemd/#httphttps-proxy
 
-To deploy your own CI toolchain running CNTT Compliance:
+To deploy your own CI toolchain running Anuket Compliance:
 ```bash
 virtualenv functest-kubernetes --system-site-packages
 . functest-kubernetes/bin/activate
@@ -58,7 +58,7 @@ Open http://127.0.0.1:8080/job/functest-kubernetes-v1.21-daily/ in a web
 browser, login as admin/admin and click on "Build with Parameters" (keep the
 default values).
 
-If the System under test (SUT) is CNTT compliant, a link to the full archive
+If the System under test (SUT) is Anuket compliant, a link to the full archive
 containing all test results and artifacts will be printed in
 functest-kubernetes-v1.21-zip's console. Be free to download it and then to send
 it to any reviewer committee.


### PR DESCRIPTION
This change replaces all occurances of CNTT and OVP with Anuket and
Anuket Assured.

Partially fixes #2501

Signed-off-by: Georg Kunz <georg.kunz@ericsson.com>