### PR TITLE
Unify Sphinx config

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,51 +1,12 @@
-import sphinx_material
-
 master_doc = 'index'
 project = "Anuket Specifications"
 html_title = "Anuket Specifications"
 copyright = '2021, Anuket. Licensed under CC BY 4.0'
 author = 'Anuket Project of Linux Foundation Networking'
-
 extensions = ['sphinx.ext.intersphinx',
               'sphinx.ext.autosectionlabel'
              ]
 html_theme = "sphinx_material"
-html_theme_path = sphinx_material.html_theme_path()
-html_context = sphinx_material.get_html_context()
-
-html_sidebars = {
-    "**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]
-}
-
-html_static_path = ['_static']
-html_css_files = [
-    'css/custom.css',
-]
-
-html_theme_options = {
-    'repo_name': 'Material for Sphinx',
-    'nav_title': 'Anuket Specifications',
-     # Set the color and the accent color
-    'color_primary': 'white',
-    'color_accent': 'teal',
-    # Visible levels of the global TOC; -1 means unlimited
-    'globaltoc_depth': 1,
-    # If False, expand all TOC entries
-    'globaltoc_collapse': False,
-    # If True, show hidden TOC entries
-    'globaltoc_includehidden': False,
-    'nav_links': [
-        {
-            'href': 'https://docs.opnfv.org/',
-            'internal': False,
-            'title': 'Anuket Project Documentation'
-        }
-    ]
-}
-
-html_logo = '_static/anuket-logo.png'
-html_favicon = '_static/favicon.ico'
-
 exclude_patterns = [
     '**/.tox',
     'ref_arch',
@@ -54,13 +15,10 @@ exclude_patterns = [
     'ref_model',
     'tech'
 ]
-
 linkcheck_ignore = [
     'https://github.com/cncf/telecom-user-group/blob/master/whitepaper/cloud_native_thinking_for_telecommunications.md#1.4',
     'https://static1.squarespace.com/static/5ad774cce74940d7115044b0/t/5db36ffa820b8d29022b6d08/1572040705841/ORAN-WG4.IOT.0-v01.00.pdf/2018/180226_NGMN_RANFSX_D1_V20_Final.pdf'
 ]
-
-
 intersphinx_mapping = {
     'ref_model': ('https://cntt.readthedocs.io/projects/rm/en/latest/', None),
     'ref_arch_openstack': ('https://cntt.readthedocs.io/projects/ra1/en/latest/', None),
@@ -70,6 +28,5 @@ intersphinx_mapping = {
     'ref_impl_cntt-ri': ('https://cntt.readthedocs.io/projects/ri1/en/latest/', None),
     'ref_impl_cntt-ri2': ('https://cntt.readthedocs.io/projects/ri2/en/latest/', None)
 }
-
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 4

--- a/doc/ref_arch/openstack/conf.py
+++ b/doc/ref_arch/openstack/conf.py
@@ -21,4 +21,6 @@ intersphinx_mapping = {
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 4
 numfig = True
+numfig_format = {'figure': 'Figure %s', 'table': 'Table %s',
+                 'code-block': 'Listing %s', 'section': 'Section %s'}
 latex_theme = 'howto'

--- a/doc/ref_cert/RC1/conf.py
+++ b/doc/ref_cert/RC1/conf.py
@@ -24,5 +24,4 @@ autosectionlabel_maxdepth = 4
 numfig = True
 numfig_format = {'figure': 'Figure %s', 'table': 'Table %s',
                  'code-block': 'Listing %s', 'section': 'Section %s'}
-
 latex_theme = 'howto'

--- a/doc/ref_impl/cntt-ri/conf.py
+++ b/doc/ref_impl/cntt-ri/conf.py
@@ -1,68 +1,25 @@
-import sphinx_material
-
 project = 'Anuket Reference Implementation for Kubernetes'
 html_title = "Anuket Reference Implementation for Kubernetes"
 copyright = '2021, Anuket. Licensed under CC BY 4.0'
 author = 'Anuket Project of Linux Foundation Networking'
-
 exclude_patterns = [
     '.tox',
     'README.rst'
 ]
 extensions = [
-    'sphinx_material',
     'sphinx.ext.intersphinx',
     'sphinx.ext.autosectionlabel'
 ]
-
-html_theme = "sphinx_material"
-html_theme_path = sphinx_material.html_theme_path()
-html_context = sphinx_material.get_html_context()
-
-html_sidebars = {
-    "**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]
-}
-
-html_static_path = ['../../_static']
-html_logo = '../../_static/anuket-logo.png'
-html_favicon = '../../_static/favicon.ico'
-#html_css_files = [
-#    'css/custom.css',
-#]
-
-html_theme_options = {
-    'repo_name': 'Material for Sphinx',
-    'nav_title': 'Anuket Specifications',
-     # Set the color and the accent color
-    'color_primary': 'white',
-    'color_accent': 'teal',
-    # Visible levels of the global TOC; -1 means unlimited
-    'globaltoc_depth': 1,
-    # If False, expand all TOC entries
-    'globaltoc_collapse': False,
-    # If True, show hidden TOC entries
-    'globaltoc_includehidden': False,
-    'nav_links': [
-        {
-            'href': 'https://docs.opnfv.org/',
-            'internal': False,
-            'title': 'Anuket Project Documentation'
-        }
-    ]
-}
-
 linkcheck_ignore = [
-        'http://127.0.0.1',
-        'https://trex-tgn.cisco.com'
+    'http://127.0.0.1',
+    'https://trex-tgn.cisco.com'
 ]
-
 intersphinx_mapping = {
     'cntt': ('https://cntt.readthedocs.io/en/latest/', None),
     'ref_model': ('https://cntt.readthedocs.io/projects/rm/en/latest/', None),
     'ref_arch_openstack': ('https://cntt.readthedocs.io/projects/ra1/en/latest/', None),
     'ref_cert_RC1': ('https://cntt.readthedocs.io/projects/rc1/en/latest/', None)
 }
-
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 4
 numfig = True

--- a/doc/ref_impl/cntt-ri2/conf.py
+++ b/doc/ref_impl/cntt-ri2/conf.py
@@ -14,47 +14,10 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.autosectionlabel'
 ]
-
 html_theme = "sphinx_material"
-html_theme_path = sphinx_material.html_theme_path()
-html_context = sphinx_material.get_html_context()
-
-html_sidebars = {
-    "**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]
-}
-
-html_static_path = ['../../_static']
-html_logo = '../../_static/anuket-logo.png'
-html_favicon = '../../_static/favicon.ico'
-#html_css_files = [
-#    'css/custom.css',
-#]
-
-html_theme_options = {
-    'repo_name': 'Material for Sphinx',
-    'nav_title': 'Anuket Specifications',
-     # Set the color and the accent color
-    'color_primary': 'white',
-    'color_accent': 'teal',
-    # Visible levels of the global TOC; -1 means unlimited
-    'globaltoc_depth': 1,
-    # If False, expand all TOC entries
-    'globaltoc_collapse': False,
-    # If True, show hidden TOC entries
-    'globaltoc_includehidden': False,
-    'nav_links': [
-        {
-            'href': 'https://docs.opnfv.org/',
-            'internal': False,
-            'title': 'Anuket Project Documentation'
-        }
-    ]
-}
-
 linkcheck_ignore = [
-        'http://127.0.0.1'
+    'http://127.0.0.1'
 ]
-
 intersphinx_mapping = {
     'cntt': ('https://cntt.readthedocs.io/en/latest/', None),
     'ref_model': ('https://cntt.readthedocs.io/projects/rm/en/latest/', None),
@@ -62,7 +25,6 @@ intersphinx_mapping = {
     'ref_cert_RC2': ('https://cntt.readthedocs.io/projects/rc2/en/latest/', None),
     'ref_impl_cntt-ri': ('https://cntt.readthedocs.io/projects/ri1/en/latest/', None)
 }
-
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 3
 numfig = True


### PR DESCRIPTION
They are several differences in Sphinx config which breaks
user naviguation.

The proposal is, by default, to use default Material values,
and to apply any change to all streams per PR.

It also selects Figure in all captions (default is Fig.).

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>