### PR TITLE
[RA]: Fix links to RA-s

### DIFF
--- a/doc/ref_arch/README.rst
+++ b/doc/ref_arch/README.rst
@@ -4,5 +4,5 @@ Anuket Project Reference Architectures
 Available Reference Architectures
 ---------------------------------
 
--  `RA1 - Openstack Based <openstack/README.md>`__
--  `RA2 - Kubernetes Based <kubernetes/README.rst>`__
+-  :doc:`RA1 - Openstack Based <openstack/README>`
+-  :doc:`RA2 - Kubernetes Based <kubernetes/README>`


### PR DESCRIPTION
Using proper :doc: directives to link to RA1 and RA2.

fixes: #2842 