### PR TITLE
[RM Ch07] Review of security standards

### DIFF
--- a/doc/ref_model/chapters/chapter07.rst
+++ b/doc/ref_model/chapters/chapter07.rst
@@ -148,16 +148,16 @@ important standards in current use.
 - The National Institute of Standards and Technology (NIST) with the special publications:
 
   - NIST SP 800-123 `Guide to General Server Security <https://nvlpubs.nist.gov/nistpubs/Legacy 
-    /SP/nistspecialpublication800-123.pdf>`_
+    /SP/nistspecialpublication800-123.pdf>`__
     
   - NIST SP 800-204A `Building Secure Microservices-based Applications Using Service-Mesh Architecture
-    <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf>`_
+    <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf>`__
      
   - NIST SP 800-204B `Attribute-based Access Control for Microservices-based Applications Using a Service Mesh 
-    <https://csrc.nist.gov/publications/detail/sp/800-204b/final>`_
+    <https://csrc.nist.gov/publications/detail/sp/800-204b/final>`__
      
   - NIST SP 800-207 `Zero Trust Architecture 
-    <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-207.pdf>`_
+    <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-207.pdf>`__
 
 - FedRAMP Certification `https://www.fedramp.gov/ <https://www.fedramp.gov/>`__
 
@@ -165,7 +165,7 @@ important standards in current use.
   ttee/cyber>`__
   
 - `ETSI Industry Specification Group Network Functions Virtualisation (ISG NFV) 
-  <https://www.etsi.org/technologies/nfv>`_ and its Security Working Group NFV-SEC
+  <https://www.etsi.org/technologies/nfv>`__ and its Security Working Group NFV-SEC
 
 - ISO (the International Organization for Standardization) and IEC (the International Electrotechnical Commission) -
   `www.iso.org <http://www.iso.org>`__. The following ISO standards are of particular interest for NFVI
@@ -650,23 +650,23 @@ Software Supply Chain Security
 Software supply chain attacks are increasing worldwilde and can cause serious damages. Many entreprises and
 organisations are experiencing these threats. Aqua security's experts estimated that `software supply chain attacks
 have more than tripled in 2021
-<https://www.aquasec.com/news/aqua-securitys-argon-experts-find-software-supply-chain-attacks-more-than-tripled-in-2021/>`_.
+<https://www.aquasec.com/news/aqua-securitys-argon-experts-find-software-supply-chain-attacks-more-than-tripled-in-2021/>`__.
 Reuters reported in August 2021 that the `ransomware affecting Kaseya Virtual System Administration product
-<https://www.reuters.com/technology/kaseya-ransomware-attack-sets-off-race-hack-service-providers-researchers-2021-08-03/>`_
+<https://www.reuters.com/technology/kaseya-ransomware-attack-sets-off-race-hack-service-providers-researchers-2021-08-03/>`__
 caused downtime for over 1500 companies. In the case of the `backdoor inserted in codecov software
-<https://www.reuters.com/technology/codecov-hackers-breached-hundreds-restricted-customer-sites-sources-2021-04-19/>`_,
+<https://www.reuters.com/technology/codecov-hackers-breached-hundreds-restricted-customer-sites-sources-2021-04-19/>`__,
 hundred of customers were affected. The Solarwinds attack detailed in `Defending against SolarWinds attacks
-<https://www.techtarget.com/searchsecurity/news/252494495/Defending-against-SolarWinds-attacks-What-can-be-done>`_
+<https://www.techtarget.com/searchsecurity/news/252494495/Defending-against-SolarWinds-attacks-What-can-be-done>`__
 is another example of how software suppliers are targeted and, by rebound, their customers affected.
 Open-source code weaknesses can also be utilised by attackers, the
-`Log4J <https://www.cisa.gov/uscert/apache-log4j-vulnerability-guidance>`_ vulnerability, impacting many
+`Log4J <https://www.cisa.gov/uscert/apache-log4j-vulnerability-guidance>`__ vulnerability, impacting many
 applications, is a recent example in this field. When addressing cyber security, the vulnerabilities of
 software supply chain are often not taken into account. Some governments are already alerting and requesting
 actions to face these risks. The British government is hardening the law and standards of cyber security for
 the supply chain. The US government requested actions to enhance the software supply chain security.
 The security of the software supply chain is a also challenge pointed out by the European Network and
 Information Security Agency, ENISA, in the report `NFV Security in 5G - Challenges and Best Practices
-<https://www.enisa.europa.eu/publications/nfv-security-in-5g-challenges-and-best-practices>`_.
+<https://www.enisa.europa.eu/publications/nfv-security-in-5g-challenges-and-best-practices>`__.
  
 
 Software security
@@ -677,15 +677,15 @@ many different supply chains in virtualised, containerised, and edge environment
 All software components must be trusted, from commercial software, open-source
 code to proprietary software, as well as the integration of these components.
 The SAFECode white paper `"Managing Security Risks Inherent in the Use of Third-party Components"
-<https://safecode.org/wp-content/uploads/2017/05/SAFECode_TPC_Whitepaper.pdf>`_ provides
+<https://safecode.org/wp-content/uploads/2017/05/SAFECode_TPC_Whitepaper.pdf>`__ provides
 a detailed risk management approach.
 
 To secure software code, the following methods must be applied:
 
