### PR TITLE
[RA1] Fix doc8 issues in RA1

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter03.rst
+++ b/doc/ref_arch/openstack/chapters/chapter03.rst
@@ -459,7 +459,7 @@ a same service must run on different nodes).
 The services can be containerised or VM hosted as long as they provide
 the high availability principles described above.
 
-The APIs for these OpenStack services are listed in 
+The APIs for these OpenStack services are listed in
 :ref:`ref_arch/openstack/chapters/chapter05:interfaces and apis`.
 
 Cloud Workload Services

--- a/doc/ref_arch/openstack/chapters/chapter04.rst
+++ b/doc/ref_arch/openstack/chapters/chapter04.rst
@@ -72,9 +72,9 @@ OpenStack Control Plane Servers (Control Nodes)
 -  BIOS Requirements
 
 For OpenStack control nodes we use the BIOS parameters for the basic
-profile defined in :ref:`ref_model/chapters/chapter05:cloud infrastructure hardware profiles features and requirements.`.
-Additionally,
-for OpenStack we need to set the following boot parameters:
+profile defined in :ref:`ref_model/chapters/chapter05:\
+cloud infrastructure hardware profiles features and requirements.`.
+Additionally, for OpenStack we need to set the following boot parameters:
 
 ================================= ===============
 BIOS/boot Parameter               Value
@@ -1713,7 +1713,8 @@ set up the flavors as specified in the tables below.
 ..
 
    -  To configure profile-extensions, for example, the “Storage
-      Intensive High Performance” profile, as defined in :ref:`ref_model/chapters/chapter02:profile extensions (specialisations)`,
+      Intensive High Performance” profile, as defined in
+      :ref:`ref_model/chapters/chapter02:profile extensions (specialisations)`,
       in addition to the above, need configure the storage IOPS: the
       following two parameters need to be specified in the flavor
       create: –property quota:disk_write_iops_sec=<IOPS#> and –property

--- a/doc/ref_arch/openstack/chapters/chapter07.rst
+++ b/doc/ref_arch/openstack/chapters/chapter07.rst
@@ -64,7 +64,8 @@ version and then the old servers are undeployed.
 Cloud Infrastructure and VIM configuration management
 -----------------------------------------------------
 
-In the Reference Model, :ref:`ref_model/chapters/chapter09:configuration and lifecycle management`
+In the Reference Model,
+:ref:`ref_model/chapters/chapter09:configuration and lifecycle management`
 defines the functions of Configuration and Life Cycle Management (LCM).
 To operate and manage a scalable cloud, that minimizes operational
 costs, requires tools that incorporates systems for automated
@@ -117,7 +118,8 @@ specifies how to provision and deploy the IaaS, and on how to update
 configuration including OpenStack services.
 
 For Airship, :ref:`ref_impl/cntt-ri/chapters/chapter08:descriptor file preparations`
-specifies the required descriptor files and in :ref:`ref_impl/cntt-ri/chapters/chapter08:deployment: installer & install steps`
+specifies the required descriptor files and in
+:ref:`ref_impl/cntt-ri/chapters/chapter08:deployment: installer & install steps`
 describes the steps to provision the OpenStack based IaaS.
 
 Configuration Management

--- a/doc/ref_arch/openstack/chapters/chapter08.rst
+++ b/doc/ref_arch/openstack/chapters/chapter08.rst
@@ -18,7 +18,8 @@ Autoscaling
 ~~~~~~~~~~~
 
 With regards to resource autoscaling
-(gen.scl.01 :ref:`ref_arch/openstack/chapters/chapter02:general recommendations`) it is
+(gen.scl.01
+:ref:`ref_arch/openstack/chapters/chapter02:general recommendations`) it is
 recommended that the NFVO/VNFM manages the policy and triggers a
 scale-up or scale-down action based on application telemetry, event, AI,
 or ML etc. While the use of telemetry and alarming system can trigger a

--- a/doc/ref_arch/openstack/tox.ini
+++ b/doc/ref_arch/openstack/tox.ini
@@ -9,6 +9,6 @@ deps =
   -r{toxinidir}/test-requirements.txt
 install_command = pip install {opts} {packages}
 commands =
-  #doc8 . --ignore-path .tox --ignore-path build
+  doc8 . --ignore-path .tox --ignore-path build --max-line-length 120
   sphinx-build -W -b html . build
   #sphinx-build -W -b linkcheck . build


### PR DESCRIPTION
It's only about wrapping long lines and removing
blank chars. Then it allows running doc8 in gates.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>