### PR TITLE
[RC1] Leverage the doc role as proposed by Sphinx

### DIFF
--- a/doc/ref_cert/RC1/chapters/chapter01.rst
+++ b/doc/ref_cert/RC1/chapters/chapter01.rst
@@ -93,8 +93,7 @@ and services used in the client software stack.
 Terminology
 ~~~~~~~~~~~
 
-Terminology in this document will follow `Anuket
-Terminology <https://cntt.readthedocs.io/en/latest/common/glossary.html>`__.
+Terminology in this document will follow :doc:`common/glossary`.
 
 Scope
 -----

--- a/doc/ref_cert/RC1/chapters/chapter02.rst
+++ b/doc/ref_cert/RC1/chapters/chapter02.rst
@@ -104,8 +104,8 @@ the Cloud Infrastructure Conformance. If the Cloud Infrastructure fails
 the tests, it will not be moved to the next workflow for Conformance.
 The Cloud Infrastructure+VNF conformance consist of a three part process
 for Compliance, Validation, and Performance. Adherence to Security
-standards are equally important and addressed in `Chapter 7 of Reference
-Model <https://cntt.readthedocs.io/en/latest/ref_model/chapters/chapter07.html>`__.
+standards are equally important and addressed in
+:doc:`ref_model/chapters/chapter07`.
 
 The three part conformance process includes NFVI Manifest conformance,
 Empirical Baseline measurements against targeted VNF families, and
@@ -328,8 +328,7 @@ of VNF developer teams.
 4. Control plane components: Validations for RabbitMQ, Ceph, MariaDB
    etc. and OpenStack components like Nova/Glance/Heat etc. APIs.
 5. Security: Validation for use RBAC roles and user group policies. See
-   `Chapter 7 <https://cntt.readthedocs.io/en/latest/ref_cert/RC1/chapters/chapter07.html>`__
-   for complete list.
+   :doc:`ref_cert/RC1/chapters/chapter07` for complete list.
 
 The following **Optional Test Categories** which can be considered by
 the Operator, or Supplier, for targeted validations to complement
@@ -389,8 +388,7 @@ Performance based.
    comparing Non-Functional (NFR) NFVI KPIs (obtained after testing)
    with the Golden KPIs. Some of the examples of performance KPIs
    include, but not limited to: TCP bandwidth, UDP throughput, Memory
-   latency, Jitter, IOPS etc. See `Chapter 4 of
-   RM <https://cntt.readthedocs.io/en/latest/ref_model/chapters/chapter04.html>`__
+   latency, Jitter, IOPS etc. See :doc:`ref_model/chapters/chapter04`
    for a complete list of metrics and requirements.
 -  **Measurement Results**. Baseline Measurements will be performed when
    there are no benchmark standards to compare results, or established
@@ -567,7 +565,7 @@ different types of requirements and system properties:
    validating the functional correctness of the system under test. API
    compliance test cases exercise only the specific well-defined APIs
    described in the reference architecture (see `Interfaces and
-   APIs <https://cntt.readthedocs.io/en/latest/ref_arch/openstack/chapters/chapter05.html>`__).
+   APIs :doc:`ref_arch/openstack/chapters/chapter05`).
 
 -  Performance: Test cases covering this type of requirement measure
    specific performance characteristics of the system under test as

--- a/doc/ref_cert/RC1/chapters/chapter03.rst
+++ b/doc/ref_cert/RC1/chapters/chapter03.rst
@@ -5,8 +5,7 @@ Introduction
 ------------
 
 The scope of this chapter is to identify and list down test cases based
-on requirements defined in `Reference Architecture-1
-(RA-1) <https://cntt.readthedocs.io/en/latest/ref_arch/openstack/README.html>`__.
+on requirements defined in :doc:`ref_arch/openstack/README`.
 This will serve as traceability between test cases and requirements.
 
 Note that each requirement may have one or more test cases associated
@@ -42,8 +41,7 @@ domains: general(gen), infrastructure(inf), VIM(vim), Interface &
 API(int), Tenants(tnt), LCM(lcm), Assurance(asr), Security(sec).
 
 For detailed information on RM & RA-1 NFVI and VNF requirements, please
-refer to `RI-1 Chapter
-3 <https://cntt.readthedocs.io/en/latest/ref_impl/cntt-ri/chapters/chapter03.html>`__.
+refer to :doc:`ref_impl/cntt-ri/chapters/chapter03`.
 
 Architecture and OpenStack Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -68,8 +66,7 @@ conform to this model which also fits the heterogeneous user
 deployments.
 
 From a Anuket Compliance state point, the capabilities are well
-described in `RA1 Core OpenStack Services
-APIs <https://cntt.readthedocs.io/en/latest/ref_arch/openstack/chapters/chapter05.html>`__
+described in :doc:`ref_arch/openstack/chapters/chapter05`
 which allows tuning the test configurations and the test lists to avoid
 skipping any test. It results that all tests covering optional
 capabilities and all upstream skipped tests due to known bugs are not