--  Use best practices coding such as design pattern recommended in the `Twelve-Factor App <https://12factor.net/>`_
-   or `OWASP "Secure Coding Practices - Quick Reference Guide" <https://owasp.org/>`_
+-  Use best practices coding such as design pattern recommended in the `Twelve-Factor App <https://12factor.net/>`__
+   or `OWASP "Secure Coding Practices - Quick Reference Guide" <https://owasp.org/>`__
 -  Do threat modelling, as described in the document `"Tactical Threat Modeling"
-   <https://safecode.org/wp-content/uploads/2017/05/SAFECode_TM_Whitepaper.pdf>`_ published by SAFECode
+   <https://safecode.org/wp-content/uploads/2017/05/SAFECode_TM_Whitepaper.pdf>`__ published by SAFECode
 -  Use trusted, authenticated and identified software images that are provided by authenticated software
    distribution portals
 -  Require suppliers to provide a Software Bill of Materials to identify all the components part of their product's
@@ -714,7 +714,7 @@ The strength of open-source code is the availability of code source developed by
 Open-source code integration with application source code helps to develop and produce applications faster.
 But, in return, it can introduce security risks if a risk management DevSecOps approach is not implemented.
 The GSMA white paper  `"Open Networking & the Security of Open Source Software Deployment - Future Networks"
-<https://www.gsma.com/futurenetworks/resources/open-networking-the-security-of-open-source-software-deployment/>`_
+<https://www.gsma.com/futurenetworks/resources/open-networking-the-security-of-open-source-software-deployment/>`__
 alerts on these risks and addresses the
 challenges coming with open-source code usage. Amongst these risks for security, we can mention a poor code quality
 containing security flaws, an obsolete code with known vulnerabilities, and the lack of knowledge of open source
@@ -746,7 +746,7 @@ and it provides assurance of the source and integrity of components. To achieve 
 a shared model must be supported by industry. This is the goal of the work performed by the US Department of Commerce
 and the National Telecommunications and Information administration (NTIA) and published, in July 2021, in the report
 `"The Minimum Elements for a Software Bill of Materials (SBOM)"
-<https://www.ntia.doc.gov/files/ntia/publications/sbom_minimum_elements_report.pdf>`_ in July 2021. The document gives
+<https://www.ntia.doc.gov/files/ntia/publications/sbom_minimum_elements_report.pdf>`__ in July 2021. The document gives
 guidance and specifies the minimum elements for the SBOM, as a starting point.
 
 A piece of software can be modeled as a hierarchical tree with components and subcomponents, each
@@ -781,7 +781,7 @@ component should have its SBOM including,  as a baseline, the information descri
 +------------------------------+---------------------------------------------------+
 
 **Table 7-2**: SBOM Data Fields components, source
-`NTIA <https://www.ntia.doc.gov/files/ntia/publications/sbom_minimum_elements_report.pdf>`_
+`NTIA <https://www.ntia.doc.gov/files/ntia/publications/sbom_minimum_elements_report.pdf>`__
 
 Refer to the NTIA SBOM document for more details on each data field. Examples of commonly used identifiers are provided.
 
@@ -797,7 +797,7 @@ and use common data syntax representations.
   associated with software components. With the SPDX specification 2.2, multiple file formats are available: YAML,
   JSON, RDF/XML, tag\:value flat text, and xls spreadsheets.
 
-- `CycloneDX <https://cyclonedx.org/>`_ was designed in 2017 for use with OWASP(Open Web Application Security Project)
+- `CycloneDX <https://cyclonedx.org/>`__ was designed in 2017 for use with OWASP(Open Web Application Security Project)
   Dependency-Track tool, an open-source Component Analysis platform that identifies risk in the software supply chain.
   CycloneDX supports a wide range of software components, including: applications, containers, libraries, files,
   firmware,   frameworks, Operating Systems. The CycloneDX project provides standards in XML, JSON, and Protocol
@@ -847,7 +847,7 @@ is a small sample of some of the testing methodologies and frameworks available.
 - OWASP testing guide
 - Penetration Testing Execution Standard, PTES
 - Technical Guide to Information Security Testing and Assessment, `NIST 800-115 
-  <https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-115.pdf>`_
+  <https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-115.pdf>`__
 - VULCAN, Vulnerability Assessment Framework for Cloud Computing, IEEE 2013
 - Penetration Testing Framework, VulnerabilityAssessment.co.uk
 - Information Systems Security Assessment Framework (ISSAF)
@@ -1242,8 +1242,9 @@ Confidentiality and Integrity
 +----------------+----------------------------------------------------------------------------+------------------------+
 | req.sec.ci.008 | The Cloud Infrastructure **must** support tenant networks segregation.     |                        |
 +----------------+----------------------------------------------------------------------------+------------------------+
-| req.sec.ci.009 | For sensitive data encryption, the key management service **should** leverage a Hardware Security   |
-|                | Module to manage and protect cryptographic keys.                           |                        |
+| req.sec.ci.009 | For sensitive data encryption, the key management service **should**       |                        |
+|                | leverage a Hardware Security Module to manage and protect cryptographic    |                        |
+|                | keys.                                                                      |                        |
 +----------------+----------------------------------------------------------------------------+------------------------+
 
 **Table 7-5:** Confidentiality and integrity requirements
@@ -1484,7 +1485,7 @@ Open Source Software
 |                 | maintained to identify the software components and their origins.         | components, `https://w |
 |                 |                                                                           | ww.ntia.gov/SBOM <http |
 |                 |                                                                           | s://www.ntia.gov/SBO   |
