### PR TITLE
[RA2][RC2] Update to K8s v1.22

### DIFF
--- a/doc/ref_arch/kubernetes/README.md
+++ b/doc/ref_arch/kubernetes/README.md
@@ -48,7 +48,7 @@ This is Kubernetes based Reference Architecture (RA-2)
 <a name="required-versions"></a>
 ## Required versions of most important components
 
-| Component | Required version(s) |
-| ----------|---------------------|
-| Kubernetes | 1.21 |
+| Component  | Required version(s) |
+| -----------|---------------------|
+| Kubernetes | 1.22                |
 

--- a/doc/ref_arch/kubernetes/chapters/chapter07.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter07.md
@@ -104,7 +104,7 @@ Note: with an underlying IaaS this is possible, but then it introduces (undesira
 
 **Related requirements:** `nfvi.com.cfg.004` and `nfvi.com.cfg.002`
 
-**Baseline project:** _Kubernetes v1.21_
+**Baseline project:** _Kubernetes v1.22_
 
 **Gap description:** Memory Manager was added in v1.21 as alpha feature. More in [3.2.1.3 Memory and Huge Pages Resources Management](chapter03.md#3213-memory-and-huge-pages-resources-management).
 
@@ -118,7 +118,7 @@ Note: with an underlying IaaS this is possible, but then it introduces (undesira
 | e.man.004   | Capability to isolate resources between tenants |
 | sec.sys.007 | The Platform must implement controls enforcing separation of duties and privileges, least privilege use and least common mechanism (Role-Based Access Control). |
 
-**Baseline project:** _Kubernetes v1.21_
+**Baseline project:** _Kubernetes v1.22_
 
 **Gap description:** Kubernetes does not support namespace scoped user IDs (UIDs). Therefore, when a container-based application requires system privileges the container either needs to run in privileged mode or the infrastructure needs to provide random system UIDs. Randomised UIDs result in errors when the application needs to set kernel capabilities (e.g.: in case of VLAN trunking) or when a Pod shares data with other Pods via persistent storage. The "privileged mode" solution is not secure while "random UID" solution is error prone, and therefore these techniques should not be used. Support for proper user namespaces in Kubernetes is [under discussion](https://github.com/kubernetes/enhancements/pull/2101).
 

--- a/doc/ref_cert/RC2/chapters/chapter02.md
+++ b/doc/ref_cert/RC2/chapters/chapter02.md
@@ -162,9 +162,9 @@ for more details.
 The regexes load.balancer, LoadBalancer and
 Network.should.set.TCP.CLOSE_WAIT.timeout are currently skipped because they
 haven't been covered successfully neither by
-[sig-release-1.21-blocking](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml)
+[sig-release-1.22-blocking](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml)
 nor by
-[Anuket RC2 verification](https://build.opnfv.org/ci/view/functest-kubernetes/job/functest-kubernetes-v1.21-daily/22/)
+[Anuket RC2 verification](https://build.opnfv.org/ci/view/functest-kubernetes/job/functest-kubernetes-v1.22-daily/8/)
 
 Please note that a couple of tests must be skipped by name below as they are no
 appropriate labels.
@@ -231,7 +231,7 @@ and [Reference Architecture-2 (RA-2) Chapter 6](../../../ref_arch/kubernetes/cha
 
 It should be noted that all in-tree driver testing, [Driver:+], is skipped.
 Conforming to
-[the upstream gate](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.21.yaml),
+[the upstream gate](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml),
 all PersistentVolumes NFS testing is also skipped.
 The following exclusions are about
 [the deprecated in-tree GitRepo volume type](https://github.com/kubernetes-sigs/kind/issues/2356):
@@ -269,9 +269,9 @@ and [Reference Architecture-2 (RA-2) Chapter 6](../../../ref_arch/kubernetes/cha
 [Rally](https://github.com/openstack/rally) is a tool and framework that
 performs Kubernetes API benchmarking.
 
-[Functest Kubernetes Benchmarking](https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking/testcases.yaml?h=stable%2Fv1.21)
+[Functest Kubernetes Benchmarking](https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking/testcases.yaml?h=stable%2Fv1.22)
 proposed a Rally-based test case,
-[xrally_kubernetes_full](http://artifacts.opnfv.org/functest-kubernetes/UFEMNKZPRBCO/functest-kubernetes-opnfv-functest-kubernetes-benchmarking-v1.21-xrally_kubernetes_full-run-16/xrally_kubernetes_full/xrally_kubernetes_full.html),
+[xrally_kubernetes_full](http://artifacts.opnfv.org/functest-kubernetes/96Y19H7RR0T5/functest-kubernetes-opnfv-functest-kubernetes-benchmarking-v1.22-xrally_kubernetes_full-run-3/xrally_kubernetes_full/xrally_kubernetes_full.html),
 which iterates 10 times the mainline
 [xrally-kubernetes](https://github.com/xrally/xrally-kubernetes) scenarios.
 
@@ -279,9 +279,9 @@ At the time of writing, no KPI is defined in
 [Kubernetes based Reference Architecture](../../../ref_arch/kubernetes/chapters/chapter02.md)
 which would have asked for an update of the default SLA (maximum failure rate
 of 0%) proposed in
-[Functest Kubernetes Benchmarking](https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking/testcases.yaml?h=stable%2Fv1.21)
+[Functest Kubernetes Benchmarking](https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking/testcases.yaml?h=stable%2Fv1.22)
 
-[Functest xrally_kubernetes_full](http://artifacts.opnfv.org/functest-kubernetes/UFEMNKZPRBCO/functest-kubernetes-opnfv-functest-kubernetes-benchmarking-v1.21-xrally_kubernetes_full-run-16/xrally_kubernetes_full/xrally_kubernetes_full.html):
+[Functest xrally_kubernetes_full](http://artifacts.opnfv.org/functest-kubernetes/96Y19H7RR0T5/functest-kubernetes-opnfv-functest-kubernetes-benchmarking-v1.22-xrally_kubernetes_full-run-3/xrally_kubernetes_full/xrally_kubernetes_full.html):
 
 | Scenarios                                                          | Iterations |
 |--------------------------------------------------------------------|:----------:|
@@ -308,12 +308,12 @@ of 0%) proposed in
 | Kubernetes.create_scale_and_delete_statefulset                     | 10         |
 | Kubernetes.list_namespaces                                         | 10         |
 
-The following software versions are considered to benchmark Kubernetes v1.21
+The following software versions are considered to benchmark Kubernetes v1.22
 (latest stable release) selected by Anuket:
 
 | software                | version     |
 |-------------------------|-------------|
-| Functest                | v1.21       |
+| Functest                | v1.22       |
 | xrally-kubernetes       | 1.1.1.dev12 |
 
 ### Dataplane benchmarking
@@ -340,13 +340,13 @@ leverages [iperf](https://github.com/esnet/iperf) (both TCP and UDP modes) and
 
 At the time of writing, no KPI is defined in Anuket chapters which would have
 asked for an update of the default SLA proposed in
-[Functest Kubernetes Benchmarking](https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking?h=stable/v1.21).
+[Functest Kubernetes Benchmarking](https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking?h=stable/v1.22).
 
 ### Security testing
 
 There are a couple of opensource tools that help securing the Kubernetes stack.
 Amongst them,
-[Functest Kubernetes Security](https://git.opnfv.org/functest-kubernetes/tree/docker/security/testcases.yaml?h=stable%2Fv1.21)
+[Functest Kubernetes Security](https://git.opnfv.org/functest-kubernetes/tree/docker/security/testcases.yaml?h=stable%2Fv1.22)
 offers two test cases based on
 [kube-hunter](https://github.com/aquasecurity/kube-hunter) and
 [kube-bench](https://github.com/aquasecurity/kube-bench).
@@ -375,14 +375,14 @@ are defined as mandatory (e.g. sec.std.001: The Cloud Operator **should**
 comply with Center for Internet Security CIS Controls) else it would have
 required an update of the default kube-bench behavior (all failures and
 warnings are only printed) as integrated in
-[Functest Kubernetes Security](https://git.opnfv.org/functest-kubernetes/tree/docker/security/testcases.yaml?h=stable%2Fv1.21).
+[Functest Kubernetes Security](https://git.opnfv.org/functest-kubernetes/tree/docker/security/testcases.yaml?h=stable%2Fv1.22).
 
-The following software versions are considered to verify Kubernetes v1.21
+The following software versions are considered to verify Kubernetes v1.22
 (latest stable release) selected by Anuket:
 
 | software                | version     |
 |-------------------------|-------------|
-| Functest                | v1.21       |
+| Functest                | v1.22       |
 | kube-hunter             | 0.3.1       |
 | kube-bench              | 0.3.1       |
 
@@ -398,12 +398,12 @@ via kubecltl and Helm. It's worth mentioning that this CNF is covered by the
 upstream tests (see
 [clearwater-live-test](https://github.com/Metaswitch/clearwater-live-test)).
 
-The following software versions are considered to verify Kubernetes v1.21
+The following software versions are considered to verify Kubernetes v1.22
 (latest stable release) selected by Anuket:
 
 | software                | version     |
 |-------------------------|-------------|
-| Functest                | v1.21       |
+| Functest                | v1.22       |
 | clearwater              | release-130 |
 | Helm                    | v3.3.1      |
 
@@ -413,25 +413,25 @@ The following test case must pass as they are for Reference Conformance:
 
 | container                                     | test case                | criteria | requirements                          |
 |-----------------------------------------------|--------------------------|:--------:|---------------------------------------|
-| opnfv/functest-kubernetes-smoke:v1.21         | xrally_kubernetes        | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | k8s_conformance          | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | k8s_conformance_serial   | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | sig_api_machinery        | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | sig_api_machinery_serial | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | sig_apps                 | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | sig_apps_serial          | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | sig_auth                 | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | sig_cluster_lifecycle    | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | sig_instrumentation      | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | sig_network              | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | sig_node                 | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | sig_scheduling_serial    | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | sig_storage              | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-smoke:v1.21         | sig_storage_serial       | PASS     | Kubernetes API testing                |
-| opnfv/functest-kubernetes-security:v1.21      | kube_hunter              | PASS     | Security testing                      |
-| opnfv/functest-kubernetes-security:v1.21      | kube_bench_master        | PASS     | Security testing                      |
-| opnfv/functest-kubernetes-security:v1.21      | kube_bench_node          | PASS     | Security testing                      |
-| opnfv/functest-kubernetes-benchmarking:v1.21  | xrally_kubernetes_full   | PASS     | Kubernetes API benchmarking           |
-| opnfv/functest-kubernetes-benchmarking:v1.21  | netperf                  | PASS     | Dataplane benchmarking                |
-| opnfv/functest-kubernetes-cnf:v1.21           | k8s_vims                 | PASS     | Opensource CNF onboarding and testing |
-| opnfv/functest-kubernetes-cnf:v1.21           | helm_vims                | PASS     | Opensource CNF onboarding and testing |
+| opnfv/functest-kubernetes-smoke:v1.22         | xrally_kubernetes        | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-smoke:v1.22         | k8s_conformance          | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-smoke:v1.22         | k8s_conformance_serial   | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-smoke:v1.22         | sig_api_machinery        | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-smoke:v1.22         | sig_api_machinery_serial | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-smoke:v1.22         | sig_apps                 | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-smoke:v1.22         | sig_apps_serial          | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-smoke:v1.22         | sig_auth                 | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-smoke:v1.22         | sig_cluster_lifecycle    | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-smoke:v1.22         | sig_instrumentation      | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-smoke:v1.22         | sig_network              | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-smoke:v1.22         | sig_node                 | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-smoke:v1.22         | sig_scheduling_serial    | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-smoke:v1.22         | sig_storage              | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-smoke:v1.22         | sig_storage_serial       | PASS     | Kubernetes API testing                |
+| opnfv/functest-kubernetes-security:v1.22      | kube_hunter              | PASS     | Security testing                      |
+| opnfv/functest-kubernetes-security:v1.22      | kube_bench_master        | PASS     | Security testing                      |
+| opnfv/functest-kubernetes-security:v1.22      | kube_bench_node          | PASS     | Security testing                      |
+| opnfv/functest-kubernetes-benchmarking:v1.22  | xrally_kubernetes_full   | PASS     | Kubernetes API benchmarking           |
+| opnfv/functest-kubernetes-benchmarking:v1.22  | netperf                  | PASS     | Dataplane benchmarking                |
+| opnfv/functest-kubernetes-cnf:v1.22           | k8s_vims                 | PASS     | Opensource CNF onboarding and testing |
+| opnfv/functest-kubernetes-cnf:v1.22           | helm_vims                | PASS     | Opensource CNF onboarding and testing |

--- a/doc/ref_cert/RC2/chapters/chapter03.md
+++ b/doc/ref_cert/RC2/chapters/chapter03.md
@@ -38,7 +38,7 @@ pip install ansible
 ansible-galaxy install collivier.xtesting
 ansible-galaxy collection install ansible.posix community.general community.grafana kubernetes.core community.docker community.postgresql
 git clone https://gerrit.opnfv.org/gerrit/functest-kubernetes functest-kubernetes-src
-(cd functest-kubernetes-src && git checkout -b stable/v1.21 origin/stable/v1.21)
+(cd functest-kubernetes-src && git checkout -b stable/v1.22 origin/stable/v1.22)
 ansible-playbook functest-kubernetes-src/ansible/site.cntt.yml
 ```
 
@@ -54,13 +54,13 @@ under test in the following location on the machine running the cookbook:
 <a name="3.3"></a>
 ### 3.3 Run Kubernetes conformance suite
 
-Open http://127.0.0.1:8080/job/functest-kubernetes-v1.21-daily/ in a web
+Open http://127.0.0.1:8080/job/functest-kubernetes-v1.22-daily/ in a web
 browser, login as admin/admin and click on "Build with Parameters" (keep the
 default values).
 
 If the System under test (SUT) is Anuket compliant, a link to the full archive
 containing all test results and artifacts will be printed in
-functest-kubernetes-v1.21-zip's console. Be free to download it and then to send
+functest-kubernetes-v1.22-zip's console. Be free to download it and then to send
 it to any reviewer committee.
 
 To clean your working dir:

--- a/doc/ref_cert/README.md
+++ b/doc/ref_cert/README.md
@@ -152,7 +152,7 @@ Here are a couple of publicly available playbooks :
 - [Xtesting samples](https://git.opnfv.org/functest-xtesting/plain/ansible/site.yml?h=stable/wallaby)
 - [OpenStack verification](https://git.opnfv.org/functest/plain/ansible/site.yml?h=stable/wallaby)
 - [Anuket RC1](https://git.opnfv.org/functest/plain/ansible/site.cntt.yml?h=stable/wallaby)
-- [Kubernetes verification](https://git.opnfv.org/functest-kubernetes/plain/ansible/site.yml?h=stable/v1.21)
+- [Kubernetes verification](https://git.opnfv.org/functest-kubernetes/plain/ansible/site.yml?h=stable/v1.22)
 
 [Xtesting CI](https://galaxy.ansible.com/collivier/xtesting) only requires
 GNU/Linux as Operating System and asks for a few dependencies as described in


### PR DESCRIPTION
CNTT RA2 follows the latest stable release.
It also takes into account the new Functest Kubernetes release [1]

[1] https://lists.anuket.io/g/anuket-tsc/message/517

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>