### PR TITLE
[RI1][RI2] Correctly link RI1 and RI2 from common index

### DIFF
--- a/doc/ref_impl/README.md
+++ b/doc/ref_impl/README.md
@@ -1,9 +1,0 @@
-[<< Back](../)
-
-# Anuket Project Reference Implementation
-
-<a name="available-ri"></a>
-
-## Available Reference Implementations
-* [RI1 - OpenStack Based](cntt-ri)
-* [RI2 - Kubernetes Based](cntt-ri2)

--- a/doc/ref_impl/README.rst
+++ b/doc/ref_impl/README.rst
@@ -1,0 +1,1 @@
+index.rst

--- a/doc/ref_impl/cntt-ri/index.rst
+++ b/doc/ref_impl/cntt-ri/index.rst
@@ -1,5 +1,5 @@
-Reference Implementation 1
-==========================
+Reference Implementation 1 - OpenStack
+======================================
 
 This is the OPNFV based Reference Implementation (RI-1)
 
@@ -44,7 +44,7 @@ Table of Contents
 -----------------
 
 .. toctree::
-   :glob:
+   :numbered:
    :maxdepth: 1
 
    chapters/chapter01

--- a/doc/ref_impl/cntt-ri/index.rst
+++ b/doc/ref_impl/cntt-ri/index.rst
@@ -1,7 +1,7 @@
 Reference Implementation 1 - OpenStack
 ======================================
 
-This is the OPNFV based Reference Implementation (RI-1)
+This is the OpenStack based Reference Implementation (RI-1)
 
 Release Information
 -------------------

--- a/doc/ref_impl/cntt-ri2/index.rst
+++ b/doc/ref_impl/cntt-ri2/index.rst
@@ -1,5 +1,5 @@
-Reference Implementation 2
-==========================
+Reference Implementation 2 - Kubernetes
+=======================================
 
 This is the Kubernetes-based Reference Implementation (RI-2).
 

--- a/doc/ref_impl/index.rst
+++ b/doc/ref_impl/index.rst
@@ -1,0 +1,8 @@
+Anuket Project Reference implementations
+========================================
+
+Available Reference Implementations
+-----------------------------------
+
+-  :ref:`ref_impl/cntt-ri/index:Reference Implementation 1 - OpenStack`
+-  :ref:`ref_impl/cntt-ri2/index:Reference Implementation 2 - Kubernetes`


### PR DESCRIPTION
Now that both RI1 and RI2 are rst based, we can link both pieces
together using proper rst directives. This also enables numbering
of RI1 headings.

Fixes #2873

Signed-off-by: Georg Kunz <georg.kunz@ericsson.com>