### PR TITLE
[RC] Update all wiki.opnfv.org links

### DIFF
--- a/doc/ref_cert/RC1/chapters/chapter03.rst
+++ b/doc/ref_cert/RC1/chapters/chapter03.rst
@@ -61,7 +61,7 @@ completed by Rally scenarios in a few cases. Skipping tests is allowed
 in all OpenStack Gates and only failures rate the review -1 because of
 the multiple capabilities and backends selected in the different Gate
 jobs. The classical `Functest
-containers <https://wiki.opnfv.org/pages/viewpage.action?pageId=29098314>`__
+containers <https://wiki.anuket.io/display/HOME/Functest+Wallaby>`__
 conform to this model which also fits the heterogeneous user
 deployments.
 
@@ -1175,9 +1175,9 @@ Specification of Networking Benchmarks and Measurement Methods for
 NFVI <https://www.etsi.org/deliver/etsi_gs/NFV-TST/001_099/009/03.01.01_60/gs_NFV-TST009v030101p.pdf>`__.
 This type of testing is better suited to measure the networking
 capabilities of a compute node. The `rapid
-scripts <https://wiki.opnfv.org/display/SAM/Rapid+scripting>`__ in
+scripts <https://git.opnfv.org/samplevnf>`__ in
 conjunction with the `PROX
-tool <https://wiki.opnfv.org/pages/viewpage.action?pageId=12387840>`__
+tool <https://docs.anuket.io/projects/samplevnf/en/latest/testing/user/userguide/index.html>`__
 offers an open source implementation for this type of testing.
 
 VMTP

--- a/doc/ref_cert/RC1/chapters/chapter04.rst
+++ b/doc/ref_cert/RC1/chapters/chapter04.rst
@@ -159,9 +159,9 @@ Additional links:
 
 -  `Homepage <https://functest.readthedocs.io/en/stable-iruya/>`__
 -  `Run Alpine Functest containers
-   (Iruya) <https://wiki.opnfv.org/pages/viewpage.action?pageId=35291769>`__
+   (Wallaby) <https://wiki.anuket.io/display/HOME/Functest+Wallaby>`__
 -  `Deploy your own Functest CI/CD
-   toolchains <https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004>`__
+   toolchains <https://github.com/collivier/ansible-role-xtesting#readme>`__
 -  `Functest gates <https://build.opnfv.org/ci/view/functest/>`__
 
 Yardstick

--- a/doc/ref_cert/RC2/chapters/chapter03.rst
+++ b/doc/ref_cert/RC2/chapters/chapter03.rst
@@ -12,7 +12,7 @@ description file will be proposed in a shared tree.
 `Xtesting CI <https://galaxy.ansible.com/collivier/xtesting>`__ only
 requires internet access, GNU/Linux as Operating System and asks for a
 few dependencies as described in `Deploy your own Xtesting CI/CD
-toolchains <https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004>`__:
+toolchains <https://github.com/collivier/ansible-role-xtesting#readme>`__:
 
 -  python-virtualenv
 -  git

--- a/doc/ref_cert/index.rst
+++ b/doc/ref_cert/index.rst
@@ -162,7 +162,7 @@ Testing Cookbooks
 leverages the common test case execution proposed by Xtesting. Thanks to
 a simple test case list, this tool deploys plug-and-play `CI/CD
 toolchains in a few
-commands <https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004>`__.
+commands <https://github.com/collivier/ansible-role-xtesting#readme>`__.
 In addition, it supports multiple components such as Jenkins and Gitlab
 CI (test schedulers) and `multiple deployment
 models <https://lists.opnfv.org/g/opnfv-tsc/message/5702>`__ such as
@@ -197,7 +197,7 @@ Here are a couple of publicly available playbooks :
 `Xtesting CI <https://galaxy.ansible.com/collivier/xtesting>`__ only
 requires GNU/Linux as Operating System and asks for a few dependencies
 as described in `Deploy your own Xtesting CI/CD
-toolchains <https://wiki.opnfv.org/pages/viewpage.action?pageId=32015004>`__:
+toolchains <https://github.com/collivier/ansible-role-xtesting#readme>`__:
 
 -  python-virtualenv
 -  git


### PR DESCRIPTION
wiki.opnfv.org is now redirected to wiki.anuket.io.
A few former pages which were not copied no longer exists.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>