### PR TITLE
[docs] fix for Jinja2 3.1.0 breaking builds with old versions of Sphinx

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,3 +7,4 @@ sphinx-markdown-tables
 sphinx_rtd_theme
 recommonmark>=0.7.1
 commonmark>=0.9.1
+jinja2<3.1.0


### PR DESCRIPTION
A recent update of Jinja2 breaks builds using the old version of Sphinx we are
using. We still use Sphinx < 2 to build the overall documentation containing
both markdown and rst files. Newer versions seem to have problems with this.

Once all files have been converted to rst, we can uplift Sphinx (see individual
builds which already today use much newer versions of Sphinx).

See also readthedocs/readthedocs.org#9037

As a temporary solution, I suggest to limit jinja2 to < 3.1.0 until we can
remove the version restriction in the overall build.

Fixes #2891

Signed-off-by: Georg Kunz <georg.kunz@ericsson.com>