### PR TITLE
[RC1] Update Rally OpenStack version

### DIFF
--- a/doc/ref_cert/RC1/chapters/chapter03.rst
+++ b/doc/ref_cert/RC1/chapters/chapter03.rst
@@ -88,17 +88,17 @@ asked by :doc:`ref_arch/openstack/chapters/chapter05`
 The following software versions are considered here to verify OpenStack
 Wallaby selected by Anuket:
 
-======================= =======
+======================= ===========
 software                version
-======================= =======
+======================= ===========
 Functest                wallaby
 Cinder Tempest plugin   1.4.0
 Keystone Tempest plugin 0.7.0
 Heat Tempest plugin     1.2.0
-Neutron Tempest plugin   1.4.0
-Rally OpenStack         2.1.0
+Neutron Tempest plugin  1.4.0
+Rally OpenStack         2.2.1.dev11
 Tempest                 27.0.0
-======================= =======
+======================= ===========
 
 Identity - Keystone
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
It fixes cinder "update_volume_type() got an unexpected keyword [1]
and the bugs detected by CI (here Cinder v3) [2].
Also see the related Functest update [3]

[1] https://github.com/openstack/rally-openstack/commit/38ab09ccbe9cea02fe7230a2580dfc8d64503662
[2] https://github.com/openstack/rally-openstack/commit/db87d7f218555f41cc743f249e7ba02b353f0a09
[3] https://github.com/opnfv/functest/commit/a0f54a3fc05ce4dd104181874bf7569607af3064

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>