### PR TITLE
[RA2 Ch6] add api and feature policy to ra2 ch6

### DIFF
--- a/doc/ref_arch/kubernetes/chapters/chapter06.md
+++ b/doc/ref_arch/kubernetes/chapters/chapter06.md
@@ -55,7 +55,7 @@ The policy for RA2 to include Kubernetes APIs as mandatory is:
 
 The Kubernetes API reference is available [here](https://kubernetes.io/docs/reference/kubernetes-api/).
 
-The list of API groups that are mandatory is:
+The list of [API groups](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#-strong-api-groups-strong-) that are mandatory is:
 
 | Group                        | Version              |
 |------------------------------|----------------------|


### PR DESCRIPTION
closes #2440, #2341 

am not sure whether the API policy should read

`An API is mandatory when its version is either  Beta or Stable, and it can be traced to a RA2 component level specification or requirement (chapter 4 of this document).`

or just

`An API is mandatory when its version is either  Beta or Stable.`