### PR TITLE
Symlink README.rst to index.rst

### DIFF
--- a/doc/ref_cert/RC2/README.rst
+++ b/doc/ref_cert/RC2/README.rst
@@ -1,0 +1,1 @@
+index.rst

--- a/doc/ref_cert/RC2/conf.py
+++ b/doc/ref_cert/RC2/conf.py
@@ -2,7 +2,8 @@ project = 'Anuket Reference Conformance for Kubernetes (RC2)'
 copyright = '2021, Anuket'
 author = 'Anuket'
 exclude_patterns = [
-    '.tox'
+    '.tox',
+    'README.rst'
 ]
 extensions = [
     'sphinx_rtd_theme',


### PR DESCRIPTION
It allows browsing our doc via Github as CNTT actors may do.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>