### PR TITLE
[GLOBAL] Fix requirements in gates

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,4 +83,4 @@ intersphinx_mapping = {
 }
 
 autosectionlabel_prefix_document = True
-autosectionlabel_maxdepth = 3
+autosectionlabel_maxdepth = 4

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,8 @@
-sphinx!=1.6.6,!=1.6.7,!=2.1.0,!=3.0.0,!=3.4.2,<3 # BSD
+sphinx!=1.6.6,!=1.6.7,!=2.1.0,!=3.0.0,!=3.4.2,>=4.2.0  # BSD
 sphinxcontrib.direct-copy
 sphinxcontrib.readme-to-index
 sphinxcontrib.relative-link-corrector
 sphinx_material
 sphinx-markdown-tables
-sphinx_rtd_theme
 recommonmark>=0.7.1
 commonmark>=0.9.1


### PR DESCRIPTION
Please note that all RTD projects created before Oct 20 2020
must set bounds to enforce a compatible Sphinx version
(see manual).

It also sets autosectionlabel_maxdepth = 4 needed by RA1 and
removes the falsy intersphinx mapping.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>