### PR TITLE
[RM] Fix RST issues

### DIFF
--- a/doc/ref_model/abbreviations.md
+++ b/doc/ref_model/abbreviations.md
@@ -1,2 +1,0 @@
-
-# Abbreviations

--- a/doc/ref_model/chapters/appendix-a.rst
+++ b/doc/ref_model/chapters/appendix-a.rst
@@ -49,7 +49,7 @@ VNF Design Guidelines
 ---------------------
 
 A number of software design guidelines (industry best practices) have been developed over the years including micro-services, cohesion and coupling.
-In addition to the industry best-practices, there are additonal guidelines and requirements specified by ONAP in 
+In addition to the industry best-practices, there are additonal guidelines and requirements specified by ONAP in
 "`VNF or PNF Requirements Documentation <https://docs.onap.org/projects/onap-vnfrqts-requirements/en/istanbul/>`__." This section
 does not supplant these well-known guidelines and practices. The content here only draws attention to some other design consideration that VNF
 Developers need to incorporate in their practices. Please note that some of these guidelines may be incorporated by operators in their contracts with

--- a/doc/ref_model/chapters/chapter01.rst
+++ b/doc/ref_model/chapters/chapter01.rst
@@ -65,7 +65,7 @@ with operational considerations, such as security and lifecycle management.
   recommended for the different types of cloud infrastructure profiles.
 
   - **Audience**: This chapter is written for architects, developers and others who need to deploy infrastructure or
-  develop applications.
+    develop applications.
 
 - **Chapter 06 - External Interfaces**: This chapter covers APIs and any actual interfaces needed to communicate with
   the workloads and any other external components.

--- a/doc/ref_model/chapters/chapter04.rst
+++ b/doc/ref_model/chapters/chapter04.rst
@@ -352,9 +352,9 @@ Profiles Specifications & Capability Mapping
 Ref       Capability                           Basic   High Performance Notes
 ========= ==================================== ======= ================ =========================================================================================
 e.cap.006 CPU pinning                          No      Yes              Exposed performance capabilities as per Table 4-2.
-e.cap.007 NUMA alignment                       No      Yes             
-e.cap.013 SR-IOV over PCI-PT                   No      Yes             
-e.cap.018 Simultaneous Multithreading (SMT)    Yes     Optional        
+e.cap.007 NUMA alignment                       No      Yes
+e.cap.013 SR-IOV over PCI-PT                   No      Yes
+e.cap.018 Simultaneous Multithreading (SMT)    Yes     Optional
 e.cap.019 vSwitch Optimisation (DPDK)          No      Yes              DPDK doesn't have to be used if some other network acceleration method is being utilised.
 e.cap.020 CPU Architecture                     <value> <value>          Values such as x64, ARM, etc.
 e.cap.021 Host Operating System (OS)           <value> <value>          Values such as a specific Linux version, Windows version, etc.

