### PR TITLE
[ra2 ch3] fix build errors

### DIFF
--- a/doc/ref_arch/kubernetes/chapters/chapter01.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter01.rst
@@ -145,7 +145,7 @@ updated to allow for a period of transitioning as and when requirements change.
 | Ref           | Name  | Description               | Valid | Rationale                               | Implication |
 |               |       |                           | Until |                                         |             |
 +===============+=======+===========================+=======+=========================================+=============+
-|ra1.exc.req.001|Req.   | xxxx                      |xxxxxxx|                                         |             |          
+|ra1.exc.req.001|Req.   | xxxx                      |xxxxxxx|                                         |             |
 +---------------+-------+---------------------------+-------+-----------------------------------------+-------------+
 
 Scope

--- a/doc/ref_arch/kubernetes/chapters/chapter02.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter02.rst
@@ -446,7 +446,7 @@ Edge Cloud Infrastructure Hardware Profile Requirements
 
 In the case of Telco Edge Cloud Deployments, hardware requirements can differ from the above to account for
 environmental and other constraints.
-The Reference Model :ref:`ref_model/chapters/chapter08:chapter 8 Hybrid Multi-Cloud`
+The Reference Model :ref:`ref_model/chapters/chapter08:hybrid multi-cloud architecture`
 includes considerations specific to deployments at the edge of the network. The infrastructure profiles "Basic" and
 "High Performance" as per :ref:`ref_model/chapters/chapter04:profiles and workload flavours` still apply, but a number
 of requirements of the above table are relaxed as follows:

--- a/doc/ref_arch/kubernetes/chapters/chapter02.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter02.rst
@@ -329,7 +329,7 @@ Cloud Infrastructure Software Profile Requirements
 |/chapters/chapter05.md#vir|cfg.005   |                        |                 |                 |                  |
 |tual-networking>`__       |          |                        |                 |                 |                  |
 +--------------------------+----------+------------------------+-----------------+-----------------+------------------+
-|`5.1.3 <../../../ref_model|infra.net.| Traffic patterns       | Must support    | Must support    | **N/A**          | 
+|`5.1.3 <../../../ref_model|infra.net.| Traffic patterns       | Must support    | Must support    | **N/A**          |
 |/chapters/chapter05.md#vir|cfg.006   | symmetry               |                 |                 |                  |
 |tual-networking>`__       |          |                        |                 |                 |                  |
 +--------------------------+----------+------------------------+-----------------+-----------------+------------------+
@@ -430,7 +430,7 @@ Cloud Infrastructure Hardware Profile Requirements
 |`5.4.3 <../../../ref_model|infra.hw. | A SmartNIC that is     | Not required    | Optional (1)    | N/A              |
 |/chapters/chapter05.md#net|nac.cfg.  | used to offload        |                 |                 |                  |
 |work-resources>`__        |002       | vSwitch functionality  |                 |                 |                  |
