### PR TITLE
[RA2][RC2] Remove sig cli testing

### DIFF
--- a/doc/ref_arch/kubernetes/chapters/chapter06.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter06.md
@@ -8,13 +8,12 @@
 * [6.2 API Machinery Special Interest Group](#6.2)
 * [6.3 Apps Special Interest Group](#6.3)
 * [6.4 Auth Special Interest Group](#6.4)
-* [6.5 CLI Special Interest Group](#6.5)
-* [6.6 Cluster Lifecycle Special Interest Group](#6.6)
-* [6.7 Instrumentation Special Interest Group](#6.7)
-* [6.8 Network Special Interest Group](#6.8)
-* [6.9 Node Special Interest Group](#6.9)
-* [6.10 Scheduling Special Interest Group](#6.10)
-* [6.11 Storage Special Interest Group](#6.11)
+* [6.5 Cluster Lifecycle Special Interest Group](#6.5)
+* [6.6 Instrumentation Special Interest Group](#6.6)
+* [6.7 Network Special Interest Group](#6.7)
+* [6.8 Node Special Interest Group](#6.8)
+* [6.9 Scheduling Special Interest Group](#6.9)
+* [6.10 Storage Special Interest Group](#6.10)
 
 <a name="6.1"></a>
 ## 6.1 Introduction
@@ -72,15 +71,7 @@ following Features tabs defined here.
 | NodeFeature:FSGroup                    | X             | ServiceAccounts should set ownership and permission when RunAsUser or FsGroup is present |
 
 <a name="6.5"></a>
-## 6.5 [CLI Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-cli)
-
-| **Labels**                             | **Mandatory** | **Description** |
-|----------------------------------------|:-------------:|:----------------|
-| Conformance                            | X             | Kubernetes conformance test |
-| None                                   | X             | Kubernetes mainstream features |
-
-<a name="6.6"></a>
-## 6.6 [Cluster Lifecycle Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle)
+## 6.5 [Cluster Lifecycle Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle)
 
 | **Labels**              | **Mandatory** | **Description** |
 |-------------------------|:-------------:|:----------------|
@@ -88,8 +79,8 @@ following Features tabs defined here.
 | None                    | X             | Kubernetes mainstream features |
 | Feature:BootstrapTokens | X             | Should delete the token secret when the secret expired |
 
-<a name="6.7"></a>
-## 6.7 [Instrumentation Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-instrumentation)
+<a name="6.6"></a>
+## 6.6 [Instrumentation Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-instrumentation)
 
 | **Labels**                               | **Mandatory** | **Description** |
 |------------------------------------------|:-------------:|:----------------|
@@ -102,8 +93,8 @@ following Features tabs defined here.
 | Feature:StackdriverMetadataAgent         |               | Stackdriver Monitoring should run Stackdriver Metadata Agent |
 | Feature:StackdriverMonitoring            |               | |
 
-<a name="6.8"></a>
-## 6.8 [Network Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-network)
+<a name="6.7"></a>
+## 6.7 [Network Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-network)
 
 | **Labels**                          | **Mandatory** | **Description** |
 |-------------------------------------|:-------------:|:----------------|
@@ -125,8 +116,8 @@ following Features tabs defined here.
 | Feature:SCTP                        |               | should allow creating a basic SCTP service with pod and endpoints |
 | Feature:SCTPConnectivity            |               | Pods should function for intra-pod communication: sctp |
 
-<a name="6.9"></a>
-## 6.9 [Node Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-node)
+<a name="6.8"></a>
+## 6.8 [Node Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-node)
 
 | **Labels**                                | **Mandatory** | **Description** |
 |-------------------------------------------|:-------------:|:----------------|
@@ -143,8 +134,8 @@ following Features tabs defined here.
 | NodeFeature:RuntimeHandler                |               | RuntimeClass should run a Pod requesting a RuntimeClass with a configured handler |
 | NodeFeature:Sysctls                       | X             | Should not launch unsafe, but not explicitly enabled sysctls on the node |
 
-<a name="6.10"></a>
-## 6.10 [Scheduling Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-scheduling)
+<a name="6.9"></a>
+## 6.9 [Scheduling Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-scheduling)
 
 | **Labels**                            | **Mandatory** | **Description** |
 |---------------------------------------|:-------------:|:----------------|
@@ -154,8 +145,8 @@ following Features tabs defined here.
 | Feature:LocalStorageCapacityIsolation | X             | Validates local ephemeral storage resource limits of pods that are allowed to run |
 | Feature:Recreate                      |               | Run Nvidia GPU Device Plugin tests with a recreation |
 
-<a name="6.11"></a>
-## 6.11 [Storage Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-storage)
+<a name="6.10"></a>
+## 6.10 [Storage Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-storage)
 
 | **Labels**                            | **Mandatory** | **Description**                |
 |---------------------------------------|:-------------:|:-------------------------------|

--- a/doc/ref_cert/RC2/chapters/chapter02.md
+++ b/doc/ref_cert/RC2/chapters/chapter02.md
@@ -125,19 +125,6 @@ See [Auth Special Interest Group](https://github.com/kubernetes/community/tree/m
 and [Reference Architecture-2 (RA-2) Chapter 6](../../../ref_arch/kubernetes/chapters/chapter06.md)
 for more details.
 
-#### CLI Testing
-
-focus: [sig-cli]
-
-skip:
-  - [alpha]
-  - [Disruptive]
-  - [Flaky]
-
-See [CLI Special Interest Group](https://github.com/kubernetes/community/tree/master/sig-cli)
-and [Reference Architecture-2 (RA-2) Chapter 6](../../../ref_arch/kubernetes/chapters/chapter06.md)
-for more details.
-
 #### Cluster Lifecycle Testing
 
 focus: [sig-cluster-lifecycle]
@@ -416,8 +403,6 @@ The following test case must pass as they are for Reference Conformance:
 | opnfv/functest-kubernetes-smoke:v1.21         | sig_apps                 | PASS     | Kubernetes API testing                |
 | opnfv/functest-kubernetes-smoke:v1.21         | sig_apps_serial          | PASS     | Kubernetes API testing                |
 | opnfv/functest-kubernetes-smoke:v1.21         | sig_auth                 | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | sig_cli                  | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | sig_cli_serial           | PASS     | Kubernetes API testing                |
 | opnfv/functest-kubernetes-smoke:v1.21         | sig_cluster_lifecycle    | PASS     | Kubernetes API testing                |
 | opnfv/functest-kubernetes-smoke:v1.21         | sig_instrumentation      | PASS     | Kubernetes API testing                |
 | opnfv/functest-kubernetes-smoke:v1.21         | sig_network              | PASS     | Kubernetes API testing                |


### PR DESCRIPTION
SIG CLI focuses on kubectl testing which makes this tests out of scope.

It could make sens to run them anyway as they indirectly test the
infrastructure. But a few test could quickly fail:
- [sig-cli] Kubectl client Simple pod [It] should support exec through an HTTP proxy
- [sig-cli] Kubectl client Simple pod [It] should support exec through kubectl proxy

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>