### PR TITLE
[RI1] Fix former wiki.opnfv.org links

### DIFF
--- a/doc/ref_impl/cntt-ri/chapters/chapter01.rst
+++ b/doc/ref_impl/cntt-ri/chapters/chapter01.rst
@@ -57,7 +57,7 @@ a) OPNFV CIRV project.
 This project is the 'landing' place for CNTT in OPNFV. It is responsible for driving activities of CNTT within OPNFV, working with multiple projects, including Airship, Functest, Dovetail, and ext.. The project team is working closely with the CNTT RI WSs.
 
 Detailed information of this project can be found here:
-https://wiki.opnfv.org/pages/viewpage.action?pageId=47284396
+https://wiki.anuket.io/display/HOME/CIRV
 
 b) OPNFV Infra WG.
 


### PR DESCRIPTION
It fails due to the new redirect.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>