### PR TITLE
[RM Ch 7.9.7] Monitoring for prod and non-prod

### DIFF
--- a/doc/ref_model/chapters/chapter07.md
+++ b/doc/ref_model/chapters/chapter07.md
@@ -629,7 +629,7 @@ The Platform is assumed to provide configurable alerting and notification capabi
 | req.sec.mon.019 | The Prod-Platform, starting from initialization, **must** collect and analyse logs to identify security events, and store these events in an external system. | |
 | req.sec.mon.020 | The Prod-Platform’s and NonProd-Platform’s components **must not** include any authentication credentials, e.g., password, in any logs, even if encrypted. | | 
 | req.sec.mon.021 | The Prod-Platform’s and NonProd-Platform’s logging system **must** support the storage of security audit logs for a configurable period of time. | |
-| req.sec.mon.022 | The Prod-Platform  **must** store security events locally if the external logging system is unavailable and shall periodically attempt to send these to the external logging system until the external loggin system becomes available | |
+| req.sec.mon.022 | The Prod-Platform  **must** store security events locally if the external logging system is unavailable and shall periodically attempt to send these to the external logging system until successful. | |
 
 <p align="center"><b>Table 7-7:</b> Monitoring and security audit requirements</p>
 


### PR DESCRIPTION
Updating table in Ch 7.9.7 differentiating between Monitoring/Auditing requirements between prod and non-prod environments.  Partially addresses Issue#2541