--- a/doc/ref_model/chapters/chapter06.rst
+++ b/doc/ref_model/chapters/chapter06.rst
@@ -69,9 +69,9 @@ A virtual compute resource is created as per the flavour template (specifies the
 =============== ====== ==== ====== ====== ====== ===========================================================================================================
 Resource        Create List Attach Detach Delete Notes
 =============== ====== ==== ====== ====== ====== ===========================================================================================================
-Flavour         +      +                  +     
+Flavour         +      +                  +
 Image           +      +                  +      Create/delete by appropriate administrators
-Key pairs       +      +                  +     
+Key pairs       +      +                  +
 Privileges                                       Created and managed by Cloud Service Provider(CSP) administrators
 Role            +      +                  +      Create/delete by authorized administrators where roles are assigned privileges and mapped to users in scope
 Security Groups +      +                  +      Create and delete only by VDC administrators
@@ -100,7 +100,7 @@ These acceleration interfaces are summarized here in Table 6.3 only for convenie
 +------------------------------------------+-------------------------------------------+-----------+--------+---------------------------+-----------------------------------------------+
 | Request                                  | Response                                  | From, To  | Type   | Parameter                 | Description                                   |
 +==========================================+===========================================+===========+========+===========================+===============================================+
-|                                          |                                           |           | Input  | accFilter                 | the accelartor sub-system(s) to               | 
+|                                          |                                           |           | Input  | accFilter                 | the accelartor sub-system(s) to               |
 |                                          |                                           |           |        |                           | initialize and retrieve their capabilities.   |
 |                                          |                                           |           +--------+---------------------------+-----------------------------------------------+
 | InitAccRequest                           | InitAccResponse                           | VNF → NFVI| Filter | accAttributeSelector      | attribute names of accelerator capabilities   |
@@ -116,7 +116,7 @@ These acceleration interfaces are summarized here in Table 6.3 only for convenie
 | AccEventNotificationRequest              | AccEventNotificationResponse              |           +--------+---------------------------+-----------------------------------------------+
 |                                          |                                           | NFVI → VNF| Input  | accEventMetaData          |                                               |
 +------------------------------------------+-------------------------------------------+-----------+--------+---------------------------+-----------------------------------------------+
-| DeRegisterForAccEventResponse            | DeRegisterForAccEventResponse             | VNF → NFVI| Input  | accEvent                  | Event VNF is deregistering from               | 
+| DeRegisterForAccEventResponse            | DeRegisterForAccEventResponse             | VNF → NFVI| Input  | accEvent                  | Event VNF is deregistering from               |
 +------------------------------------------+-------------------------------------------+-----------+--------+---------------------------+-----------------------------------------------+
 | ReleaseAccRequest                        | ReleaseAccResponse                        | VNF → NFVI|        |                           |                                               |
 +------------------------------------------+-------------------------------------------+-----------+--------+---------------------------+-----------------------------------------------+
@@ -124,13 +124,13 @@ These acceleration interfaces are summarized here in Table 6.3 only for convenie
 | ModifyAccConfigurationResponse           | ModifyAccConfigurationResponse            |           +--------+---------------------------+-----------------------------------------------+
 |                                          |                                           |           | Input  | accSubSysConfigurationData| Config data for accelerator sub-system        |
 +------------------------------------------+-------------------------------------------+-----------+--------+---------------------------+-----------------------------------------------+
-|                                          |                                           |           | Input  | accFilter                 | Filter for subsystems from which config data  | 
+|                                          |                                           |           | Input  | accFilter                 | Filter for subsystems from which config data  |
 |                                          |                                           |           |        |                           | requested                                     |
 |                                          |                                           |           +--------+---------------------------+-----------------------------------------------+
 | GetAccConfigsRequest                     | GetAccConfigsResponse                     | VNF → NFVI| Input  | accConfigSelector         | attributes of config types                    |
 |                                          |                                           |           +--------+---------------------------+-----------------------------------------------+
 |                                          |                                           |           | Output | accConfigs                | Config info (only for the specified           |
-|                                          |                                           |           |        |                           | attributes) for specified subsystems          | 
+|                                          |                                           |           |        |                           | attributes) for specified subsystems          |
 +------------------------------------------+-------------------------------------------+-----------+--------+---------------------------+-----------------------------------------------+
 |                                          |                                           |           | Input  | accFilter                 | Filter for subsystems for which config is to  |
 |                                          |                                           | VNF → NFVI|        |                           | be reset                                      |
@@ -138,23 +138,23 @@ These acceleration interfaces are summarized here in Table 6.3 only for convenie
 |                                          |                                           |           | Input  | accConfigSelector         | attributes of config types whose values will  |
 |                                          |                                           |           |        |                           | be reset                                      |
 +------------------------------------------+-------------------------------------------+-----------+--------+---------------------------+-----------------------------------------------+