@@ -86,8 +83,7 @@ Functest containers.
 The next subsections only detail the Tempest tests which must not be
 executed from a Compliance state point. The remaining tests have to pass
 successfully. They cover all together the API testing requirements as
-asked by `RA1 Core OpenStack Services
-APIs <https://cntt.readthedocs.io/en/latest/ref_arch/openstack/chapters/chapter05.html>`__
+asked by :doc:`ref_arch/openstack/chapters/chapter05`
 
 The following software versions are considered here to verify OpenStack
 Wallaby selected by Anuket:
@@ -113,8 +109,7 @@ Keystone API is covered in the OpenStack Gates via
 as integrated in `Functest Smoke
 CNTT <https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml?h=stable%2Fwallaby>`__.
 
-According to `RA1 Core OpenStack Services
-APIs <https://cntt.readthedocs.io/en/latest/ref_arch/openstack/chapters/chapter05.html>`__
+According to :doc:`ref_arch/openstack/chapters/chapter05`
 the following test names must not be executed:
 
 +-------------------------------------------------+--------------+
@@ -164,8 +159,7 @@ Glance API is covered in the OpenStack Gates via
 `Functest Smoke
 CNTT <https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml>`__.
 
-According to `RA1 Core OpenStack Services
-APIs <https://cntt.readthedocs.io/en/latest/ref_arch/openstack/chapters/chapter05.html>`__
+According to :doc:`ref_arch/openstack/chapters/chapter05`
 the following test names must not be executed:
 
 +--------------------------------------------------------+--------------------+
@@ -211,8 +205,7 @@ Cinder API is covered in the OpenStack Gates via
 as integrated in `Functest Smoke
 CNTT <https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml?h=stable%2Fwallaby>`__.
 
-According to `RA1 Core OpenStack Services
-APIs <https://cntt.readthedocs.io/en/latest/ref_arch/openstack/chapters/chapter05.html>`__
+According to :doc:`ref_arch/openstack/chapters/chapter05`
 the following test names must not be executed:
 
 +-------------------------------------------------+---------------------------+
@@ -286,8 +279,7 @@ Swift API is covered in the OpenStack Gates via
 `Functest Smoke
 CNTT <https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml?h=stable%2Fwallaby>`__.
 
-According to `RA1 Core OpenStack Services
-APIs <https://cntt.readthedocs.io/en/latest/ref_arch/openstack/chapters/chapter05.html>`__
+According to :doc:`ref_arch/openstack/chapters/chapter05`
 the following test names must not be executed:
 
 +---------------------------------------------------+-------------------------+
@@ -326,8 +318,7 @@ Neutron API is covered in the OpenStack Gates via
 as integrated in `Functest Smoke
 CNTT <https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml?h=stable%2Fwallaby>`__.
 
-According to `RA1 Core OpenStack Services
-APIs <https://cntt.readthedocs.io/en/latest/ref_arch/openstack/chapters/chapter05.html>`__
+According to :doc:`ref_arch/openstack/chapters/chapter05`
 the following test names must not be executed:
 
 +-------------------------------------------------+---------------------------+
@@ -506,8 +497,7 @@ Nova API is covered in the OpenStack Gates via
 `Functest Smoke
 CNTT <https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml?h=stable%2Fwallaby>`__.
 
-According to `RA1 Core OpenStack Services
-APIs <https://cntt.readthedocs.io/en/latest/ref_arch/openstack/chapters/chapter05.html>`__
+According to :doc:`ref_arch/openstack/chapters/chapter05`
 the following test names must not be executed:
 
 +----------------------------------------------------+------------------------+
@@ -715,8 +705,7 @@ Heat API is covered in the OpenStack Gates via
 as integrated in `Functest Smoke
 CNTT <https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml?h=stable%2Fwallaby>`__
 
-According to `RA1 Core OpenStack Services
-APIs <https://cntt.readthedocs.io/en/latest/ref_arch/openstack/chapters/chapter05.html>`__
+According to :doc:`ref_arch/openstack/chapters/chapter05`
 the following test names must not be executed:
 
 +-----------------------------------------+-----------------------------------+
@@ -782,9 +771,8 @@ CNTT <https://git.opnfv.org/functest/tree/docker/benchmarking-cntt/testcases.yam
 -  `rally_jobs <http://artifacts.opnfv.org/functest/KDBNITEN317M/functest-opnfv-functest-benchmarking-cntt-wallaby-rally_jobs_cntt-run-5/rally_jobs_cntt/rally_jobs_cntt.html>`__:
    Neutron scenarios executed in the OpenStack gates
 