-|                 |                                                                           | M>`__.                 |
+|                 |                                                                           | M>`__                  |
 +-----------------+---------------------------------------------------------------------------+------------------------+
 
 **Table 7-10:** Open Source Software requirements
@@ -1498,13 +1499,13 @@ IaaC - Secure Design and Architecture Stage Requirements
 | req.sec.arch.001 | Threat Modelling methodologies and tools    | Methodology to identify and understand threats      |
 |                  | **should** be used during the               | impacting a resource or set of resources. It may be |
 |                  | Secure Design and Architecture stage        | done manually or using tools like open source OWASP |
-|                  | triggered by Software Feature Design        | Threat Dragon                                       |
-|                  | trigger                                     |                                                     |
+|                  | triggered by Software Feature Design        | Threat Dragon.                                      |
+|                  | trigger.                                    |                                                     |
 +------------------+---------------------------------------------+-----------------------------------------------------+
 | req.sec.arch.002 | Security Control Baseline Assessment        | Typically done manually by internal or independent  |
 |                  | **should** be performed during the Secure   | assessors.                                          |
 |                  | Design and Architecture stage triggered by  |                                                     |
-|                  | Software Feature Design trigger             |                                                     |
+|                  | Software Feature Design trigger.            |                                                     |
 +------------------+---------------------------------------------+-----------------------------------------------------+
 
 **Table 7-11:** IaaC - Secure Design and Architecture Stage Requirements
@@ -1720,4 +1721,61 @@ Compliance with Standards
 +-----------------+----------------------------------------------+-----------------------------------------------------+
 
 **Table 7-16:** Compliance with standards requirements
+
+Additional Security References
+------------------------------ 
+
+In addition to the security standards used throughout this specification, 
+the following lists gather additional standards of interest for Cloud Infrastructure security.
+
+**ETSI Documents**
+
+- Network Functions Virtualisation (NFV);NFV Security; Problem Statement, ETSI GS NFV-SEC 001 V1.1.1 (2014-10)
+
+- Network Functions Virtualisation (NFV);NFV Security; Security and Trust Guidance, ETSI GS NFV-SEC 003 V1.1.1
+  (2014-12)
+
+- Network Functions Virtualisation (NFV) Release 3; Security; Security Management and Monitoring specification,
+  ETSI GS NFV-SEC 013 V3.1.1 (2017-02)
+
+- Network Functions Virtualisation (NFV) Release 3; NFV Security; Security Specification for MANO Components and 
+  Reference points, ETSI GS NFV-SEC 014 V3.1.1 (2018-04)
+
+- Network Functions Virtualisation (NFV) Release 2; Security; VNF Package Security Specification,
+  ETSI GS NFV-SEC 021 V2.6.1 (2019-06)
+
+**NIST Documents**
+
+- `NIST SP 800-53 Security and Privacy Controls for Federal Information Systems and Organizations
+  <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf>`__
+
+- `NIST SP 800-53A Assessing Security and Privacy Controls in Federal Information Systems and Organizations: Building
+  Effective Assessment Plans
+  <https://www.serdp-estcp.org/content/download/47513/453118/file/NIST%20SP%20800-53A%20Rev%204%202013.pdf>`__
+
+- `NIST SP 800-63B Digital Identity Guidelines
+  <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63b.pdf>`__
+
+- `NIST SP 800-115 Technical Guide to Information Security Testing and Assessment
+  <https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-115.pdf>`__
+
+- `NIST SP 800-125 Guide to Security for Full Virtualization Technologies
+  <https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-125.pdf>`__
+
+- `NIST SP 800-125a Security Recommendations for Server-based Hypervisor Platforms
+  <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-125Ar1.pdf>`__
+
+- `NIST SP 800-125b Secure Virtual Network Configuration for Virtual Machine (VM) Protection
+  <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-125B.pdf>`__
+
+- `NIST SP 800-137 Information Security Continuous Monitoring for Federal Information 
+  Systems and Organizations
+  <https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-137.pdf>`__
+
+- `NIST SP 800-145 The NIST Definition of Cloud Computing
+  <https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-145.pdf>`__
+
+- `NIST SP 800-190 Application Container Security Guide
+  <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-190.pdf>`__
+
 

--- a/doc/ref_model/chapters/chapter07.rst
+++ b/doc/ref_model/chapters/chapter07.rst
@@ -368,7 +368,7 @@ security activities need to determine whether the requirements of the process ch
 of the security activities meets the requirements, the next set of security activities are performed as the process
 transitions to the next checkpoint, or, alternatively, to the next stage if the checkpoint is the last one in the
 current stage. If, on the other hand, the outcome of the security activities does not meet the requirements, then the
-process should not be allowed to advance to the next checkpoint. In the section 
+process should not be allowed to advance to the next checkpoint. In the section
 ":ref:`ref_model/chapters/chapter07:consolidated security requirements`", the IaaC
 security activities are presented as security requirements mapped to particular stages and trigger points.
 
