### PR TITLE
[RA2] Fix false markdown links

### DIFF
--- a/doc/ref_arch/kubernetes/chapters/chapter03.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter03.rst
@@ -389,7 +389,7 @@ agreed between the CNF vendors and the CNF operators:
    `DANM <https://github.com/nokia/danm>`__)
 -  An external, **federated networking manager** that uses the Kubernetes API Server
    to create and manage additional connections for Pods (e.g. `Network Service
-   Mesh <https://networkservicemesh.io/docs/concepts/what-is-nsm/>`__)
+   Mesh <https://networkservicemesh.io>`__)
 
 +----------------------+---------------------+----------------------+----------------------+---------------------------+
 | Requirement          | Networking Solution | Networking Solution  | Networking Solution  | Networking Solution       |

--- a/doc/ref_arch/kubernetes/chapters/chapter04.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter04.rst
@@ -233,10 +233,10 @@ the following specifications:
 |           |                  | listed in the `Kubernetes Distributions and       |                |                 |
 |           |                  | Platforms document <https://docs.google.com/sprea |                |                 |
 |           |                  | dsheets/d/1uF9BoDzzisHSQemXHIKegMhuythuq_GL3N1mlU |                |                 |
-|           |                  | UK2h0/edit#gid=0>`__ and marked (X) as conformant |                |                 |
-|           |                  | for the Kubernetes version defined in `README <.. |                |                 |
-|           |                  | /README.md#required-versions-of-most-important-co |                |                 |
-|           |                  | mponents>`__.                                     |                |                 |
+|           |                  | UK2h0/edit>`__ and marked (X) as conformant       |                |                 |
+|           |                  | for the Kubernetes version defined in             |                |                 |
+|           |                  | :ref:`index:required versions of most important   |                |                 |
+|           |                  | components`.                                      |                |                 |
 +-----------+------------------+---------------------------------------------------+----------------+-----------------+
 |ra2.k8s.002| Highly available | An implementation **must** consist of either      | `req.gen.rsl.  | `RI2 4.3.1`     |
 |           | etcd             | three, five or seven nodes running the etcd       | 02`, `req.gen. |                 |
@@ -294,9 +294,9 @@ the following specifications:
 |           | Version          | policy <https://kubernetes.io/docs/setup/release/ |                |                 |
 |           |                  | version-skew-policy/#supported-versions>`__, an   |                |                 |
 |           |                  | implementation **must** use a Kubernetes version  |                |                 |
-|           |                  | as per the subcomponent versions table in `README |                |                 |
-|           |                  | <../README.md#required-versions-of-most-important |                |                 |
-|           |                  | -components>`__.                                  |                |                 |
+|           |                  | as per the subcomponent versions table in         |                |                 |
+|           |                  | :ref:`index:required versions of most important   |                |                 |
+|           |                  | components`.                                      |                |                 |
 +-----------+------------------+---------------------------------------------------+----------------+-----------------+
 |ra2.k8s.006| NUMA Support     | When hosting workloads matching the High          | `e.cap.007`,   |                 |
 |           |                  | Performance profile, the ``TopologyManager`` and  | `infra.com.cfg |                 |
@@ -365,8 +365,9 @@ the following specifications:
 |           |                  | must be set to ``true`` on the worker node if it  |                |                 |
 |           |                  | can fulfil the requirements of the High           |                |                 |
 |           |                  | Performance profile. The requirements for both    |                |                 |
-|           |                  | profiles can be found in `chapter 2 <./chapter02. |                |                 |
-|           |                  | md#reference-model-requirements>`__               |                |                 |
+|           |                  | profiles can be found in                          |                |                 |
+|           |                  | :ref:`chapters/chapter02:reference model          |                |                 |
+|           |                  | requirements`                                     |                |                 |
 +-----------+------------------+---------------------------------------------------+----------------+-----------------+
 |ra2.k8s.012| Kubernetes APIs  | Kubernetes `Alpha API <https://kubernetes.io/docs |                |                 |
 |           |                  | /reference/using-api/#api-versioning>`__ are      |                |                 |
@@ -669,7 +670,7 @@ Service meshes
 Application service meshes are not in scope for the architecture. The service mesh is a dedicated infrastructure layer
 for handling service-to-service communication, and it is recommended to secure service-to-service communications within
 a cluster and to reduce the attack surface. The benefits of the service mesh framework are described in
-`5.4.3 <./chapter05.md#use-transport-layer-security-and-service-mesh>`__. In addition to securing communications, the
+:ref:`chapters/chapter05:use transport layer security and service mesh`. In addition to securing communications, the
 use of a service mesh extends Kubernetes capabilities regarding observability and reliability.
 
 Network service mesh specifications are handled in section `4.5 Networking solutions <#networking-solutions>`__.

--- a/doc/ref_arch/kubernetes/chapters/chapter07.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter07.rst
@@ -91,8 +91,7 @@ Kubernetes as a VM-based VNF Orchestrator
 Multiple network interfaces on Pods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   **Related requirements:** `RM Chapter 4.2.2 <../../../ref_model/chapters/chapter04.md#virtual-network-interface-spec
-   ifications>`__
+   **Related requirements:** :ref:`ref_model:chapters/chapter04:virtual network interface specifications`
 
 ..
 
@@ -107,7 +106,7 @@ Multiple network interfaces on Pods
 Dynamic network management
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   **Related requirements:** `req.inf.ntw.03 <chapter02.md#kubernetes-architecture-requirements>`__
+   **Related requirements:** :ref:`req.inf.ntw.03 <chapters/chapter02:kubernetes architecture requirements>`
 
 ..
 
@@ -160,7 +159,7 @@ HW topology aware huge pages
 **Baseline project:** *Kubernetes*
 
 **Gap description:** Memory Manager was added in v1.21 as alpha feature. More in
-`3.2.1.3 Memory and Huge Pages Resources Management <chapter03.md#memory-and-huge-pages-resources-management>`__.
+:ref:`chapters/chapter03:memory and huge pages resources management`.
 
 User namespaces in Kubernetes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/ref_arch/kubernetes/conf.py
+++ b/doc/ref_arch/kubernetes/conf.py
@@ -10,6 +10,13 @@ extensions = [
     'sphinx.ext.autosectionlabel'
 ]
 html_theme = "sphinx_material"
+linkcheck_ignore = [
+    "https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md",
+    "https://github.com/opencontainers/runtime-spec/blob/master/config.md",
+    "https://www.iso.org/obp/ui/#iso:std:iso-iec:27001:ed-2:v1:en",
+    "https://www.iso.org/obp/ui/#iso:std:iso-iec:27002:ed-2:v1:en",
+    "https://www.iso.org/obp/ui/#iso:std:iso-iec:27032:ed-1:v1:en"
+]
 intersphinx_mapping = {
     'cntt': ('https://cntt.readthedocs.io/en/latest/', None),
     'ref_model': ('https://cntt.readthedocs.io/projects/rm/en/latest/', None)


### PR DESCRIPTION
Please note https://networkservicemesh.io/docs/concepts/what-is-nsm/
no longer exists (it's replaced by https://networkservicemesh.io)

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>