### PR TITLE
Lookup to the local references

### DIFF
--- a/doc/ref_arch/openstack/conf.py
+++ b/doc/ref_arch/openstack/conf.py
@@ -18,7 +18,7 @@ intersphinx_mapping = {
     'cntt': ('https://cntt.readthedocs.io/en/latest/', None)
 }
 autosectionlabel_prefix_document = True
-autosectionlabel_maxdepth = 3
+autosectionlabel_maxdepth = 4
 numfig = True
 numfig_format = {'figure': 'Figure %s', 'table': 'Table %s',
                  'code-block': 'Listing %s', 'section': 'Section %s'}

--- a/doc/ref_arch/openstack/tox.ini
+++ b/doc/ref_arch/openstack/tox.ini
@@ -8,7 +8,9 @@ deps =
   -chttps://opendev.org/openstack/requirements/raw/branch/stable/xena/upper-constraints.txt
   -r{toxinidir}/test-requirements.txt
 install_command = pip install {opts} {packages}
+allowlist_externals = /bin/bash
 commands =
+  bash -c 'sed -i "s|:ref:\`ref_arch/openstack/chapters|:ref:\`chapters|g" index.rst chapters/*.rst'
   doc8 . --ignore-path .tox --ignore-path build --max-line-length 120
   sphinx-build --keep-going -W -b html . build
   sphinx-build --keep-going -W -b latex . build

--- a/doc/ref_cert/RC1/tox.ini
+++ b/doc/ref_cert/RC1/tox.ini
@@ -8,7 +8,9 @@ deps =
   -chttps://opendev.org/openstack/requirements/raw/branch/stable/xena/upper-constraints.txt
   -r{toxinidir}/test-requirements.txt
 install_command = pip install {opts} {packages}
+allowlist_externals = /bin/bash
 commands =
+  bash -c 'sed -i "s|:ref:\`ref_cert/RC1/chapters|:ref:\`chapters|g" index.rst chapters/*.rst'
   doc8 . --ignore-path .tox --ignore-path build
   sphinx-build -W -b html . build
   sphinx-build -W -b latex . build

--- a/doc/ref_cert/RC2/tox.ini
+++ b/doc/ref_cert/RC2/tox.ini
@@ -8,7 +8,9 @@ deps =
   -chttps://opendev.org/openstack/requirements/raw/branch/stable/xena/upper-constraints.txt
   -r{toxinidir}/test-requirements.txt
 install_command = pip install {opts} {packages}
+allowlist_externals = /bin/bash
 commands =
+  bash -c 'sed -i "s|:ref:\`ref_cert/RC2/chapters|:ref:\`chapters|g" index.rst chapters/*.rst'
   doc8 . --ignore-path .tox --ignore-path build
   sphinx-build -W -b html . build
   sphinx-build -W -b latex . build

--- a/doc/ref_cert/tox.ini
+++ b/doc/ref_cert/tox.ini
@@ -8,7 +8,9 @@ deps =
   -chttps://opendev.org/openstack/requirements/raw/branch/stable/xena/upper-constraints.txt
   -r{toxinidir}/test-requirements.txt
 install_command = pip install {opts} {packages}
+allowlist_externals = /bin/bash
 commands =
+  bash -c 'sed -i "s|:ref:\`ref_cert/|:ref:\`|g" index.rst'
   doc8 index.rst
   sphinx-build -W -b html . build
   sphinx-build -W -b linkcheck . build


### PR DESCRIPTION
It preprocesses ref to generates internal refs instead
of external refs to cntt.readthedocs.org. It's crucial
for GSMA documents (PDF).

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>