### PR TITLE
[RC2] Leverage the doc role as proposed by Sphinx

### DIFF
--- a/doc/ref_cert/RC2/chapters/chapter02.rst
+++ b/doc/ref_cert/RC2/chapters/chapter02.rst
@@ -75,9 +75,8 @@ single tests:
 -  focus basically matches Conformance or `Testing Special Interest
    Groups <https://github.com/kubernetes/community/blob/master/sig-testing/charter.md>`__
    in sub-sections below
--  skip excludes the SIG labels listed as optional in `Reference
-   Architecture-2 (RA-2) Chapter
-   6 <https://cntt.readthedocs.io/en/latest/ref_arch/kubernetes/chapters/chapter06.html>`__
+-  skip excludes the SIG labels listed as optional in
+   :doc:`ref_arch/kubernetes/chapters/chapter06`.
 
 The Reference Conformance suites must be stable and executed on real
 deployments. Then all the following labels are defacto skipped in
@@ -122,9 +121,7 @@ skip:
 
 See `API Machinery Special Interest
 Group <https://github.com/kubernetes/community/tree/master/sig-api-machinery>`__
-and `Reference Architecture-2 (RA-2) Chapter
-6 <https://cntt.readthedocs.io/en/latest/ref_arch/kubernetes/chapters/chapter06.html>`__
-for more details.
+and :doc:`ref_arch/kubernetes/chapters/chapter06` for more details.
 
 Apps Testing
 ^^^^^^^^^^^^
@@ -144,9 +141,7 @@ skip:
 
 See `Apps Special Interest
 Group <https://github.com/kubernetes/community/tree/master/sig-apps>`__
-and `Reference Architecture-2 (RA-2) Chapter
-6 <https://cntt.readthedocs.io/en/latest/ref_arch/kubernetes/chapters/chapter06.html>`__
-for more details.
+and :doc:`ref_arch/kubernetes/chapters/chapter06` for more details.
 
 Auth Testing
 ^^^^^^^^^^^^
@@ -163,9 +158,7 @@ skip:
 
 See `Auth Special Interest
 Group <https://github.com/kubernetes/community/tree/master/sig-auth>`__
-and `Reference Architecture-2 (RA-2) Chapter
-6 <https://cntt.readthedocs.io/en/latest/ref_arch/kubernetes/chapters/chapter06.html>`__
-for more details.
+and :doc:`ref_arch/kubernetes/chapters/chapter06` for more details.
 
 Cluster Lifecycle Testing
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -180,9 +173,7 @@ skip:
 
 See `Cluster Lifecycle Special Interest
 Group <https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle>`__
-and `Reference Architecture-2 (RA-2) Chapter
-6 <https://cntt.readthedocs.io/en/latest/ref_arch/kubernetes/chapters/chapter06.html>`__
-for more details.
+and :doc:`ref_arch/kubernetes/chapters/chapter06` for more details.
 
 Instrumentation Testing
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -203,9 +194,7 @@ skip:
 
 See `Instrumentation Special Interest
 Group <https://github.com/kubernetes/community/tree/master/sig-instrumentation>`__
-and `Reference Architecture-2 (RA-2) Chapter
-6 <https://cntt.readthedocs.io/en/latest/ref_arch/kubernetes/chapters/chapter06.html>`__
-for more details.
+and :doc:`ref_arch/kubernetes/chapters/chapter06` for more details.
 
 Network Testing
 ^^^^^^^^^^^^^^^
@@ -246,8 +235,7 @@ skip:
 
 See `Network Special Interest
 Group <https://github.com/kubernetes/community/tree/master/sig-network>`__
-and `Reference Architecture-2 (RA-2) Chapter
-6 <https://cntt.readthedocs.io/en/latest/ref_arch/kubernetes/chapters/chapter06.html>`__
+and :doc:`ref_arch/kubernetes/chapters/chapter06`.
 
 Node Testing
 ^^^^^^^^^^^^
@@ -268,8 +256,7 @@ skip:
 
 See `Node Special Interest
 Group <https://github.com/kubernetes/community/tree/master/sig-node>`__
-and `Reference Architecture-2 (RA-2) Chapter
-6 <https://cntt.readthedocs.io/en/latest/ref_arch/kubernetes/chapters/chapter06.html>`__
+and :doc:`ref_arch/kubernetes/chapters/chapter06`.
 
 Scheduling Testing
 ^^^^^^^^^^^^^^^^^^
@@ -286,8 +273,7 @@ skip:
 
 See `Scheduling Special Interest
 Group <https://github.com/kubernetes/community/tree/master/sig-scheduling>`__
-and `Reference Architecture-2 (RA-2) Chapter
-6 <https://cntt.readthedocs.io/en/latest/ref_arch/kubernetes/chapters/chapter06.html>`__
+and :doc:`ref_arch/kubernetes/chapters/chapter06`.
 
 Storage Testing
 ^^^^^^^^^^^^^^^
@@ -328,8 +314,7 @@ skip:
 
 See `Storage Special Interest
 Group <https://github.com/kubernetes/community/tree/master/sig-storage>`__
-and `Reference Architecture-2 (RA-2) Chapter
-6 <https://cntt.readthedocs.io/en/latest/ref_arch/kubernetes/chapters/chapter06.html>`__
+and :doc:`ref_arch/kubernetes/chapters/chapter06`.
 
 Kubernetes API benchmarking
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -345,8 +330,7 @@ which iterates 10 times the mainline
 `xrally-kubernetes <https://github.com/xrally/xrally-kubernetes>`__
 scenarios.
 
-At the time of writing, no KPI is defined in `Kubernetes based Reference
-Architecture <https://cntt.readthedocs.io/en/latest/ref_arch/kubernetes/>`__
+At the time of writing, no KPI is defined in :doc:`ref_arch/kubernetes/README`
 which would have asked for an update of the default SLA (maximum failure
 rate of 0%) proposed in `Functest Kubernetes
 Benchmarking <https://git.opnfv.org/functest-kubernetes/tree/docker/benchmarking/testcases.yaml?h=stable%2Fv1.22>`__

--- a/doc/ref_cert/RC2/chapters/chapter04.rst
+++ b/doc/ref_cert/RC2/chapters/chapter04.rst
@@ -5,8 +5,7 @@ Introduction
 ------------
 
 The scope of this chapter is to identify and list test cases based on
-requirements defined in `Reference Architecture-2
-(RA-2) <https://cntt.readthedocs.io/en/latest/ref_arch/kubernetes>`__.
+requirements defined in :doc:`ref_arch/kubernetes/README`.
 This will serve as traceability between test cases and requirements for
 Kubernetes platform interoperability.
 

--- a/doc/ref_cert/RC2/conf.py
+++ b/doc/ref_cert/RC2/conf.py
@@ -6,8 +6,12 @@ exclude_patterns = [
 ]
 extensions = [
     'sphinx_rtd_theme',
+    'sphinx.ext.intersphinx'
 ]
 html_theme = "sphinx_rtd_theme"
 linkcheck_ignore = [
-        'http://127.0.0.1'
+    'http://127.0.0.1'
 ]
+intersphinx_mapping = {
+    'cntt': ('https://cntt.readthedocs.io/en/latest/', None)
+}


### PR DESCRIPTION
It leverages intersphinx [1] and doc role [2] to avoid hardcoding urls.
It remains one case in chapter04.rst which could be removed once CNTT
leverages autosectionlabel.

[1] https://docs.readthedocs.io/en/stable/guides/intersphinx.html
[2] https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html#the-doc-role

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>