-|                          |          | to hardware            |                 |                 |                  | 
+|                          |          | to hardware            |                 |                 |                  |
 +--------------------------+----------+------------------------+-----------------+-----------------+------------------+
 |`5.4.3 <../../../ref_model|infra.hw. | Compression            | Optional        | Optional        | N/A              |
 |/chapters/chapter05.md#net|nac.cfg.  |                        |                 |                 |                  |
@@ -446,8 +446,8 @@ Edge Cloud Infrastructure Hardware Profile Requirements
 
 In the case of Telco Edge Cloud Deployments, hardware requirements can differ from the above to account for
 environmental and other constraints.
-The Reference Model :ref:`ref_model/chapters/chapter08:chapter 8 Hybrid Multi-Cloud: Data Centre to Edge` 
-includes considerations specific to deployments at the edge of the network. The infrastructure profiles "Basic" and 
+The Reference Model :ref:`ref_model/chapters/chapter08:chapter 8 Hybrid Multi-Cloud: Data Centre to Edge`
+includes considerations specific to deployments at the edge of the network. The infrastructure profiles "Basic" and
 "High Performance" as per :ref:`ref_model/chapters/chapter04:profiles and workload flavours` still apply, but a number
 of requirements of the above table are relaxed as follows:
 
@@ -1443,7 +1443,7 @@ machines or containers.
 |          |              |              |                                      | solutions>`__, `ra2.ntw.006 <chapte |
 |          |              |              |                                      | r04.md#networking-solutions>`__,    |
 |          |              |              |                                      | `ra2.ntw.007 <chapter04.md#networki |
-|          |              |              |                                      | ng-solutions>`__                    | 
+|          |              |              |                                      | ng-solutions>`__                    |
 +----------+--------------+--------------+--------------------------------------+-------------------------------------+
 |inf.com.01|Infrastructure| Compute      | The Architecture **must** provide    | `ra2.k8s.004 <chapter04.md#kubernet |
 |          |              |              | compute resources for Pods.          | es>`__                              |
@@ -1587,5 +1587,5 @@ machines or containers.
 |          |              |              | must not be dropped, but the schema  |                                     |
 |          |              |              | or other details can change.         |                                     |
 +----------+--------------+--------------+--------------------------------------+-------------------------------------+
-  
+
 **Table 2-8:** Kubernetes Architecture Requirements

--- a/doc/ref_arch/kubernetes/chapters/chapter02.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter02.rst
@@ -446,7 +446,7 @@ Edge Cloud Infrastructure Hardware Profile Requirements
 
 In the case of Telco Edge Cloud Deployments, hardware requirements can differ from the above to account for
 environmental and other constraints.
-The Reference Model :ref:`ref_model/chapters/chapter08:chapter 8 Hybrid Multi-Cloud: Data Centre to Edge`
+The Reference Model :ref:`ref_model/chapters/chapter08:chapter 8 Hybrid Multi-Cloud`
 includes considerations specific to deployments at the edge of the network. The infrastructure profiles "Basic" and
 "High Performance" as per :ref:`ref_model/chapters/chapter04:profiles and workload flavours` still apply, but a number
 of requirements of the above table are relaxed as follows:

--- a/doc/ref_arch/kubernetes/chapters/chapter02.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter02.rst
@@ -132,8 +132,8 @@ Cloud Infrastructure Software Profile Capabilities
 |                          |          |                        |                 |                 |ter04.md#networkin|
 |                          |          |                        |                 |                 |g-solutions>`__   |
 +--------------------------+----------+------------------------+-----------------+-----------------+------------------+
