### PR TITLE
[RA2][RC2] Disable Feature:PerformanceDNS

### DIFF
--- a/doc/ref_arch/kubernetes/chapters/chapter06.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter06.md
@@ -121,7 +121,7 @@ following Features tabs defined here.
 | Feature:Networking-IPv6             |               | Networking should provide Internet connection for containers |
 | Feature:Networking-Performance      | X             | run iperf2 |
 | Feature:NetworkPolicy               |               | NetworkPolicy between server and client should enforce policy to allow traffic only from a different namespace, based on NamespaceSelector |
-| Feature:PerformanceDNS              | X             | Should answer DNS query for maximum number of services per cluster |
+| Feature:PerformanceDNS              |               | Should answer DNS query for maximum number of services per cluster |
 | Feature:SCTP                        |               | should allow creating a basic SCTP service with pod and endpoints |
 | Feature:SCTPConnectivity            |               | Pods should function for intra-pod communication: sctp |
 

--- a/doc/ref_cert/RC2/chapters/chapter02.md
+++ b/doc/ref_cert/RC2/chapters/chapter02.md
@@ -194,6 +194,7 @@ skip:
   - [Feature:NEG]
   - [Feature:Networking-IPv6]
   - [Feature:NetworkPolicy]
+  - [Feature:PerformanceDNS]
   - [Feature:SCTP]
   - [Feature:SCTPConnectivity]
   - load.balancer


### PR DESCRIPTION
Its testing could quickly break the cluster [1][2] due to
etcdserver: mvcc: database space exceeded

[1] https://github.com/kubernetes/test-infra/pull/18956
[2] https://github.com/kubernetes/kubernetes/issues/94029

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>