@@ -396,8 +396,8 @@ the same level as in the production environment (typically of **must** type), le
 
 In the context of the contemporary telecommunication technology, the cloud infrastructure typically is considered to be
 Infrastructure as a Code (IaaC). This fact implies that many aspects of code related security automatically apply to
-IaaC. Security aspects of IaaC in the telco context is discussed in the previous section 
-":ref:`ref_model/chapters/chapter07:infrastructure as a code`", 
+IaaC. Security aspects of IaaC in the telco context is discussed in the previous section
+":ref:`ref_model/chapters/chapter07:infrastructure as a code security`",
 which introduces the relevant framework for security automation and programmatic execution and monitoring of
 security controls. Organisations need to identify which of the stages or activities within these stages should be
 performed within the non-production versus production environments. This mapping will then dictate which security
@@ -560,7 +560,7 @@ TPM will be unable to decrypt the data.
 Static Root of Trust for Measurement
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Static Root of Trust for Measurement (SRTM) begins with measuring and verifying the integrity of the BIOS firmware. 
+Static Root of Trust for Measurement (SRTM) begins with measuring and verifying the integrity of the BIOS firmware.
 It then measures additional
 firmware modules, verifies their integrity, and adds each component’s measure to an SRTM value. The final value
 represents the expected state of boot path loads. SRTM stores results as one or more values stored in PCR storage. In
@@ -608,7 +608,7 @@ platform.
 Zero Trust Architecture
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The sections ":ref:`ref_model/chapters/chapter07:remote attestation/opencit`" and 
+The sections ":ref:`ref_model/chapters/chapter07:remote attestation/opencit`" and
 ":ref:`ref_model/chapters/chapter07:root of trust for measurements`" provide
 methods to ensure the integrity of the infrastructure. The Zero Trust concept moves a step forward enabling to build
 secure by design cloud infrastructure, from hardware to applications. The adoption of Zero Trust principles mitigates

--- a/doc/ref_model/chapters/chapter07.rst
+++ b/doc/ref_model/chapters/chapter07.rst
@@ -15,7 +15,7 @@ whatever form they take.
 
 This chapter examines multiple aspects of security as it relates to Cloud Infrastructure and security aspects for
 workloads. After discussing security attack vectors, this chapter delves into security requirements. Regarding security
-requirements and best practices, specifications and documents are published by standards organizations. A selection of
+requirements and best practices, specifications and documents are published by standards organisations. A selection of
 standards of interest for Cloud Infrastructure security is listed in a dedicated section. The chapter culminates with a
 consolidated set of “must” requirements and desired (should) recommendations; it is suggested that operators carefully
 evaluate the recommendations for possible implementation.
@@ -127,30 +127,46 @@ A good place to start to understand the security requirements is to use the wide
 principles developed by the OWASP, Open Web Application Security Project:
 
 - Confidentiality – Only allow access to data for which the user is permitted.
-- Integrity – Ensure data is not tampered with or altered by unauthorized users.
-- Availability – ensure systems and data are available to authorized users when they need it.
+- Integrity – Ensure data is not tampered with or altered by unauthorised users.
+- Availability – ensure systems and data are available to authorised users when they need it.
 
 These 3 principles are complemented for Cloud Infrastructure security by:
 
 - Authenticity – The ability to confirm the users are in fact valid users with the correct rights to access the systems
   or data.
 
-Standards organizations with recommendations and best practices, and certifications that need to be taken into
+Standards organisations with recommendations and best practices, and certifications that need to be taken into
 consideration include the following examples. However this is by no means an exhaustive list, just some of the more
 important standards in current use.
 
 - Center for Internet Security - `https://www.cisecurity.org/ <https://www.cisecurity.org/>`__
+
 - Cloud Security Alliance - `https://cloudsecurityalliance.org/ <https://cloudsecurityalliance.org/>`__
-- Open Web Application Security Project `https://www.owasp.org <https://www.owasp.org>`__
-- The National Institute of Standards and Technology (NIST)
+
+- Open Web Application Security Project - `https://www.owasp.org <https://www.owasp.org>`__
+
+- The National Institute of Standards and Technology (NIST) with the special publications:
+
+  - NIST SP 800-123 `Guide to General Server Security <https://nvlpubs.nist.gov/nistpubs/Legacy 
+    /SP/nistspecialpublication800-123.pdf>`_
+    
+  - NIST SP 800-204A `Building Secure Microservices-based Applications Using Service-Mesh Architecture
+    <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf>`_
+     
+  - NIST SP 800-204B `Attribute-based Access Control for Microservices-based Applications Using a Service Mesh 
+    <https://csrc.nist.gov/publications/detail/sp/800-204b/final>`_
+     
+  - NIST SP 800-207 `Zero Trust Architecture 
+    <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-207.pdf>`_
+
 - FedRAMP Certification `https://www.fedramp.gov/ <https://www.fedramp.gov/>`__
+
 - ETSI Cyber Security Technical Committee (TC CYBER) - `https://www.etsi.org/committee/cyber <https://www.etsi.org/commi
   ttee/cyber>`__
