### PR TITLE
[RM Ch] conf.py add numfig

### DIFF
--- a/doc/ref_model/conf.py
+++ b/doc/ref_model/conf.py
@@ -19,3 +19,6 @@ linkcheck_ignore = [
 ]
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 3
+numfig = True
+numfig_format = {'figure': 'Figure %s', 'table': 'Table %s',
+                 'code-block': 'Listing %s', 'section': 'Section %s'}


### PR DESCRIPTION
Added numfig = True

This will enable Figure numbering.

Here is a suggested use for the Figure 1-1 

LIne 54: within the text use :numref:`Fig-1-1` and the Figure block as:

.. _Fig-1-1:
.. image:: ../figures/ch01_scope.png
   :alt: "Scope of Reference Model"

   Scope of Reference Model

@collivier @gkunz Can you confirm? Thanks