-At the time of writing, no KPI is defined in `RA1 Core OpenStack
-Services
-APIs <https://cntt.readthedocs.io/en/latest/ref_arch/openstack/chapters/chapter05.html>`__
+At the time of writing, no KPI is defined in
+:doc:`ref_arch/openstack/chapters/chapter05`
 which would have asked for an update of the default SLA (maximum failure
 rate of 0%) proposed in `Functest Benchmarking
 CNTT <https://git.opnfv.org/functest/tree/docker/benchmarking-cntt/testcases.yaml?h=stable%2Fwallaby>`__
@@ -1215,7 +1203,7 @@ Test Cases Traceability to Requirements
 RM/RA-1 Requirements
 ~~~~~~~~~~~~~~~~~~~~
 
-According to `RC1 Chapter04 <https://cntt.readthedocs.io/en/latest/ref_cert/RC1/chapters/chapter04.html>`__
+According to :doc:`ref_cert/RC1/chapters/chapter04`
 the following test cases must pass as they are for Anuket NFVI Conformance:
 
 ======================================== ===================== ========

--- a/doc/ref_cert/RC1/chapters/chapter05.rst
+++ b/doc/ref_cert/RC1/chapters/chapter05.rst
@@ -24,8 +24,8 @@ given VNF.
 
    End-End framework
 
-Here, the steps 1-4 are NFVI related steps are covered in detail in the
-`RC NFVi chapters <https://cntt.readthedocs.io/en/latest/ref_cert/RC1/chapters/chapter02.html>`__.
+Here, the steps 1-4 are NFVI related steps are covered in detail in
+:doc:`ref_cert/RC1/chapters/chapter02`.
 
 Step-5. Interoperability validations for VNF functional testing defined.
 
@@ -88,11 +88,9 @@ defined capabilities and metrics. This would help operators to host
 their Telco Workload (VNF) with different traffic types, behaviour and
 from any vendor on a unified consistent Infrastructure. so as part of
 VNF Conformance, its important to certify the VNF based on profiled
-defined in `reference
-model <https://cntt.readthedocs.io/en/latest/ref_model/chapters/chapter02.html>`__.
+defined in :doc:ref_model/chapters/chapter02`.
 
-In `reference
-model <https://cntt.readthedocs.io/en/latest/ref_model/chapters/chapter02.html>`__,
+In :doc:`ref_model/chapters/chapter02`,
 following NFVi profiles are proposed as reference:
 
 -  **Basic**: for VNF that can tolerate resource over-subscription and

--- a/doc/ref_cert/RC1/chapters/chapter08.rst
+++ b/doc/ref_cert/RC1/chapters/chapter08.rst
@@ -38,8 +38,7 @@ Test Case Gaps
 
 Anuket has developed many test cases in the different `test
 projects <https://wiki.opnfv.org/display/testing/TestPerf>`__ which can
-quickly improve RC. As listed in `RC Test case integration
-requirements <https://cntt.readthedocs.io/en/latest/ref_cert/RC1/chapters/chapter02.html>`__,
+quickly improve RC. As listed in :doc:`ref_cert/RC1/chapters/chapter02`,
 porting all the existing testcases to Xtesting will unify the test case
 execution and simplify the test integration as required by RC. Here are all the
 related issues:
@@ -69,8 +68,8 @@ Framework Gaps
 
 As proposed in `port VTP test cases to
 Xtesting <https://github.com/cntt-n/CNTT/issues/917>`__, VTP selected in
-`VNF E2E C&V Framework <https://cntt.readthedocs.io/en/latest/ref_cert/RC1/chapters/chapter05.html>`__
-requires small adaptations to fully fulfill the current `RC Test case
-integration requirements <https://cntt.readthedocs.io/en/latest/ref_cert/RC1/chapters/chapter02.html>`__.
+:doc:`ref_cert/RC1/chapters/chapter05`
+requires small adaptations to fully fulfill the current
+:doc:`ref_cert/RC1/chapters/chapter02`.
 It seems trivial changes as VTP proposed a REST API but will ensure that both
 NFVI and VNF testing can be executed in the same CI toolchain very easily.

--- a/doc/ref_cert/RC1/conf.py
+++ b/doc/ref_cert/RC1/conf.py
@@ -6,8 +6,12 @@ exclude_patterns = [
 ]
 extensions = [
     'sphinx_rtd_theme',
+    'sphinx.ext.intersphinx'
 ]
 html_theme = "sphinx_rtd_theme"
 linkcheck_ignore = [
-        'http://127.0.0.1'
+    'http://127.0.0.1'
 ]
+intersphinx_mapping = {
+    'cntt': ('https://cntt.readthedocs.io/en/latest/', None)
+}


### PR DESCRIPTION
It leverages intersphinx [1] and doc role [2] to avoid hardcoding urls.
It remains several cases in chapter01.rst and chapter02.rst which could
be removed once CNTT leverages autosectionlabel.

[1] https://docs.readthedocs.io/en/stable/guides/intersphinx.html
[2] https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html#the-doc-role

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>