### PR TITLE
[ra2] multitenancy

### DIFF
--- a/doc/ref_arch/kubernetes/chapters/appendix-a.md
+++ b/doc/ref_arch/kubernetes/chapters/appendix-a.md
@@ -68,6 +68,6 @@ By default, the Kubernetes scheduler will run pods belonging to any namespace on
 
 When tenants do not belong to the same trust domain, or the requirements on the cluster setup and configuration are irreconciliable, Hard Multitenancy must be implemented by creating multiple Kubernetes clusters for each tenant or group of compatible tenants.
 
-All the default design decision for Kubernetes clusters apply in this case, and no special segregation or capacity management is required to be setup within the clusters as it is occupied only by a single tenant at a time.
+All the default design decision for Kubernetes clusters apply in this case, and no special segregation or capacity management is required to be setup within the clusters.
 
 From an operational perspective, the increased computational and operational overhead and the Cluster LCM (incl. Cluster provisioning automation) are the most impactful aspects.


### PR DESCRIPTION
closes #993 and #1878 and #2254 
adding description of hard and soft multitenancy to appendix A
tidied up appendix A and its structure
not sure if specs on soft multitenancy (e.g. 

```RBAC must be configured with rules to allow specific tenants to access only the objects within their own Namespace, using a `Role` Object to group the resources within a namespace, and a `RoleBinding` Object to assign it to a user or a group of users within a Namespace

should be included in chapter 4 or 5 now) - to close #2510 