### PR TITLE
Couple of minor typos in the RC2 documentation.

### DIFF
--- a/doc/ref_cert/RC2/chapters/chapter01.rst
+++ b/doc/ref_cert/RC2/chapters/chapter01.rst
@@ -166,7 +166,7 @@ executed. 3rd Party test platforms may also be leveraged if desired.
 
 **Dependencies** infrastructure and workload validation will rely upon
 test harnesses, test tools, and test suites provided by upstream
-projects, including OPNFV and CNF conformance. These upstream projects
+projects, including Anuket and CNF conformance. These upstream projects
 will be reviewed semi-annually to verify they are still healthy and
 active projects. Over time, the projects representing the conformance
 process may change, but test parity is required if new test suites are

--- a/doc/ref_cert/RC2/chapters/chapter02.rst
+++ b/doc/ref_cert/RC2/chapters/chapter02.rst
@@ -69,7 +69,7 @@ expected to grow according to the ongoing requirement traceability.
 
 `End-to-End
 Testing <https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md>`__
-basically asks for focus and skip regexes to select or to blacklist
+basically asks for focus and skip regexes to select or to exclude
 single tests:
 
 -  focus basically matches Conformance or `Testing Special Interest
@@ -498,7 +498,7 @@ Virtualization requirements.
 
 Functest CNF offers 2 test cases which automatically onboard and test
 `Clearwater IMS <https://github.com/Metaswitch/clearwater-docker>`__ via
-kubecltl and Helm. It’s worth mentioning that this CNF is covered by the
+kubectl and Helm. It’s worth mentioning that this CNF is covered by the
 upstream tests (see
 `clearwater-live-test <https://github.com/Metaswitch/clearwater-live-test>`__).
 


### PR DESCRIPTION
* Minor typos and spelling corrections.
* Removed "blacklist" in favor of "excludes."

Signed-off-by: Lincoln Lavoie <lylavoie@iol.unh.edu>