### PR TITLE
[RC2] Remove all bogometers in RC2

### DIFF
--- a/doc/ref_cert/RC2/README.md
+++ b/doc/ref_cert/RC2/README.md
@@ -1,5 +1,3 @@
-[<< Back](../)
-
 # Reference Conformance - Kubernetes based platform for Telecom
 
 This is the Kubernetes Based Reference Conformance (RC-2)

--- a/doc/ref_cert/RC2/chapters/chapter01.md
+++ b/doc/ref_cert/RC2/chapters/chapter01.md
@@ -1,7 +1,5 @@
 # Introduction
 
-![Scope](../figures/bogo_lsf.png)
-
 ## Executive Summary
 
 The Reference Conformance for the Kubernetes-based workstream (RC2) was established to ensure implementations of the Anuket Reference Architecture 2 (RA2), such as the Reference Implementation 2 (RI2), meet functional and performance requirements specified in RA2 and the Anuket Reference Model (RM). Cloud infrastructure and workload verification and validation will be utilised to evaluate **Conformance** (i.e. adherence) to the RA2 and RM requirements. Conformance scope includes:

--- a/doc/ref_cert/RC2/chapters/chapter02.md
+++ b/doc/ref_cert/RC2/chapters/chapter02.md
@@ -1,7 +1,5 @@
 # Kubernetes Test Cases and Requirements Traceability
 
-![Scope](../figures/bogo_lsf.png)
-
 ## Introduction
 
 All of the requirements for RC2 have been defined in the Reference Model (RM) and Reference Architecture (RA2). The scope of this chapter is to identify and list down test cases based on these requirements. Users of this chapter will be able to use it to determine which test cases they must run in order to test compliance with the requirements. This will enable traceability between the test cases and requirements. They should be able to clearly see which requirements are covered by which tests and the mapping from a specific test result (pass or fail) to a requirement. Each requirement may have one or more test case associated with it.

--- a/doc/ref_cert/RC2/chapters/chapter03.md
+++ b/doc/ref_cert/RC2/chapters/chapter03.md
@@ -1,7 +1,5 @@
 # Kubernetes Testing Cookbook
 
-![Scope](../figures/bogo_dfp.png)
-
 ## Deploy your own conformance toolchain
 
 At the time of writing, the CI description file is hosted in Functest and only

--- a/doc/ref_cert/RC2/chapters/chapter04.md
+++ b/doc/ref_cert/RC2/chapters/chapter04.md
@@ -1,7 +1,5 @@
 # CNF Test Cases and Requirements Traceability
 
-![Scope](../figures/bogo_ifo.png)
-
 ## Introduction
 
 The scope of this chapter is to identify and list test cases based on requirements defined in [Reference Architecture-2 (RA-2)](../../../ref_arch/kubernetes/README.md). This will serve as traceability between test cases and requirements for Kubernetes platform interoperability.

--- a/doc/ref_cert/RC2/chapters/chapter05.md
+++ b/doc/ref_cert/RC2/chapters/chapter05.md
@@ -1,3 +1,1 @@
 # CNF Testing Cookbook
-
-![Scope](../figures/bogo_ifo.png)

--- a/doc/ref_cert/RC2/chapters/chapter06.md
+++ b/doc/ref_cert/RC2/chapters/chapter06.md
@@ -1,3 +1,1 @@
 # Gap Analysis and Development
-
-![Scope](../figures/bogo_ifo.png)


### PR DESCRIPTION
It cleans the markdown files before we merge all rst.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>