-|`4.1.2 <../../../ref_model|*e.cap.017| *Ability to monitor    | *n/a (2)*       | \*n/a (2) \*    | N/A              |
-|/chapters/chapter04.md#exp|*         | L2-L7 data from        |                 |                 |                  |
+|`4.1.2 <../../../ref_model|e.cap.017 | *Ability to monitor    | *n/a (2)*       | \*n/a (2) \*    | N/A              |
+|/chapters/chapter04.md#exp|          | L2-L7 data from        |                 |                 |                  |
 |osed-infrastructure-capabi|          | workload*              |                 |                 |                  |
 |lities>`__                |          |                        |                 |                 |                  |
 +--------------------------+----------+------------------------+-----------------+-----------------+------------------+

--- a/doc/ref_arch/kubernetes/chapters/chapter03.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter03.rst
@@ -604,27 +604,27 @@ The basic semantics of Kubernetes, and the information found in manifests, defin
 without any references to IP addresses. This has many advantages, it makes it easy to create portable, scalable SW
 services and network policies for them that are not location aware and therefore can be executed more or less anywhere.
 
-+----------------------------------------+-----------------------------------------------------------------------------+
-| Network objects                        | Description                                                                 |
-+========================================+=============================================================================+
-| `Ingress: <https://kubernetes.io/docs/ | Ingress is a collection of rules that allow inbound connections to reach    |
-| concepts/services-networking/ingress/> | the endpoints defined by a backend. An Ingress can be configured to give    |
-| `__                                    | services externally reachable URLs, load balance traffic, terminate SSL,    |
-|                                        | offer name based virtual hosting etc.                                       |
-+----------------------------------------+-----------------------------------------------------------------------------+
-| `Service: <https://kubernetes.io/docs/ | Service is a named abstraction of an application running on a set of pods   |
-| concepts/services-networking/service/> | consisting of a local port (for example 3306) that the proxy listens on,    |
-| `__                                    | and the selector that determines which pods will answer requests sent       |
-|                                        | through the proxy.                                                          |
-+----------------------------------------+-----------------------------------------------------------------------------+
-| `EndpointSlices: <https://kubernetes.i | Endpoints and Endpointslices are a collection of objects that contain the   |
-| o/docs/concepts/services-networking/en | ip address, v4 and v6, of the pods that represents a service.               |
-| dpoint-slices/>`__                     |                                                                             |
-+----------------------------------------+-----------------------------------------------------------------------------+
-| `Network Policy: <https://kubernetes.i | Network Policy defines which network traffic is allowed to ingress and      |
-| o/docs/concepts/services-networking/en | egress from a set of pods.                                                  |
-| dpoint-slices/>`__                     |                                                                             |
-+----------------------------------------+-----------------------------------------------------------------------------+
++------------------------------------------------+--------------------------------------------------------------------+
+| Network objects                                | Description                                                        |
++================================================+====================================================================+
+| `Ingress: <https://kubernetes.io/docs/concepts/| Ingress is a collection of rules that allow inbound connections to |
+| services-networking/ingress/>`__               | reach the endpoints defined by a backend. An Ingress can be        |
+|                                                | configured to give services externally reachable URLs, load balance|
+|                                                | traffic, terminate SSL, offer name based virtual hosting etc.      |
++------------------------------------------------+--------------------------------------------------------------------+
+| `Service: <https://kubernetes.io/docs/concepts/| Service is a named abstraction of an application running on a set  |
+| services-networking/service/>`__               | of pods consisting of a local port (for example 3306) that the     |
+|                                                | proxy listens on, and the selector that determines which pods will |
+|                                                | answer requests sent through the proxy.                            |
++------------------------------------------------+--------------------------------------------------------------------+
+| `EndpointSlices: <https://kubernetes.io/docs/  | Endpoints and Endpointslices are a collection of objects that      |
+| concepts/services-networking/endpoint-         | contain the ip address, v4 and v6, of the pods that represents a   |
+| slices/>`__                                    | service.                                                           |
++------------------------------------------------+--------------------------------------------------------------------+
+| `Network Policies: <https://kubernetes.io/     | Network Policy defines which network traffic is allowed to ingress |
+| docs/concepts/services-networking/             | and egress from a set of pods.                                     |
+| network-policies/>`__                          |                                                                    |
++------------------------------------------------+--------------------------------------------------------------------+
 
 There is no need to explicitly define internal load balancers, server pools, service monitors, firewalls and so on.
 The Kubernetes semantics and relation between the different objects defined in the object manifests contains all the

--- a/doc/ref_arch/kubernetes/chapters/chapter03.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter03.rst
@@ -611,16 +611,16 @@ services and network policies for them that are not location aware and therefore
 | concepts/services-networking/ingress/> | the endpoints defined by a backend. An Ingress can be configured to give    |
 | `__                                    | services externally reachable URLs, load balance traffic, terminate SSL,    |
 |                                        | offer name based virtual hosting etc.                                       |