-|                                          |                                           |           | Input  | accData                   | Data (metadata) sent too accelerator          | 
+|                                          |                                           |           | Input  | accData                   | Data (metadata) sent too accelerator          |
 |                                          |                                           |           +--------+---------------------------+-----------------------------------------------+
 | AccDataRequest                           | AccDataResponse                           | VNF → NFVI| Input  | accChannel                | Channel data is to be sent to                 |
 |                                          |                                           |           +--------+---------------------------+-----------------------------------------------+
 |                                          |                                           |           | Output | accData                   | Data from accelerator                         |
 +------------------------------------------+-------------------------------------------+-----------+--------+---------------------------+-----------------------------------------------+
-| AccSendDataRequest                       | AccSendDataResponse                       | VNF → NFVI| Input  | accData                   | Data (metadata) sent too accelerator          | 
+| AccSendDataRequest                       | AccSendDataResponse                       | VNF → NFVI| Input  | accData                   | Data (metadata) sent too accelerator          |
 |                                          |                                           |           +--------+---------------------------+-----------------------------------------------+
 |                                          |                                           |           | Input  | accChannel                | Channel data is to be sent to                 |
 +------------------------------------------+-------------------------------------------+-----------+--------+---------------------------+-----------------------------------------------+
-|                                          |                                           |           | Input  | maxNumberOfDataItems      | Max number of data items to be received       | 
+|                                          |                                           |           | Input  | maxNumberOfDataItems      | Max number of data items to be received       |
 |                                          |                                           |           +--------+---------------------------+-----------------------------------------------+
 | AccReceiveDataRequest                    | AccReceiveDataResponse                    | VNF → NFVI| Input  | accChannel                | Channel data is requested from                |
 |                                          |                                           |           +--------+---------------------------+-----------------------------------------------+
 |                                          |                                           |           | Output | accData                   | Data received form Accelerator                |
 +------------------------------------------+-------------------------------------------+-----------+--------+---------------------------+-----------------------------------------------+
-| RegisterForAccDataAvailableEventRequest  | RegisterForAccDataAvailableEventResponse  | VNF → NFVI| Input  | regHandlerId              | Registration Identifier                       | 
+| RegisterForAccDataAvailableEventRequest  | RegisterForAccDataAvailableEventResponse  | VNF → NFVI| Input  | regHandlerId              | Registration Identifier                       |
 |                                          |                                           |           +--------+---------------------------+-----------------------------------------------+
 |                                          |                                           |           | Input  | accChannel                | Channel where event is requested for          |
 +------------------------------------------+-------------------------------------------+-----------+--------+---------------------------+-----------------------------------------------+
@@ -189,7 +189,7 @@ These acceleration interfaces are summarized here in Table 6.3 only for convenie
 |                                          |                                           |           | Output | accStatistics             | Statistics data of the accelerators matching  |
 |                                          |                                           |           |        |                           | the input filter located in the selected host.|
 +------------------------------------------+-------------------------------------------+-----------+--------+---------------------------+-----------------------------------------------+
-| ResetAccStatisticsRequest                | ResetAccStatisticsResponse                | VIM → NFVI| Input  | accFilter                 | Accelerator subsystems for which data is to be| 
+| ResetAccStatisticsRequest                | ResetAccStatisticsResponse                | VIM → NFVI| Input  | accFilter                 | Accelerator subsystems for which data is to be|
 |                                          |                                           |           |        |                           | reset                                         |
 |                                          |                                           |           +--------+---------------------------+-----------------------------------------------+
 |                                          |                                           |           | Input  | accStatSelector           | attributes of AccStatistics whose data will be|
@@ -204,7 +204,7 @@ These acceleration interfaces are summarized here in Table 6.3 only for convenie
 |                                          |                                           |           | Output | SubscriptionId            | Identifier of the successfully created        |
 |                                          |                                           |           |        |                           | subscription.                                 |
 +------------------------------------------+-------------------------------------------+-----------+--------+---------------------------+-----------------------------------------------+