-- ETSI Industry Specification Group Network Functions Virtualisation (ISG NFV) - `https://www.etsi.org/technologies/nfv
-  <https://www.etsi.org/technologies/nfv>`__
-- ETSI ISG NFV `SEC WG specifications <https://www.etsi.org/standards-search#page=1&search=NFV-SEC&title=0&etsiNumber=1&
-  content=0&version=1&onApproval=0&published=1&historical=0&startDate=1988-01-15&endDate=2020-02-27&harmonized=0&keyword
-  =&TB=&stdType=&frequency=&mandate=&collection=&sort=1>`__
+  
+- `ETSI Industry Specification Group Network Functions Virtualisation (ISG NFV) 
+  <https://www.etsi.org/technologies/nfv>`_ and its Security Working Group NFV-SEC
+
 - ISO (the International Organization for Standardization) and IEC (the International Electrotechnical Commission) -
   `www.iso.org <http://www.iso.org>`__. The following ISO standards are of particular interest for NFVI
 
@@ -159,8 +175,6 @@ important standards in current use.
   - ISO/IEC 27032 - ISO/IEC 27032 is the international Standard focusing explicitly on cybersecurity
   - ISO/IEC 27035 - ISO/IEC 27035 is the international Standard for incident management
   - ISO/IEC 27031 - ISO/IEC 27031 is the international Standard for ICT readiness for business continuity
-
-
 
 In mobile network field, the GSM Association (`GSMA <https://www.gsma.com/>`__) and its Fraud and Security working group
 of experts have developed a set of documents specifying how to secure the global mobile ecosystem.
@@ -354,8 +368,9 @@ security activities need to determine whether the requirements of the process ch
 of the security activities meets the requirements, the next set of security activities are performed as the process
 transitions to the next checkpoint, or, alternatively, to the next stage if the checkpoint is the last one in the
 current stage. If, on the other hand, the outcome of the security activities does not meet the requirements, then the
-process should not be allowed to advance to the next checkpoint. Tables 7-9 to 7-13 in Section 7.9 define the IaaC
-security activities presented as security requirements mapped to particular stages and trigger points.
+process should not be allowed to advance to the next checkpoint. In the section 
+":ref:`ref_model/chapters/chapter07:consolidated security requirements`", the IaaC
+security activities are presented as security requirements mapped to particular stages and trigger points.
 
 Security of Production and Non-production Environments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -377,12 +392,13 @@ environment for infrastructure software development experimentation, the configu
 in comparison with the production environment, where such experimentation is not allowed. Therefore, in this document,
 when dealing with such dilemma, the focus has been placed on those non-production security requirements that must be on
 the same level as in the production environment (typically of **must** type), leaving relaxed requirements (typically of
-**should** or **may**) in cases there is no such necessity, see Sec. 7.9.7.
+**should** or **may**) in cases there is no such necessity.
 
 In the context of the contemporary telecommunication technology, the cloud infrastructure typically is considered to be
 Infrastructure as a Code (IaaC). This fact implies that many aspects of code related security automatically apply to
-IaaC. Security aspects of IaaC in the telco context is discussed in the previous Section 7.4.4 "Infrastructure as a
-Code", which introduces the relevant framework for security automation and programmatic execution and monitoring of
+IaaC. Security aspects of IaaC in the telco context is discussed in the previous section 
+":ref:`ref_model/chapters/chapter07:infrastructure as a code`", 
+which introduces the relevant framework for security automation and programmatic execution and monitoring of
 security controls. Organisations need to identify which of the stages or activities within these stages should be
 performed within the non-production versus production environments. This mapping will then dictate which security
 activities defined for particular stages and triggers (e.g, vulnerability tests, patch testing, penetration tests) are
@@ -518,8 +534,8 @@ integrated in order to protect the cryptographic keys. A HSM is a physical devic
 Usage of a HSM strengthens the secrets security. For 5G services, GSMA FASG strongly recommends the implementation of a
 HSM to secure the storage of UICC (Universal Integrated Circuit Card) credentials.
 
-Root of Trust for Measurements (RTM)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Root of Trust for Measurements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The sections that follow define mechanisms to ensure the integrity of the infrastructure pre-boot and post-boot
 (running). The following defines a set of terms used in those sections.
@@ -534,17 +550,18 @@ The sections that follow define mechanisms to ensure the integrity of the infras
 - Root of Trust for Measurement (RTM) is a computing engine capable of making integrity measurements.
 - Core Root of Trust for Measurements (CRTM) is a set of instructions executed when performing RTM.
 - Platform Attestation provides proof of validity of the platform’s integrity measurements. Please see Section
-  `7.6.1 Remote Attestation/openCIT <#7.6.1>`__.
+  ":ref:`ref_model/chapters/chapter07:remote attestation/opencit`".
 
 Values stored in a PCR cannot be reset (or forged) as they can only be extended. Whenever a measurement is sent to a
 TPM, the hash of the concatenation of the current value of the PCR and the new measurement is stored in the PCR. The PCR
 values are used to encrypt data. If the proper environment is not loaded which will result in different PCR values, the
 TPM will be unable to decrypt the data.
 
