### PR TITLE
[RC1] Make title4 uniq

### DIFF
--- a/doc/ref_cert/RC1/chapters/chapter03.rst
+++ b/doc/ref_cert/RC1/chapters/chapter03.rst
@@ -100,8 +100,8 @@ Rally OpenStack         2.2.1.dev11
 Tempest                 27.0.0
 ======================= ===========
 
-Identity - Keystone
-^^^^^^^^^^^^^^^^^^^
+Identity - Keystone API testing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Keystone API is covered in the OpenStack Gates via
 `Tempest <https://opendev.org/openstack/tempest>`__ and
@@ -151,8 +151,8 @@ CNTT <https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml?h=sta
 -  KeystoneBasic.create_and_list_users
 -  KeystoneBasic.create_tenant_with_users
 
-Image - Glance
-^^^^^^^^^^^^^^
+Image - Glance API testing
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Glance API is covered in the OpenStack Gates via
 `Tempest <https://opendev.org/openstack/tempest>`__ as integrated in
@@ -196,8 +196,8 @@ CNTT <https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml?h=sta
 -  GlanceImages.list_images
 -  GlanceImages.create_image_and_boot_instances
 
-Block Storage - Cinder
-^^^^^^^^^^^^^^^^^^^^^^
+Block Storage - Cinder API testing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Cinder API is covered in the OpenStack Gates via
 `Tempest <https://opendev.org/openstack/tempest>`__ and
@@ -271,8 +271,8 @@ CNTT <https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml?h=sta
 -  Quotas.cinder_update_and_delete
 -  Quotas.cinder_update
 
-Object Storage - Swift
-^^^^^^^^^^^^^^^^^^^^^^
+Object Storage - Swift API testing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Swift API is covered in the OpenStack Gates via
 `Tempest <https://opendev.org/openstack/tempest>`__ as integrated in
@@ -309,8 +309,8 @@ CNTT <https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml?h=sta
 -  SwiftObjects.create_container_and_object_then_delete_all
 -  SwiftObjects.list_and_download_objects_in_containers
 
-Networking - Neutron
-^^^^^^^^^^^^^^^^^^^^
+Networking - Neutron API testing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Neutron API is covered in the OpenStack Gates via
 `Tempest <https://opendev.org/openstack/tempest>`__ and
@@ -489,8 +489,8 @@ CNTT <https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml?h=sta
 -  NeutronNetworks.set_and_clear_router_gateway
 -  Quotas.neutron_update
 
-Compute - Nova
-^^^^^^^^^^^^^^
+Compute - Nova API testing
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Nova API is covered in the OpenStack Gates via
 `Tempest <https://opendev.org/openstack/tempest>`__ as integrated in
@@ -697,8 +697,8 @@ CNTT <https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml?h=sta
 -  NovaServerGroups.create_and_delete_server_group
 -  Quotas.nova_update
 
-Orchestration - Heat
-^^^^^^^^^^^^^^^^^^^^
+Orchestration - Heat API testing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Heat API is covered in the OpenStack Gates via
 `heat-tempest-plugin <https://opendev.org/openstack/heat-tempest-plugin>`__
@@ -777,8 +777,8 @@ which would have asked for an update of the default SLA (maximum failure
 rate of 0%) proposed in `Functest Benchmarking
 CNTT <https://git.opnfv.org/functest/tree/docker/benchmarking-cntt/testcases.yaml?h=stable%2Fwallaby>`__
 
-Identity - Keystone
-^^^^^^^^^^^^^^^^^^^
+Identity - Keystone API benchmarking
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 `Functest
 rally_full_cntt <http://artifacts.opnfv.org/functest/KDBNITEN317M/functest-opnfv-functest-benchmarking-cntt-wallaby-rally_full_cntt-run-5/rally_full_cntt/rally_full_cntt.html>`__:
@@ -800,8 +800,8 @@ KeystoneBasic.create_and_list_users            10
 KeystoneBasic.create_tenant_with_users         10
 ============================================== ==========
 
-Image - Glance
-^^^^^^^^^^^^^^
+Image - Glance API benchmarking
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 `Functest
 rally_full_cntt <http://artifacts.opnfv.org/functest/KDBNITEN317M/functest-opnfv-functest-benchmarking-cntt-wallaby-rally_full_cntt-run-5/rally_full_cntt/rally_full_cntt.html>`__:
@@ -820,8 +820,8 @@ GlanceImages.create_and_get_image            10
 GlanceImages.create_and_update_image         10
 ============================================ ==========
 