-| UnsubscribeRequest                       | UnsubscribeResponse                       | VIM → NFVI| Input  | hostId                    | Id of specified host                          | 
+| UnsubscribeRequest                       | UnsubscribeResponse                       | VIM → NFVI| Input  | hostId                    | Id of specified host                          |
 |                                          |                                           |           +--------+---------------------------+-----------------------------------------------+
 |                                          |                                           |           | Input  | SubscriptionId            | Identifier of the subscription to be          |
 |                                          |                                           |           |        |                           | unsubscribed.                                 |
@@ -220,7 +220,7 @@ These acceleration interfaces are summarized here in Table 6.3 only for convenie
 |                                          |                                           |           | Output | Alarm                     | Information about the alarms if filter matches|
 |                                          |                                           |           |        |                           | an alarm.                                     |
 +------------------------------------------+-------------------------------------------+-----------+--------+---------------------------+-----------------------------------------------+
-| AccResourcesDiscoveryRequest             | AccResourcesDiscoveryResponse             | VIM → NFVI| Input  | hostId                    | Id of specified host                          | 
+| AccResourcesDiscoveryRequest             | AccResourcesDiscoveryResponse             | VIM → NFVI| Input  | hostId                    | Id of specified host                          |
 |                                          |                                           |           +--------+---------------------------+-----------------------------------------------+
 |                                          |                                           |           | Output | discoveredAccResourceInfo | nformation on the acceleration resources      |
 |                                          |                                           |           |        |                           | discovered within the NFVI.                   |
@@ -247,4 +247,3 @@ Enabler Services Interfaces
 ---------------------------
 
 An operational cloud needs a set of standard services to function. Services such as NTP for time synchronization, DHCP for IP address allocation, DNS for obtaining IP addresses for domain names, and LBaaS (version 2) to distribute incoming requests amongst a pool of designated resources.
-

--- a/doc/ref_model/chapters/chapter09.rst
+++ b/doc/ref_model/chapters/chapter09.rst
@@ -145,24 +145,24 @@ The goals of LCM are to provide a reliable administration of a system from its 
  -  Enablement for automation of most system maintenance tasks
 
 Essential foundation functional blocks for Infrastructure LCM automation:
- -  Representation Model 
+ -  Representation Model
  -  Repository functions
  -  Available Software Versions and Dependencies
  -  Orchestration Engine
 
 Automated LCM uses Representation Model to:
  - abstract various automation technologies
- - promote evolution from automation understood as automation of human tasks to autonomous systems using intent-based, declarative automation, supported by evolving AI/ML technologies 
+ - promote evolution from automation understood as automation of human tasks to autonomous systems using intent-based, declarative automation, supported by evolving AI/ML technologies
 
 Automated LCM uses Repository functions to:
   -  store and manage configuration data
-  -  store and manage metrics related data such as event data,  alert data, and performance data 
+  -  store and manage metrics related data such as event data,  alert data, and performance data
   -  maintain currency of data by the use of discovery of current versions of software modules
   -  track and account for all systems, assets, subscriptions (monitoring)
   -  provide an inventory of all virtual and physical assets
   -  provide a topological view of interconnected resources
   -  support network design function
-  
+
 
 Automated LCM uses available IAC Software Versions and Dependencies component to:
  -  store information about available software versions, software patches and dependency expectations
@@ -175,7 +175,6 @@ Automated LCM uses Orchestration Engine to:
  -  dynamically remediate dependencies during the change process to optimise outcome
  -  ensure that the system is consistent across its life cycle by maintaining it in accordance with the intent templates
 
-=======
 Note: Developmnet of new structure and contents for this section in progress for Moselle release, driven by Issue#2087 and subordinate issues.
 
 Software Onboarding Automation and CI/CD Requirements


### PR DESCRIPTION
It allows running successfully doc8 vs RM.
It also removes abbreviations.md which should have been
after the RST conversion.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>