-+========================================+=============================================================================+
++----------------------------------------+-----------------------------------------------------------------------------+
 | `Service: <https://kubernetes.io/docs/ | Service is a named abstraction of an application running on a set of pods   |
 | concepts/services-networking/service/> | consisting of a local port (for example 3306) that the proxy listens on,    |
 | `__                                    | and the selector that determines which pods will answer requests sent       |
 |                                        | through the proxy.                                                          |
-+========================================+=============================================================================+
++----------------------------------------+-----------------------------------------------------------------------------+
 | `EndpointSlices: <https://kubernetes.i | Endpoints and Endpointslices are a collection of objects that contain the   |
 | o/docs/concepts/services-networking/en | ip address, v4 and v6, of the pods that represents a service.               |
 | dpoint-slices/>`__                     |                                                                             |
-+========================================+=============================================================================+
++----------------------------------------+-----------------------------------------------------------------------------+
 | `Network Policy: <https://kubernetes.i | Network Policy defines which network traffic is allowed to ingress and      |
 | o/docs/concepts/services-networking/en | egress from a set of pods.                                                  |
 | dpoint-slices/>`__                     |                                                                             |

--- a/doc/ref_arch/kubernetes/chapters/chapter03.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter03.rst
@@ -591,7 +591,7 @@ connect them all together.
 Kubernetes networking can be divided into two parts, built in network functionality available through the pod's
 mandatory primary interface and network functionality available through the pod's optional secondary interfaces.
 
-Built in Kubernetes Network Functionality
+Built-in Kubernetes Network Functionality
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Kubernetes currently only allows for one network, the *cluster* network, and one network attachment for each pod.

--- a/doc/ref_arch/kubernetes/chapters/chapter04.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter04.rst
@@ -53,13 +53,13 @@ the following specifications:
 |              |Functions     |(VFs) **must** be configured within the       |e-software-profile-requ|apter04.md#installation|
 |              |              |Kubernetes Node OS, as the SR-IOV Device      |irements>`__           |-on-bare-metal-infratru|
 |              |              |Plugin does not manage the creation of these  |                       |cture>`__              |