-Block Storage - Cinder
-^^^^^^^^^^^^^^^^^^^^^^
+Block Storage - Cinder API benchmarking
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 `Functest
 rally_full_cntt <http://artifacts.opnfv.org/functest/KDBNITEN317M/functest-opnfv-functest-benchmarking-cntt-wallaby-rally_full_cntt-run-5/rally_full_cntt/rally_full_cntt.html>`__:
@@ -854,8 +854,8 @@ Quotas.cinder_update_and_delete                               10
 Quotas.cinder_update                                          10
 ============================================================= ==========
 
-Object Storage - Swift
-^^^^^^^^^^^^^^^^^^^^^^
+Object Storage - Swift API benchmarking
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 `Functest
 rally_full_cntt <http://artifacts.opnfv.org/functest/KDBNITEN317M/functest-opnfv-functest-benchmarking-cntt-wallaby-rally_full_cntt-run-5/rally_full_cntt/rally_full_cntt.html>`__:
@@ -870,8 +870,8 @@ SwiftObjects.create_container_and_object_then_delete_all      10
 SwiftObjects.list_and_download_objects_in_containers          10
 ============================================================= ==========
 
-Networking - Neutron
-^^^^^^^^^^^^^^^^^^^^
+Networking - Neutron API benchmarking
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 `Functest
 rally_full_cntt <http://artifacts.opnfv.org/functest/KDBNITEN317M/functest-opnfv-functest-benchmarking-cntt-wallaby-rally_full_cntt-run-5/rally_full_cntt/rally_full_cntt.html>`__:
@@ -925,8 +925,8 @@ NeutronTrunks.create_and_list_trunks       4
 Quotas.neutron_update                      40
 ========================================== ==========
 
-Compute - Nova
-^^^^^^^^^^^^^^
+Compute - Nova API benchmarking
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 `Functest
 rally_full_cntt <http://artifacts.opnfv.org/functest/KDBNITEN317M/functest-opnfv-functest-benchmarking-cntt-wallaby-rally_full_cntt-run-5/rally_full_cntt/rally_full_cntt.html>`__:
@@ -993,8 +993,8 @@ rally_full_cntt <http://artifacts.opnfv.org/functest/KDBNITEN317M/functest-opnfv
 | Quotas.nova_update                                             | 10         |
 +----------------------------------------------------------------+------------+
 
-Orchestration - Heat
-^^^^^^^^^^^^^^^^^^^^
+Orchestration - Heat API benchmarking
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 `Functest
 rally_full_cntt <http://artifacts.opnfv.org/functest/KDBNITEN317M/functest-opnfv-functest-benchmarking-cntt-wallaby-rally_full_cntt-run-5/rally_full_cntt/rally_full_cntt.html>`__:

--- a/doc/ref_cert/RC1/conf.py
+++ b/doc/ref_cert/RC1/conf.py
@@ -17,7 +17,7 @@ intersphinx_mapping = {
     'cntt': ('https://cntt.readthedocs.io/en/latest/', None)
 }
 autosectionlabel_prefix_document = True
-autosectionlabel_maxdepth = 2
+autosectionlabel_maxdepth = 4
 numfig = True
 numfig_format = {'figure': 'Figure %s', 'table': 'Table %s',
                  'code-block': 'Listing %s', 'section': 'Section %s'}

--- a/doc/ref_cert/RC2/conf.py
+++ b/doc/ref_cert/RC2/conf.py
@@ -17,7 +17,7 @@ intersphinx_mapping = {
     'cntt': ('https://cntt.readthedocs.io/en/latest/', None)
 }
 autosectionlabel_prefix_document = True
-autosectionlabel_maxdepth = 2
+autosectionlabel_maxdepth = 4
 numfig = True
 numfig_format = {'figure': 'Figure %s', 'table': 'Table %s',
                  'code-block': 'Listing %s', 'section': 'Section %s'}

--- a/doc/ref_cert/conf.py
+++ b/doc/ref_cert/conf.py
@@ -21,7 +21,7 @@ intersphinx_mapping = {
     'cntt': ('https://cntt.readthedocs.io/en/latest/', None)
 }
 autosectionlabel_prefix_document = True
-autosectionlabel_maxdepth = 2
+autosectionlabel_maxdepth = 4
 numfig = True
 numfig_format = {'figure': 'Figure %s', 'table': 'Table %s',
                  'code-block': 'Listing %s', 'section': 'Section %s'}


### PR DESCRIPTION
It removes duplicates in chapter3 and enforces
all local builds to generate labels to title4.

This global work is needed for RA1.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>