### PR TITLE
fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,13 +6,7 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
-*       @walterkozlowski
-*       @karinesevilla
-*       @jgu17
-*       @collivier
-*       @rgstori
-*       @xudan16
-*       @steelescotr
+*       @walterkozlowski @karinesevilla @jgu17 @collivier @rgstori @xudan16 @steelescotr
 
 
 # Governance


### PR DESCRIPTION
with PR #2901 , the last owner of `*`  takes precedence over the rest - that's @steelescotr 

Fixing to allow all project leads to actually be code owners at the same time