-Static Root of Trust for Measurement (SRTM)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Static Root of Trust for Measurement
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Static RTM (SRTM) begins with measuring and verifying the integrity of the BIOS firmware. It then measures additional
+Static Root of Trust for Measurement (SRTM) begins with measuring and verifying the integrity of the BIOS firmware. 
+It then measures additional
 firmware modules, verifies their integrity, and adds each component’s measure to an SRTM value. The final value
 represents the expected state of boot path loads. SRTM stores results as one or more values stored in PCR storage. In
 SRTM, the CRTM resets PCRs 0 to 15 only at boot.
@@ -569,8 +586,8 @@ kernel level.
 The validation of the platform measurements can be performed by TPM’s launch control policy (LCP) or through the remote
 attestation server.
 
-Dynamic Root of Trust for Measurement (DRTM)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Dynamic Root of Trust for Measurement
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In Dynamic Root of Trust for Measurement (DRTM), the RTM for the running environment are stored in PCRs starting with
 PCR 17.
@@ -588,10 +605,11 @@ lifecycle of the platform.
 This allows the attestation server to detect any tampering with the static file system during the runtime of the
 platform.
 
-Zero Trust Architecture (ZTA)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Zero Trust Architecture
+~~~~~~~~~~~~~~~~~~~~~~~
 
-Remote attestation, section `7.6.1 <#7.6.1>`__, and Root of trust for measurements, section `7.6.5 <#7.6.5>`__, provide
+The sections ":ref:`ref_model/chapters/chapter07:remote attestation/opencit`" and 
+":ref:`ref_model/chapters/chapter07:root of trust for measurements`" provide
 methods to ensure the integrity of the infrastructure. The Zero Trust concept moves a step forward enabling to build
 secure by design cloud infrastructure, from hardware to applications. The adoption of Zero Trust principles mitigates
 the threats and attacks within an enterprise, a network or an infrastructure, ensuring a fine grained segmentation
@@ -713,8 +731,8 @@ Access to the repository must be granted by a dedicated authorization. The code 
 identified as described previously. After validating the software, it can be moved to the appropriate production
 repository.
 