-|              |              |VFs.                                          |                       |                       |      
+|              |              |VFs.                                          |                       |                       |
 +--------------+--------------+----------------------------------------------+-----------------------+-----------------------+
 |``ra2.ch.004``|CPU Simultaneo|SMT **must** be enabled in the BIOS on the    |`infra.hw.cpu.cfg.004  |`3.3 <../../../ref_impl|
 |              |us Multi-Threa|physical machine on which the Kubernetes Node |<./chapter02.md#cloud-i|/cntt-ri2/chapters/chap|
 |              |ding (SMT)    |runs.                                         |nfrastructure-hardware-|ter03.md#infrastructure|
 |              |              |                                              |profile-require        |-requirements>`__      |
-|              |              |                                              |ments>`__              |                       |      
+|              |              |                                              |ments>`__              |                       |
 +--------------+--------------+----------------------------------------------+-----------------------+-----------------------+
 |``ra2.ch.005``|CPU Allocation|For Kubernetes nodes running as Virtual       |                       |                       |
 |              |Ratio - VMs   |Machines, the CPU allocation ratio between    |                       |                       |
@@ -73,7 +73,7 @@ the following specifications:
 |              |              |``requests.cpu < allocatable.cpu`` and        |                       |                       |
 |              |              |``limits.cpu < allocatable.cpu``).            |                       |                       |
 +--------------+--------------+----------------------------------------------+-----------------------+-----------------------+
-|``ra2.ch.007``|IPv6DualStack |To support IPv4/IPv6 dual stack networking,   |                       |                       | 
+|``ra2.ch.007``|IPv6DualStack |To support IPv4/IPv6 dual stack networking,   |                       |                       |
 |              |              |the Kubernetes Node OS **must** support and   |                       |                       |
 |              |              |be allocated routable IPv4 and IPv6 addresses.|                       |                       |
 +--------------+--------------+----------------------------------------------+-----------------------+-----------------------+
@@ -93,7 +93,7 @@ the following specifications:
 |              |              |State Drives (SSDs).                          |d-infrastructure-hardwa|ter03.md#infrastructure|
 |              |              |                                              |re-profile-require     |-requirements>`__      |
 |              |              |                                              |ments>`__              |                       |
-|              |              |                                              |                       |                       |      
+|              |              |                                              |                       |                       |
 +--------------+--------------+----------------------------------------------+-----------------------+-----------------------+
 |``ra2.ch.010``|Local         |The Kubernetes Nodes **must** be equipped     |`e.cap.003 <./chapter02|`3.3 <../../../ref_impl|
 |              |Filesystem    |with local filesystem capacity of at least    |.md#cloud-infrastructur|/cntt-ri2/chapters/chap|
@@ -720,7 +720,7 @@ Architecture they must be implemented as per the following specifications:
 |           |                  | (version 3) charts.                               |                |                 |
 +-----------+------------------+---------------------------------------------------+----------------+-----------------+
 
-Helm version 3 has been chosen as the Application packaging mechanism to ensure compliance with the 
+Helm version 3 has been chosen as the Application packaging mechanism to ensure compliance with the
 `ONAP ASD NF descriptor specification <https://wiki.onap.org/display/DW/Application+Service+Descriptor+%28ASD%29+and+pac
 kaging+Proposals+for+CNF>`__ and `ETSI SOL0001 rel. 4 MCIOP specification <https://www.etsi.org/deliver/etsi_gs/NFV-SOL/
 001_099/001/04.02.01_60/gs_NFV-SOL001v040201p.pdf>`__.

--- a/doc/ref_arch/kubernetes/chapters/chapter06.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter06.rst
@@ -8,7 +8,7 @@ The CNCF has defined a
 `Testing Special Interest Group <https://github.com/kubernetes/community/blob/master/sig-testing/charter.md>`__ to make
 it easier for the community to write and run tests, and to contribute, analyse and act upon test results.
 This chapter maps the requirements written in the previous chapters as mandatory Special Interest Group Features. It
-enforces the overall requirements traceability to testing, especially those offered for 
+enforces the overall requirements traceability to testing, especially those offered for
 `End-to-End Testing <https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/
 e2e-tests.md>`__.
 The Anuket Reference Conformance (RC2) testing then matches the following Features tabs defined here.
@@ -286,7 +286,7 @@ storage.k8s.io               v1, v1beta1, v1alpha1
 | ExperimentalResourceUsageTracking       |             |                                                             |
 +-----------------------------------------+-------------+-------------------------------------------------------------+
 | Feature:GPUUpgrade                      |             | Master upgrade should NOT disrupt GPU Pod                   |
-+-----------------------------------------+-------------+-------------------------------------------------------------+ 
++-----------------------------------------+-------------+-------------------------------------------------------------+
 | Feature:PodGarbageCollector             |             | Should handle the creation of 1000 pods                     |
 +-----------------------------------------+-------------+-------------------------------------------------------------+
 | Feature:RegularResourceUsageTracking    |             | Resource tracking for 0 pods per node                       |


### PR DESCRIPTION
fixing build errors

./chapters/chapter03.rst:614: D000 Malformed table.
Multiple head/body row separators (table lines 3 and 8); only one allowed.

D002 Trailing whitespace

D000 Inline emphasis start-string without end-string.

D000 Inline interpreted text or phrase reference start-string without end-string

fix double colon in link:
`/home/opnfv/slave_root/workspace/cntt-tox-ra2/doc/ref_arch/kubernetes/chapters/chapter02.rst:447:undefined label: ref_model/chapters/chapter08:chapter 8 hybrid multi-cloud: data centre to edge
ERROR: InvocationError for command /home/opnfv/slave_root/workspace/cntt-tox-ra2/doc/ref_arch/kubernetes/.tox/docs/bin/sphinx-build -W -b html . build (exited with code 2)
`