-Software Bill of Materials (SBOM)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Software Bill of Materials
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In order to ensure software security, it is crucial to identify the software components and their origins. The
 Software Bill of Materials (SBOM), described by `US NTIA <https://www.ntia.gov/SBOM>`__ (National
@@ -774,26 +792,21 @@ eXchange (SPDX), CycloneDX, and Software Identification Tags (SWID tags) are int
 and use common data syntax representations.
 
 - `SPDX <https://spdx.dev/>`__ is an open-source machine-readable format developed under the umbrella of the Linux
-  Foundation.
-
-  The `SPDX specification 2.2 <https://spdx.dev/specifications/>`__ has been published as the standard
+  Foundation. The `SPDX specification 2.2 <https://spdx.dev/specifications/>`__ has been published as the standard
   ISO/IEC 5962:2021. It provides a language for communicating the data, licenses, copyrights, and security information
   associated with software components. With the SPDX specification 2.2, multiple file formats are available: YAML,
   JSON, RDF/XML, tag\:value flat text, and xls spreadsheets.
 
 - `CycloneDX <https://cyclonedx.org/>`_ was designed in 2017 for use with OWASP(Open Web Application Security Project)
   Dependency-Track tool, an open-source Component Analysis platform that identifies risk in the software supply chain.
-
   CycloneDX supports a wide range of software components, including: applications, containers, libraries, files,
   firmware,   frameworks, Operating Systems. The CycloneDX project provides standards in XML, JSON, and Protocol
   Buffers, as well as a large collection of official and community supported tools that create or interoperate with
   the standard.
 
 - `SWID Tags <https://nvd.nist.gov/products/swid>`__ is an international XML-based standard used by commercial software
-  publishers and has been published as the standard ISO/IEC 19770-2.
-
-  The specification defines four types of SWID tags:
-  primary, patch, corpus, and supplemental to describe a software component.
+  publishers and has been published as the standard ISO/IEC 19770-2. The specification defines four types of SWID 
+  tags: primary, patch, corpus, and supplemental to describe a software component.
 
 The SBOM should be integrated into the operations of the secure development life cycle, especially for vulnerabilities
 management. It should also evolve in time. When a software component is updated, a new SBOM must be created. The
@@ -833,7 +846,8 @@ is a small sample of some of the testing methodologies and frameworks available.
 
 - OWASP testing guide
 - Penetration Testing Execution Standard, PTES
-- Technical Guide to Information Security Testing and Assessment, NIST 00-115
+- Technical Guide to Information Security Testing and Assessment, `NIST 800-115 
+  <https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-115.pdf>`_
 - VULCAN, Vulnerability Assessment Framework for Cloud Computing, IEEE 2013
 - Penetration Testing Framework, VulnerabilityAssessment.co.uk
 - Information Systems Security Assessment Framework (ISSAF)
@@ -920,7 +934,7 @@ SOC, but also commonly used frameworks like OWASP, ISAE, NIST, ETSI and ISO 2700
 geographically localised standard frameworks like NIST (as used in the U.S.A.), ENISA, GDPR, ISM.
 
 The use of the ISO 2700s, OWASP, ISAE, NIST and ETSI security frameworks for cloud infrastructure is referenced in
-“Common Security Standards”, “Compliance with  Standards” and “Security References” sections of this chapter.
+"Common Security Standards" and "Compliance with  Standards" sections.
 
 Examples of regulatory frameworks are briefly presented below. It is intended to expand this list of examples in the
 future releases to cover more jurisdictions and  to accommodate changes in the rapidly evolving security and
@@ -981,7 +995,7 @@ government, providing a unified source of advice, guidance and support on cyber 
 cyber security incidents. From this perspective it is critical for the cloud related security in the UK
 telecommunications industry. The NCSC is not a regulator. Within the general UK cyber security regulatory environment,
 including both NIS and GDPR, the NCSC’s aim is to operate as a trusted, expert and impartial advisor to all
-interested parties. The NCSC supports Security of Networks & Information Systems (NIS) Regulations
+interested parties. The NCSC supports Security of Networks & Information Systems (NIS) Regulations.
 
 The data protection in UK is controlled by
 `Data Protection Act 2018 <https://www.legislation.gov.uk/ukpga/2018/12/contents/enacted/>`__, which is UK’s
@@ -1079,9 +1093,9 @@ System Hardening
 |                 | and Write only storage partitions (write only    |                                                 |
 |                 | permission to one or more authorized actors).    |                                                 |
 +-----------------+--------------------------------------------------+-------------------------------------------------+
-| req.sec.gen.012 | The Operator **must** ensure that only           | It is mandatory for a Cloud Infrastructure      |
-|                 | authorized actors have physical access to the    | Operator, but this requirement’s verification   |
-|                 | underlying infrastructure.                       | is out of scope                                 |
+| req.sec.gen.012 | The Operator **must** ensure that only           |                                                 |
+|                 | authorized actors have physical access to the    |                                                 |
+|                 | underlying infrastructure.                       |                                                 |
 +-----------------+--------------------------------------------------+-------------------------------------------------+
 | req.sec.gen.013 | The Platform **must** ensure that only           |                                                 |
 |                 | authorized actors have logical access to the     |                                                 |
@@ -1156,7 +1170,7 @@ Platform and Access
 |                 | different Platform components (e.g., on          |                                                 |
 |                 | different hosts, or different services).         |                                                 |
 +-----------------+--------------------------------------------------+-------------------------------------------------+
-| req.sec.sys.012 | The Platform **must** protect all secrets by     | (e.g., in OpenStack Barbican).                  |
+| req.sec.sys.012 | The Platform **must** protect all secrets by     | E.g., in OpenStack Barbican.                    |
 |                 | using strong encryption techniques, and storing  |                                                 |
 |                 | the protected secrets externally from the        |                                                 |
 |                 | component.                                       |                                                 |
@@ -1171,7 +1185,7 @@ Platform and Access
 | req.sec.sys.015 | The Platform **must not** contain back door      |                                                 |
 |                 | entries (unpublished access points, APIs, etc.). |                                                 |
 +-----------------+--------------------------------------------------+-------------------------------------------------+
-| req.sec.sys.016 | Login access to the platform's components        | Note: Hardened jump servers isolated from       |
+| req.sec.sys.016 | Login access to the platform's components        | Hardened jump servers isolated from             |
 |                 | **must** be through encrypted protocols such as  | external networks are recommended               |
 |                 | SSH v2 or TLS v1.2 or higher.                    |                                                 |
 +-----------------+--------------------------------------------------+-------------------------------------------------+
@@ -1251,9 +1265,8 @@ Workload Security
 | req.sec.wl.004 | The Platform **must** support Location assertion (for mandated in-country  |                        |
 |                | or location requirements).                                                 |                        |
 +----------------+----------------------------------------------------------------------------+------------------------+
-| req.sec.wl.005 | The Platform **must** support the separation of production and             | This requirement’s     |
-|                | non-production Workloads.                                                  | verification is out of |
-|                |                                                                            | scope.                 |
+| req.sec.wl.005 | The Platform **must** support the separation of production and             |                        |
+|                | non-production Workloads.                                                  |                        |
 +----------------+----------------------------------------------------------------------------+------------------------+
 | req.sec.wl.006 | The Platform **must** support the separation of Workloads based on their   |                        |
 |                | categorisation (for example, payment card information, healthcare, etc.).  |                        |
@@ -1359,7 +1372,8 @@ systems, policies and procedures to act on alerts and notifications in a timely 
 and logging capabilities can trigger alerts and notifications for appropriate action. In general, it is a good practice
 to have the same security monitoring and auditing capabilities in both production and non-production environements.
 However, we distinguish between requirements for Production Platform (Prod-Platform) and Non-production Platform
-(NonProd-Platform) as some of the requirements may in practice need to differ, see Sec. 7.4.5 for the general discussion
+(NonProd-Platform) as some of the requirements may in practice need to differ, see section 
+:ref:`ref_model/chapters/chapter07:security of production and non-production environments` for the general discussion
 of this topic. In the table below, when a requirement mentions only Prod-Platform, it is assumed that this requirement
 is optional for NonProd-Platform. If a requirement does not mention any environment, it is assumed that it is valid for
 both Prod-Platform and NonProd-Platform.
@@ -1707,79 +1721,3 @@ Compliance with Standards
 
 **Table 7-16:** Compliance with standards requirements
 
-Security References
--------------------
-
-Network Functions Virtualisation (NFV);NFV Security; Problem Statement, ETSI GS NFV-SEC 001 V1.1.1 (2014-10)
-
-Network Functions Virtualisation (NFV);NFV Security; Security and Trust Guidance, ETSI GS NFV-SEC 003 V1.1.1 (2014-12)
-
-Network Functions Virtualisation (NFV) Release 3; Security; Security Management and Monitoring specification,
-ETSI GS NFV-SEC 013 V3.1.1 (2017-02)
-
-Network Functions Virtualisation (NFV) Release 3; NFV Security; Security Specification for MANO Components and Reference
-points, ETSI GS NFV-SEC 014 V3.1.1 (2018-04)
-
-Network Functions Virtualisation (NFV) Release 2; Security; VNF Package Security Specification,
-ETSI GS NFV-SEC 021 V2.6.1 (2019-06)
-
-ETSI Industry Specification Group Network Functions Virtualisation (ISG NFV),
-`https://www.etsi.org/committee/1427-nfv <https://www.etsi.org/committee/1427-nfv>`__
-
-ETSI Cyber Security Technical Committee (TC CYBER),
-`https://www.etsi.org/committee/cyber <https://www.etsi.org/committee/cyber>`__
-
-**NIST Documents**
-
-NIST SP 800-53 Security and Privacy Controls for Federal Information Systems and Organizations,
-`https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf <https://nvlpubs.nist.gov/nistpubs/SpecialPu
-blications/NIST.SP.800-53r4.pdf>`__
-
-NIST SP 800-53A Assessing Security and Privacy Controls in Federal Information Systems and Organizations: Building
-Effective Assessment Plans,
-`https://www.serdp-estcp.org/content/download/47513/453118/file/NIST%20SP%20800-53A%20Rev%204%202013.pdf <https://www.se
-rdp-estcp.org/content/download/47513/453118/file/NIST%20SP%20800-53A%20Rev%204%202013.pdf>`__
-
-NIST SP 800-63B Digital Identity Guidelines,
-`https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63b.pdf <https://nvlpubs.nist.gov/nistpubs/SpecialPub
-lications/NIST.SP.800-63b.pdf>`__
-
-NIST SP 800-115 Technical Guide to Information Security Testing and Assessment,
-`https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-115.pdf <https://nvlpubs.nist.gov/nistpubs/Legacy
-/SP/nistspecialpublication800-115.pdf>`__
-
-NIST SP 800-123 Guide to General Server Security,
-`https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-123.pdf <https://nvlpubs.nist.gov/nistpubs/Legacy
-/SP/nistspecialpublication800-123.pdf>`__
-
-NIST SP 800-125 Guide to Security for Full Virtualization Technologies,
-`https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-125.pdf <https://nvlpubs.nist.gov/nistpubs/Legacy
-/SP/nistspecialpublication800-125.pdf>`__
-
-NIST SP 800-125a Security Recommendations for Server-based Hypervisor Platforms,
-`https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-125Ar1.pdf <https://nvlpubs.nist.gov/nistpubs/Special
-Publications/NIST.SP.800-125Ar1.pdf>`__
-
-NIST SP 800-125b Secure Virtual Network Configuration for Virtual Machine (VM) Protection,
-`https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-125B.pdf <https://nvlpubs.nist.gov/nistpubs/SpecialPu
-blications/NIST.SP.800-125B.pdf>`__
-
-NIST SP 800-137 Information Security Continuous Monitoring for Federal Information Systems and Organizations,
-`https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-137.pdf <https://nvlpubs.nist.gov/nistpubs/Legacy
-/SP/nistspecialpublication800-137.pdf>`__
-
-NIST SP 800-145 The NIST Definition of Cloud Computing,
-`https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-145.pdf <https://nvlpubs.nist.gov/nistpubs/Legacy
-/SP/nistspecialpublication800-145.pdf>`__
-
-NIST SP 800-190 Application Container Security Guide,
-`https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-190.pdf <https://nvlpubs.nist.gov/nistpubs/SpecialPub
-lications/NIST.SP.800-190.pdf>`__
-
-NIST SP 800-204A Building Secure Microservices-based Applications Using Service-Mesh Architecture,
-`https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf <https://nvlpubs.nist.gov/nistpubs/SpecialPu
-blications/NIST.SP.800-204A.pdf>`__
-
-NIST SP 800-204B Attribute-based Access Control for Microservices-based Applications Using a Service Mesh,
-`https://csrc.nist.gov/publications/detail/sp/800-204b/final <https://csrc.nist.gov/publications/detail/sp/800-204b/fina
-l>`__

--- a/doc/ref_model/chapters/chapter09.rst
+++ b/doc/ref_model/chapters/chapter09.rst
@@ -174,9 +174,6 @@ Automation
 Infrastructure LCM Automation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Introduction
-^^^^^^^^^^^^
-
 In a typical telecom operator environment, infrastructure Life Cycle Management is highly complex and error-prone. The
 environment, with its multiple vendors and products, is maintenance expensive (both in terms of time and costs) because
 of the need for complex planning, testing, and the out-of-business-hours execution required to perform disruptive


### PR DESCRIPTION
Fixes issue#2841
Review of security standards: Standards not mentioned into text are removed
The 'security references' section is removed, references added to 'common security standards'
Links to sections added, manual numbering removed
Some typos correction