### PR TITLE
[RA1] Stop overfulling cells and tables

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter01.rst
+++ b/doc/ref_arch/openstack/chapters/chapter01.rst
@@ -20,7 +20,7 @@ deployment into development, test and production. Another reason to
 choose OpenStack is that it has a large active community of vendors and
 operators, which means that any code or component changes needed to
 support the Common Telco Cloud Infrastructure requirements can be
-managed through the existing project communities’ processes to add and
+managed through the existing project communities' processes to add and
 validate the required features through well-established mechanisms.
 
 Vision
@@ -30,7 +30,7 @@ The OpenStack-based Reference Architecture will host NFV
 workloads, primarily VNFs (Virtual Network Functions),
 of interest to the Anuket community. The
 Reference Architecture document can be used by operators to deploy
-Anuket conformant infrastructure; hereafter, “conformant” denotes that
+Anuket conformant infrastructure; hereafter, "conformant" denotes that
 the resource can satisfy tests conducted to verify conformance with this
 reference architecture.
 
@@ -57,12 +57,12 @@ Examples include:
    application generates larger packets with longer-lived connections,
    you can optimize bandwidth utilization for long duration TCP. Normal
    bandwidth planning applies here with regards to benchmarking a
-   session’s usage multiplied by the expected number of concurrent
+   session's usage multiplied by the expected number of concurrent
    sessions with overhead.
 
 -  **Network functions**: Network functions is a broad category but
    encompasses workloads that support the exchange of information (data,
-   voice, multi-media) over a system’s network. Some of these workloads
+   voice, multi-media) over a system's network. Some of these workloads
    tend to consist of a large number of small-sized packets that are
    short lived, such as DNS queries or SNMP traps. These messages need
    to arrive quickly and, thus, do not handle packet loss. Network
@@ -130,8 +130,8 @@ Document Organisation
 Chapter 2 defines the Reference Architecture requirements and, when
 appropriate, provides references to where these requirements are
 addressed in this document. The intent of this document is to address
-all of the mandatory (“must”) requirements and the most useful of the
-other optional (“should”) requirements. Chapter 3 and 4 cover the Cloud
+all of the mandatory ("must") requirements and the most useful of the
+other optional ("should") requirements. Chapter 3 and 4 cover the Cloud
 Infrastructure resources and the core OpenStack services, while the APIs
 are covered in Chapter 5. Chapter 6 covers the implementation and
 enforcement of security capabilities and controls. Life Cycle Management

--- a/doc/ref_arch/openstack/chapters/chapter02.rst
+++ b/doc/ref_arch/openstack/chapters/chapter02.rst
@@ -548,6 +548,7 @@ System Hardening Requirements
 .. list-table:: Reference Model Requirements - System Hardening Requirements
    :widths: 15 20 45 20
    :header-rows: 1
+   :class: longtable
 
    * - Reference
      - sub-category
@@ -637,6 +638,7 @@ Platform and Access Requirements
                 Requirements
    :widths: 15 20 45 20
    :header-rows: 1
+   :class: longtable
 
    * - Reference
      - sub-category
@@ -1007,6 +1009,7 @@ can trigger alerts and notifications for appropriate action.
                 Requirements
    :widths: 15 20 45 20
    :header-rows: 1
+   :class: longtable
 
    * - Reference
      - sub-category
@@ -1326,6 +1329,7 @@ Infrastructure Requirements
 .. list-table:: Infrastructure Requirements
    :widths: 15 20 45 20
    :header-rows: 1
+   :class: longtable
 
    * - Reference
      - sub-category
@@ -1660,6 +1664,7 @@ Infrastructure Recommendations
 .. list-table:: Infrastructure Recommendations
    :widths: 15 20 45 20
    :header-rows: 1
+   :class: longtable
 
    * - Reference
      - sub-category
@@ -2219,6 +2224,7 @@ Compliance with Standards Recommendations
 .. list-table:: Compliance with Security Recommendations
    :widths: 15 20 45 20
    :header-rows: 1
+   :class: longtable
 
    * - Reference
      - sub-category

--- a/doc/ref_arch/openstack/chapters/chapter02.rst
+++ b/doc/ref_arch/openstack/chapters/chapter02.rst
@@ -22,8 +22,9 @@ following requirements are referenced through:
 Cloud Infrastructure Software Profile Requirements for Compute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. list-table:: Reference Model Requirements: Cloud Infrastructure Software Profile Capabilities
-   :widths: 16 20 12 12 20
+.. list-table:: Reference Model Requirements: Cloud Infrastructure Software
+                Profile Capabilities
+   :widths: 20 20 12 12 16
    :header-rows: 1
 
    * - Reference
@@ -32,47 +33,60 @@ Cloud Infrastructure Software Profile Requirements for Compute
      - Requirement for High-Performance Profile
      - Specification Reference
    * - e.cap.001
-     - Max number of vCPU that can be assigned to a single instance by the Cloud Infrastructure
+     - Max number of vCPU that can be assigned to a single instance by the
+       Cloud Infrastructure
      - At least 16
      - At least 16
      - :ref:`chapters/chapter04:compute nodes`
    * - e.cap.002
-     - Max memory that can be assigned to a single instance by the Cloud Infrastructure
+     - Max memory that can be assigned to a single instance by the Cloud
+       Infrastructure
      - at least 32 GB
      - at least 32 GB
      - :ref:`chapters/chapter03:virtual storage`
    * - e.cap.003
-     - Max storage that can be assigned to a single instance by the Cloud Infrastructure
+     - Max storage that can be assigned to a single instance by the Cloud
+       Infrastructure
      - at least 320 GB
      - at least 320 GB
      - :ref:`chapters/chapter03:virtual storage` and
        :ref:`chapters/chapter04:storage backend`
    * - e.cap.004
-     - Max number of connection points that can be assigned to a single instance by the Cloud Infrastructure
+     - Max number of connection points that can be assigned to a single
+       instance by the Cloud Infrastructure
      - 6
      - 6
      - Not Detailed
    * - e.cap.005
-     - Max storage that can be attached / mounted to an instance by the Cloud Infrastructure
+     - Max storage that can be attached / mounted to an instance by the Cloud
+       Infrastructure
      - Up to 16TB [*]
      - Up to 16TB [*]
      - :ref:`chapters/chapter04:storage backend`
-   * - e.cap.006/infra.com.cfg.003
+   * - e.cap.006 /
+
+       infra.com.cfg.003
      - CPU pinning support
      - Not required
      - Must support
      - :ref:`chapters/chapter04:consumable infrastructure resources and services`
-   * - e.cap.007/infra.com.cfg.002
+   * - e.cap.007 /
+
+       infra.com.cfg.002
      - NUMA support
      - Not required
      - Must support
      - :ref:`chapters/chapter04:consumable infrastructure resources and services`
-   * - e.cap.018/infra.com.cfg.005
+   * - e.cap.018 /
+
+       infra.com.cfg.005
      - Simultaneous Multithreading (SMT) enabled
      - Must
      - Optional support
      - :ref:`chapters/chapter04:consumable infrastructure resources and services`
-   * - i.cap.018/infra.com.cfg.004
+   * - i.cap.018 /
+
+       infra.com.cfg.004
      - Huge pages configured
      - Not required
      - Must support
@@ -85,8 +99,9 @@ Cloud Infrastructure Software Profile Requirements for Compute
 Cloud Infrastructure Software Profile Extensions Requirements for Compute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. list-table:: Cloud Infrastructure Software Profile Extensions Requirements for Compute
-   :widths: 16 20 12 12 20
+.. list-table:: Cloud Infrastructure Software Profile Extensions Requirements
+                for Compute
+   :widths: 20 20 12 12 16
    :header-rows: 1
 
    * - Reference
@@ -94,18 +109,23 @@ Cloud Infrastructure Software Profile Extensions Requirements for Compute
      - Profile Extensions
      - Profile Extra-Specs
      - Specification Reference
-   * - e.cap.008/
+   * - e.cap.008 /
+
        infra.com.acc.cfg.001
      - IPSec Acceleration using the virtio-ipsec interface
      - Compute Intensive GPU
      -
      - :ref:`chapters/chapter03:acceleration`
-   * - e.cap.010/infra.com.acc.cfg.002
+   * - e.cap.010 /
+
+       infra.com.acc.cfg.002
      - Transcoding Acceleration
      - Compute Intensive GPU
      - Video Transcoding
      - :ref:`chapters/chapter03:acceleration`
-   * - e.cap.011/infra.com.acc.cfg.003
+   * - e.cap.011 /
+
+       infra.com.acc.cfg.003
      - Programmable Acceleration
      - Firmware-programmable adapter
      - Accelerator
@@ -115,13 +135,16 @@ Cloud Infrastructure Software Profile Extensions Requirements for Compute
      - E
      - E
      - Not detailed
-   * - e.cap.014/
+   * - e.cap.014 /
+
        infra.com.acc.cfg.004
      - Hardware coprocessor support (GPU/NPU)
      - Compute Intensive GPU
      -
      - :ref:`chapters/chapter03:acceleration`
-   * - e.cap.016/infra.com.acc.cfg.005
+   * - e.cap.016 /
+
+       infra.com.acc.cfg.005
      - FPGA/other Acceleration H/W
      - Firmware-programmable adapter
      -
@@ -135,7 +158,7 @@ networking for the two (2) types of Cloud Infrastructure Profiles are
 specified below followed by networking bandwidth requirements.
 
 .. list-table:: Reference Model Requirements - Virtual Networking
-   :widths: 16 20 12 12 20
+   :widths: 20 20 12 12 16
    :header-rows: 1
 
    * - Reference
@@ -168,7 +191,7 @@ specified below followed by networking bandwidth requirements.
      - SFC support
      - Not required
      - Must support
-     - :ref:`chapters/chapter03:virtual networking – 3rd party sdn solution`
+     - :ref:`chapters/chapter03:virtual networking - 3rd party sdn solution`
    * - infra.net.cfg.006
      - Traffic patterns symmetry
      - Must support
@@ -219,7 +242,7 @@ Cloud Infrastructure Software Profile Extensions Requirements for Networking
 
 .. list-table:: Cloud Infrastructure Software Profile Extensions Requirements
                 for Networking
-   :widths: 16 20 12 12 20
+   :widths: 20 20 12 12 16
    :header-rows: 1
 
    * - Reference
@@ -227,24 +250,31 @@ Cloud Infrastructure Software Profile Extensions Requirements for Networking
      - Requirement for Basic Profile
      - Requirement for High-Performance Profile
      - Specification Reference
-   * - e.cap.013/
+   * - e.cap.013 /
+
        infra.hw.nac.cfg.004
      - SR-IOV over PCI-PT
      - N
      - Y
      - :ref:`chapters/chapter04:compute nodes`
-   * - e.cap.019/infra.net.acc.cfg.001
+   * - e.cap.019 /
+
+       infra.net.acc.cfg.001
      - vSwitch optimisation (DPDK)
      - N
      - Y
      - :ref:`chapters/chapter04:compute nodes` and
        :ref:`chapters/chapter04:network quality of service`
-   * - e.cap.015/infra.net.acc.cfg.002
+   * - e.cap.015 /
+
+       infra.net.acc.cfg.002
      - SmartNIC (for HW Offload)
      - N
      - Optional
      - :ref:`chapters/chapter03:acceleration`
-   * - e.cap.009/infra.net.acc.cfg.003
+   * - e.cap.009 /
+
+       infra.net.acc.cfg.003
      - Crypto acceleration
      - N
      - Optional
@@ -260,7 +290,7 @@ Cloud Infrastructure Software Profile Requirements for Storage
 
 .. list-table:: Reference Model Requirements - Cloud Infrastructure Software
                 Profile Requirements for Storage
-   :widths: 16 20 12 12 20
+   :widths: 20 20 12 12 16
    :header-rows: 1
 
    * - Reference
@@ -300,9 +330,8 @@ Cloud Infrastructure Software Profile Extensions Requirements for Storage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table:: Reference Model Requirements - Cloud Infrastructure Software
-   Profile Extensions Requirements for Storage
-   for Networking
-   :widths: 20 15 15 15 15
+                Profile Extensions Requirements for Storage
+   :widths: 20 20 12 12 16
    :header-rows: 1
 
    * - Reference
@@ -325,7 +354,7 @@ Cloud Infrastructure Hardware Profile Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table:: Reference Model Requirements - Cloud Infrastructure Hardware
-   Profile Requirements
+                Profile Requirements
    :widths: 20 20 12 12 16
    :header-rows: 1
 
@@ -404,8 +433,8 @@ Cloud Infrastructure Hardware Profile-Extensions Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Reference Model Requirements - Cloud Infrastructure Hardware
-   Profile Extensions Requirements
-   :widths: 16 20 12 12 20
+                Profile Extensions Requirements
+   :widths: 20 20 12 12 16
    :header-rows: 1
 
    * - Reference
@@ -413,23 +442,30 @@ Cloud Infrastructure Hardware Profile-Extensions Requirements
      - Requirement for Basic Profile
      - Requirement for High-Performance Profile
      - Specification Reference
-   * - e.cap.014/
+   * - e.cap.014 /
+
        infra.hw.cac.cfg.001
      - GPU
      - N
      - Optional
      - :ref:`chapters/chapter03:acceleration`
-   * - e.cap.016/infra.hw.cac.cfg.002
+   * - e.cap.016 /
+
+       infra.hw.cac.cfg.002
      - FPGA/other Acceleration H/W
      - N
      - Optional
      - :ref:`chapters/chapter03:acceleration`
-   * - e.cap.009/infra.hw.nac.cfg.001
+   * - e.cap.009 /
+
+       infra.hw.nac.cfg.001
      - Crypto Acceleration
      - N
      - Optional
      - :ref:`chapters/chapter03:acceleration`
-   * - e.cap.015/infra.hw.nac.cfg.002
+   * - e.cap.015 /
+
+       infra.hw.nac.cfg.002
      - SmartNIC
      - N
      - Optional
@@ -439,7 +475,9 @@ Cloud Infrastructure Hardware Profile-Extensions Requirements
      - Optional
      - Optional
      - :ref:`chapters/chapter03:acceleration`
-   * - e.cap.013/infra.hw.nac.cfg.004
+   * - e.cap.013 /
+
+       infra.hw.nac.cfg.004
      - SR-IOV over PCI-PT
      - N
      - Yes
@@ -450,8 +488,8 @@ Cloud Infrastructure Management Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table:: Reference Model Requirements - Cloud Infrastructure
-   Management Requirements
-   :widths: 16 30 14 20
+                Management Requirements
+   :widths: 15 45 20 20
    :header-rows: 1
 
    * - Reference
@@ -508,7 +546,7 @@ System Hardening Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Reference Model Requirements - System Hardening Requirements
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -596,8 +634,8 @@ Platform and Access Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Reference Model Requirements - Platform and Access
-   Requirements
-   :widths: 20 10 30 20
+                Requirements
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -686,7 +724,7 @@ Platform and Access Requirements
      - Not detailed
    * - sec.sys.016
      - Access
-     - Login access to the Platform’s components **must** be through encrypted
+     - Login access to the Platform's components **must** be through encrypted
        protocols such as SSH v2 or TLS v1.2 or higher. Note: Hardened jump
        servers isolated from external networks are recommended
      - :ref:`chapters/chapter06:security lcm`
@@ -711,8 +749,8 @@ Confidentiality and Integrity Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Reference Model Requirements - Confidentiality and Integrity
-   Requirements
-   :widths: 12 20 30 18
+                Requirements
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -720,7 +758,7 @@ Confidentiality and Integrity Requirements
      - Description
      - Specification Reference
    * - sec.ci.001
-     - Confidentiality/
+     - Confidentiality /
 
        Integrity
      - The Platform **must** support Confidentiality and Integrity of data
@@ -728,7 +766,7 @@ Confidentiality and Integrity Requirements
      - :ref:`chapters/chapter06:confidentiality and
        integrity`
    * - sec.ci.003
-     - Confidentiality/
+     - Confidentiality /
 
        Integrity
      - The Platform **must** support Confidentiality and Integrity of data
@@ -743,7 +781,7 @@ Confidentiality and Integrity Requirements
      - :ref:`chapters/chapter06:confidentiality and
        integrity`
    * - sec.ci.005
-     - Confidentiality/
+     - Confidentiality /
 
        Integrity
      - The Platform **must** support Confidentiality and Integrity of process-
@@ -752,7 +790,7 @@ Confidentiality and Integrity Requirements
      - :ref:`chapters/chapter06:confidentiality and
        integrity`
    * - sec.ci.006
-     - Confidentiality/
+     - Confidentiality /
 
        Integrity
      - The Platform **must** support Confidentiality and Integrity of
@@ -761,7 +799,7 @@ Confidentiality and Integrity Requirements
        workload owner (e.g., tenant)
      - :ref:`chapters/chapter06:platform access`
    * - sec.ci.007
-     - Confidentiality/
+     - Confidentiality /
 
        Integrity
      - The Platform **must not** allow Memory Inspection by any actor
@@ -781,8 +819,8 @@ Workload Security Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Reference Model Requirements - Workload Security
-   Requirements
-   :widths: 15 15 30 20
+                Requirements
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -830,8 +868,8 @@ Image Security Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Reference Model Requirements - Image Security
-   Requirements
-   :widths: 15 15 30 20
+                Requirements
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -882,8 +920,8 @@ Security LCM Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Reference Model Requirements - Security LCM
-   Requirements
-   :widths: 15 15 30 20
+                Requirements
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -966,8 +1004,8 @@ timely fashion. In the following the monitoring and logging capabilities
 can trigger alerts and notifications for appropriate action.
 
 .. list-table:: Reference Model Requirements - Monitoring and Security Audit
-   Requirements
-   :widths: 15 15 30 20
+                Requirements
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -975,7 +1013,7 @@ can trigger alerts and notifications for appropriate action.
      - Description
      - Specification Reference
    * - sec.mon.001
-     - Monitoring/Audit
+     - Monitoring / Audit
      - Platform **must** provide logs and these logs must be regularly
        monitored for events of interest. The logs must contain the following
        fields: event type, date/time, protocol, service or program used for
@@ -999,54 +1037,54 @@ can trigger alerts and notifications for appropriate action.
        sensitive information) both in-transit and at rest
      - :ref:`chapters/chapter06:security lcm`
    * - sec.mon.005
-     - Monitoring/Audit
+     - Monitoring / Audit
      - The Platform **must** Monitor and Audit various behaviours of
        connection and login attempts to detect access attacks and potential
        access attempts and take corrective accordingly actions
      - :ref:`chapters/chapter06:what to log / what not
        to log`
    * - sec.mon.006
-     - Monitoring/Audit
+     - Monitoring / Audit
      - The Platform **must** Monitor and Audit operations by authorised
        account access after login to detect malicious operational activity
        and take corrective actions
      - :ref:`chapters/chapter06:monitoring and security
        audit`
    * - sec.mon.007
-     - Monitoring/Audit
+     - Monitoring / Audit
      - The Platform **must** Monitor and Audit security parameter
        configurations for compliance with defined security policies
      - :ref:`chapters/chapter06:integrity of openstack
        components configuration`
    * - sec.mon.008
-     - Monitoring/Audit
+     - Monitoring / Audit
      - The Platform **must** Monitor and Audit externally exposed interfaces
        for illegal access (attacks) and take corrective security hardening
        measures
      - :ref:`chapters/chapter06:confidentiality and
        integrity of communications (sec.ci.001)`
    * - sec.mon.009
-     - Monitoring/Audit
+     - Monitoring / Audit
      - The Platform **must** Monitor and Audit service for various attacks
        (malformed messages, signalling flooding and replaying, etc.) and take
        corrective actions accordingly
      - :ref:`chapters/chapter06:monitoring and security
        audit`
    * - sec.mon.010
-     - Monitoring/Audit
+     - Monitoring / Audit
      - The Platform **must** Monitor and Audit running processes to detect
        unexpected or unauthorised processes and take corrective actions
        accordingly
      - :ref:`chapters/chapter06:monitoring and security
        audit`
    * - sec.mon.011
-     - Monitoring/Audit
+     - Monitoring / Audit
      - The Platform **must** Monitor and Audit logs from infrastructure elements
        and workloads to detected anomalies in the system components and take
        corrective actions accordingly
      - :ref:`chapters/chapter06:creating logs`
    * - sec.mon.012
-     - Monitoring/Audit
+     - Monitoring / Audit
      - The Platform **must** Monitor and Audit Traffic patterns and volumes to
        prevent malware download attempts
      - :ref:`chapters/chapter06:confidentiality and
@@ -1082,7 +1120,7 @@ can trigger alerts and notifications for appropriate action.
      - :ref:`chapters/chapter06:what to log / what not
        to log`
    * - sec.mon.020
-     - Monitoring/Audit
+     - Monitoring / Audit
      - The Platform's logging system **must** support the storage of security
        audit logs for a configurable period of time
      - :ref:`chapters/chapter06:data retention`
@@ -1097,8 +1135,8 @@ Open-Source Software Security Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Reference Model Requirements - Open-Source Software Security
-   Requirements
-   :widths: 15 15 30 20
+                Requirements
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1135,8 +1173,8 @@ IaaC security Requirements
 **Secure Code Stage Requirements**
 
 .. list-table:: Reference Model Requirements: IaaC Security Requirements,
-   Secure Code Stage
-   :widths: 15 15 30 20
+                Secure Code Stage
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1155,8 +1193,8 @@ IaaC security Requirements
 **Continuous Build, Integration and Testing Stage Requirements**
 
 .. list-table:: Reference Model Requirements - IaaC Security Requirements,
-   Continuous Build, Integration and Testing Stage
-   :widths: 15 15 30 20
+                Continuous Build, Integration and Testing Stage
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1175,8 +1213,8 @@ IaaC security Requirements
 **Continuous Delivery and Deployment Stage Requirements**
 
 .. list-table:: Reference Model Requirements - IaaC Security Requirements,
-   Continuous Delivery and Deployment Stage
-   :widths: 15 15 30 20
+                Continuous Delivery and Deployment Stage
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1210,8 +1248,8 @@ IaaC security Requirements
 **Runtime Defence and Monitoring Requirements**
 
 .. list-table:: Reference Model Requirements - IaaC Security Requirements,
-   Runtime Defence and Monitoring Stage
-   :widths: 15 15 30 20
+                Runtime Defence and Monitoring Stage
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1230,7 +1268,7 @@ Compliance with Standards Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Reference Model Requirements: Compliance with Standards
-   :widths: 15 15 30 20
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1248,14 +1286,14 @@ Compliance with Standards Requirements
 Architecture and OpenStack Requirements
 ---------------------------------------
 
-“Architecture” in this chapter refers to Cloud Infrastructure (referred
+"Architecture" in this chapter refers to Cloud Infrastructure (referred
 to as NFVI by ETSI) and VIM, as specified in Reference Model Chapter 3.
 
 General Requirements
 ~~~~~~~~~~~~~~~~~~~~
 
 .. list-table:: General Requirements
-   :widths: 15 15 30 20
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1286,7 +1324,7 @@ Infrastructure Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table:: Infrastructure Requirements
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1366,7 +1404,7 @@ Infrastructure Requirements
        OpenStack Neutron service, such as networking of VTEPs to the Border
        Edge based VRFs
      - :ref:`chapters/chapter03:\
-       virtual networking – 3rd party sdn solution`
+       virtual networking - 3rd party sdn solution`
    * - inf.nw.03
      - Network
      - The Architecture **must** support low latency and high throughput
@@ -1385,7 +1423,7 @@ Infrastructure Requirements
    * - inf.nw.10
      - Network
      - The Cloud Infrastructure Network Fabric **must** be capable of enabling
-       highly available (Five 9’s or better) Cloud Infrastructure
+       highly available (Five 9's or better) Cloud Infrastructure
      - :ref:`chapters/chapter03:network`
    * - inf.nw.15
      - Network
@@ -1393,7 +1431,7 @@ Infrastructure Requirements
        Infrastructure to support various infrastructure profiles (Basic and
        High Performance)
      - :ref:`chapters/chapter04:neutron extensions`
-        and OpenStack Neutron Plugins :cite:p:`openstackneut`
+       and OpenStack Neutron Plugins :cite:p:`openstackneut`
    * - inf.nw.16
      - Network
      - The Architecture **must** support dual stack IPv4 and IPv6 for tenant
@@ -1404,7 +1442,7 @@ VIM Requirements
 ~~~~~~~~~~~~~~~~
 
 .. list-table:: VIM Requirements
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1439,7 +1477,7 @@ Interfaces & APIs Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table:: Interfaces and APIs Requirements
-   :widths: 15 15 30 20
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1503,7 +1541,7 @@ Tenant Requirements
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table:: Tenant Requirements
-   :widths: 15 15 30 20
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1522,7 +1560,7 @@ Operations and LCM
 ~~~~~~~~~~~~~~~~~~
 
 .. list-table:: LCM Requirements
-   :widths: 15 15 30 20
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1547,7 +1585,7 @@ Assurance Requirements
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table:: Assurance Requirements
-   :widths: 15 15 30 20
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1584,7 +1622,7 @@ General Recommendations
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table:: General Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1620,7 +1658,7 @@ Infrastructure Recommendations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table:: Infrastructure Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1709,7 +1747,7 @@ VIM Recommendations
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table:: VIM Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1742,7 +1780,7 @@ Interfaces and APIs Recommendations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table:: Interfaces and APIs Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1766,7 +1804,7 @@ Tenant Recommendations
 This section is left blank for future use.
 
 .. list-table:: Tenant Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1782,7 +1820,7 @@ Operations and LCM Recommendations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table:: LCM Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1823,7 +1861,7 @@ Assurance Recommendations
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table:: Assurance Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1844,7 +1882,7 @@ System Hardening Recommendations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: System Hardening Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1867,7 +1905,7 @@ Platform and Access Recommendations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Platform and Access Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1889,7 +1927,7 @@ Confidentiality and Integrity Recommendations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Confidentiality and Integrity Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1897,11 +1935,15 @@ Confidentiality and Integrity Recommendations
      - Description
      - Notes
    * - sec.ci.002
-     - Confidentiality/Integrity
+     - Confidentiality /
+
+       Integrity
      - The Platform **should** support self-encrypting storage devices
      -
    * - sec.ci.009
-     - Confidentiality/Integrity
+     - Confidentiality /
+
+       Integrity
      - For sensitive data encryption, the key management service **should**
        leverage a Hardware Security Module to manage and protect cryptographic
        keys
@@ -1911,7 +1953,7 @@ Workload Security Recommendations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Workload Security Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1928,7 +1970,7 @@ Image Security Recommendations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Image Security Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1948,7 +1990,7 @@ Security LCM Recommendations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: LCM Security Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1971,7 +2013,7 @@ timely fashion. In the following the monitoring and logging capabilities
 can trigger alerts and notifications for appropriate action.
 
 .. list-table:: Monitoring and Security Audit Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -1993,7 +2035,7 @@ Open-Source Software Security Recommendations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Open-Source Software Security Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -2014,7 +2056,7 @@ IaaC security Recommendations
 
 .. list-table:: Reference Model Requirements: IaaC Security,
                 Design and Architecture Stage
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -2039,7 +2081,7 @@ IaaC security Recommendations
 **Secure Code Stage Recommendations**
 
 .. list-table:: Reference Model Requirements: IaaC Security, Secure Code Stage
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -2048,7 +2090,7 @@ IaaC security Recommendations
      - Notes
    * - sec.code.002
      - IaaC
-     - SCA – Software Composition Analysis **should** be applied during
+     - SCA - Software Composition Analysis **should** be applied during
        Secure Coding stage triggered by Pull, Clone or Comment trigger.
        Security testing that analyses application source code or compiled code
        for software components with known vulnerabilities
@@ -2076,7 +2118,7 @@ IaaC security Recommendations
 
 .. list-table:: Reference Model Requirements: IaaC Security, Continuous Build,
                 Integration and Testing Stage
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -2091,13 +2133,13 @@ IaaC security Recommendations
      - Example: open source OWASP range of tools.
    * - sec.bld.002
      - IaaC
-     - SCA – Software Composition Analysis **should** be applied during the
+     - SCA - Software Composition Analysis **should** be applied during the
        Continuous Build, Integration and Testing stage triggered by Build and
        Integrate trigger
      - Example: open source OWASP range of tools
    * - sec.bld.004
      - IaaC
-     - SDAST – Dynamic Application Security Testing **should** be applied
+     - SDAST - Dynamic Application Security Testing **should** be applied
        during the Continuous Build, Integration and Testing stage triggered
        by Stage & Test trigger. Security testing that analyses a running
        application by exercising application functionality and detecting
@@ -2113,7 +2155,7 @@ IaaC security Recommendations
      - Example: GitLab Open Sources Protocol Fuzzer Community Edition
    * - sec.bld.006
      - IaaC
-     - IAST – Interactive Application Security Testing **should** be applied
+     - IAST - Interactive Application Security Testing **should** be applied
        during the Continuous Build, Integration and Testing stage triggered by
        Stage & Test trigger. Software component deployed with an application
        that assesses application behaviour and detects presence of
@@ -2125,7 +2167,7 @@ IaaC security Recommendations
 
 .. list-table:: Reference Model Requirements: IaaC Security, Continuous
                 Delivery and Deployment Stage
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -2143,7 +2185,7 @@ IaaC security Recommendations
 
 .. list-table:: Reference Model Requirements: Iaac Security, Runtime Defence
                 and Monitoring Stage
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference
@@ -2152,7 +2194,7 @@ IaaC security Recommendations
      - Notes
    * - sec.run.002
      - IaaC
-     - RASP – Runtime Application Self-Protection **should** be continuously
+     - RASP - Runtime Application Self-Protection **should** be continuously
        applied during the Runtime Defence and Monitoring stage. Security
        technology deployed within the target application in production for
        detecting, alerting, and blocking attacks
@@ -2175,7 +2217,7 @@ Compliance with Standards Recommendations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Compliance with Security Recommendations
-   :widths: 15 15 40 30
+   :widths: 15 20 45 20
    :header-rows: 1
 
    * - Reference

--- a/doc/ref_arch/openstack/chapters/chapter03.rst
+++ b/doc/ref_arch/openstack/chapters/chapter03.rst
@@ -34,9 +34,9 @@ This chapter is organised as follows:
 
       -  Virtual compute: vCPU / vRAM
       -  Virtual storage: Ephemeral, Persistent and Image
-      -  Virtual networking – neutron standalone: network plugin,
+      -  Virtual networking - neutron standalone: network plugin,
          virtual switch, accelerator features
-      -  Virtual networking – 3rd party SDN solution
+      -  Virtual networking - 3rd party SDN solution
       -  Additional network services: Firewall, DC Gateway
 
 -  Cloud Infrastructure Management Software (VIM): is how we manage the
@@ -62,7 +62,7 @@ This chapter is organised as follows:
 
 .. [#] Please note "flavours" is used in the Reference Model and shall
    continue to be used in the context of specifying the geometry of
-   the virtual resources. The term “flavor” is used in this document
+   the virtual resources. The term "flavor" is used in this document
    in the OpenStack context including when specifying configurations;
    the OpenStack term flavor includes the profile configuration
    information as "extra specs".
@@ -87,11 +87,11 @@ Multi-Tenancy (execution environment)
 
 The multi tenancy service permits hosting of several VNF projects with
 the assurance of isolated environments for each project. Tenants or
-confusingly “Projects” in OpenStack are isolated environments that
+confusingly "Projects" in OpenStack are isolated environments that
 enable workloads to be logically separated from each other with:
 
 -  differentiated set of associated users
--  role-based access of two levels – admin or member (see :ref:`chapters/chapter06:rbac`).
+-  role-based access of two levels - admin or member (see :ref:`chapters/chapter06:rbac`).
 -  quota system to provide maximum resources that can be consumed.
 
 This RA does not intend to restrict how workloads are distributed across
@@ -132,7 +132,7 @@ The OpenStack services, Cinder for block storage and Swift for Object
 Storage, are discussed below in Section "Cloud Infrastructure
 Management Software (VIM)".
 
-Ephemeral data is typically stored on the compute host’s local disks,
+Ephemeral data is typically stored on the compute host's local disks,
 in the form of a file system as part of the provisioning.
 This storage is volatile, it is deleted when instances are stopped.
 In environments that support live instance migration between
@@ -169,8 +169,8 @@ manager (VIM)`.
 Virtual Networking Neutron standalone
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Neutron is an OpenStack project that provides “network connectivity as a
-service” between interface devices (e.g., vNICs) managed by other
+Neutron is an OpenStack project that provides "network connectivity as a
+service" between interface devices (e.g., vNICs) managed by other
 OpenStack services (e.g., Nova). Neutron allows users to create
 networks, subnets, ports, routers, etc. Neutron also facilitates traffic
 isolation between different subnets - within as well as across
@@ -180,23 +180,23 @@ Neutron API consumer, this is abstracted and provided by Neutron.
 Multiple network segments are supported by Neutron via ML2 plugins to
 simultaneously utilise variety of layer 2 networking technologies like
 VLAN, VxLAN, GRE, etc. Neutron also allows to create routers to connect
-layer 2 networks via “neutron-l3-agent”. In addition, floating IP
+layer 2 networks via "neutron-l3-agent". In addition, floating IP
 support is also provided that allows a project VM to be accessed using a
 public IP.
 
-Virtual Networking – 3rd party SDN solution
+Virtual Networking - 3rd party SDN solution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 SDN (Software Defined Networking) controllers separate control and data
 (user) plane functions where the control plane programmatically
 configures and controls all network data path elements via open APIs.
-Open Networking Forum (ONF) defines SDN as “Software-Defined Networking
+Open Networking Forum (ONF) defines SDN as "Software-Defined Networking
 (SDN) is an emerging architecture that is dynamic, manageable,
 cost-effective, and adaptable, making it ideal for the high-bandwidth,
-dynamic nature of today’s applications. This architecture decouples the
+dynamic nature of today's applications. This architecture decouples the
 network control and forwarding functions enabling the network control to
 become directly programmable and the underlying infrastructure to be
-abstracted for applications and network services.”
+abstracted for applications and network services."
 
 The key messages of the SDN definition are:
 
@@ -233,10 +233,10 @@ it works as a multi-stack SDN to support VMs, containers, and baremetal
 workloads. It provides separation of control plane functions and data
 plane functions with its two components:
 
--  Tungsten Fabric Controller– a set of software services that maintains
+-  Tungsten Fabric Controller- a set of software services that maintains
    a model of networks and network policies, typically running on
    several servers for high availability
--  Tungsten Fabric vRouter– installed in each host that runs workloads
+-  Tungsten Fabric vRouter- installed in each host that runs workloads
    (virtual machines or containers), the vRouter performs packet
    forwarding and enforces network and security policies
 
@@ -496,7 +496,7 @@ Cloud Workload Services
 
 This section describes the core set of services and service components
 needed to run workloads; instances (such as VMs), their networks and
-storage are referred to as the “Compute Node Services” (a.k.a. user or
+storage are referred to as the "Compute Node Services" (a.k.a. user or
 data plane services). Contrast this with the Controller nodes which host
 OpenStack services used for cloud administration and management. The
 Compute Node Services include virtualisation, hypervisor instance
@@ -516,8 +516,8 @@ scheduling, networking and cinder volume creation/attachment.
 Tenant Isolation
 ~~~~~~~~~~~~~~~~
 
-In Keystone v1 and v2 (both deprecated), the term “tenant” was used in
-OpenStack. With Keystone v3, the term “project” got adopted and both the
+In Keystone v1 and v2 (both deprecated), the term "tenant" was used in
+OpenStack. With Keystone v3, the term "project" got adopted and both the
 terms became interchangeable. According to OpenStack
 glossary :cite:p:`openstackglos`,
 Projects represent the base unit of resources (compute, storage and
@@ -535,8 +535,8 @@ project are placed on the host. Overall, tenant isolation ensures that
 the resources of a project are not affected by resources of another
 project.
 
-This document uses the term “project” when referring to OpenStack
-services and “tenant” (RM Section
+This document uses the term "project" when referring to OpenStack
+services and "tenant" (RM Section
 :ref:`ref_model:chapters/chapter03:virtual resources`)
 to represent an independently manageable logical pool of resources.
 
@@ -558,12 +558,12 @@ Availability Zones (AZs) rely on Host Aggregates and make the
 partitioning visible to tenants. They are defined by attaching specific
 metadata information to an aggregate, making the aggregate visible for
 tenants. Hosts can only be in a single Availability Zone. By default a
-host is part of a default Availability Zone, even if it doesn’t belong
+host is part of a default Availability Zone, even if it doesn't belong
 to an aggregate. Availability Zones can be used to provide resiliency
 and fault tolerance for workloads deployments, for example by means of
 physical hosting distribution of Compute Nodes in separate racks with
 separate power supply and eventually in different rooms. They permit
-rolling upgrades – an AZ at a time upgrade with enough time between AZ
+rolling upgrades - an AZ at a time upgrade with enough time between AZ
 upgrades to allow recovery of tenant workloads on the upgraded AZ. AZs
 can also be used to seggregate workloads.
 
@@ -635,9 +635,9 @@ up (in a shipping container), and what resources are required of the DC
 
    -  Data centre gateway
    -  Firewall (around the control plane, storage, etc.)
-   -  Data centre network fabric / Clos (spine/leaf) – Horizontal scale
+   -  Data centre network fabric / Clos (spine/leaf) - Horizontal scale
    -  Storage networking, control plane and data plane
-   -  Raw packet – tenant networking allowing “wild west” connection
+   -  Raw packet - tenant networking allowing "wild west" connection
 
 -  Storage
 
@@ -671,13 +671,13 @@ Network
 The recommended network architecture is spine and leaf topology.
 
 .. figure:: ../figures/RA1-Ch03-Network-Fabric.png
-   :alt: Network Fabric – Physical
+   :alt: Network Fabric - Physical
    :align: center
-   :name: Network Fabric – Physical
+   :name: Network Fabric - Physical
 
-   Network Fabric – Physical
+   Network Fabric - Physical
 
-:numref:`Network Fabric – Physical` shows a physical network layout where each
+:numref:`Network Fabric - Physical` shows a physical network layout where each
 physical server is dual homed to TOR (Leaf/Access) switches with redundant
 (2x) connections. The Leaf switches are dual homed with redundant connections
 to spines.
@@ -704,7 +704,7 @@ techniques ensure high-performance, high availability storage system.
 Cloud Topology
 --------------
 
-A telco cloud will typically be deployed in multiple locations (“sites”)
+A telco cloud will typically be deployed in multiple locations ("sites")
 of varying size and capabilities (HVAC, for example); or looking at this
 in the context of OpenStack, multiple clouds (i.e. OpenStack end-points)
 will be deployed that do not rely on each other, by design; each cloud
@@ -735,9 +735,9 @@ data centre capabilities, economics and risks.
 Availability of any single OpenStack cloud is dependent on a number of
 factors including:
 
--  environmental – dual connected power and PDUs, redundant cooling,
+-  environmental - dual connected power and PDUs, redundant cooling,
    rack distribution, etc.
--  resilient network fabric – ToR (leaf), spine, overlay networking,
+-  resilient network fabric - ToR (leaf), spine, overlay networking,
    underlay networking, etc. It is assumed that all network components
    are designed to be fault tolerant and all OpenStack controllers,
    computes and storage are dual-homed to alternate leaf switches.
@@ -753,7 +753,7 @@ factors including:
 Assumptions and conventions:
 
 -  Region is represented by a single OpenStack control plane.
--  Resource Failure Domain is effectively the “blast radius” of any
+-  Resource Failure Domain is effectively the "blast radius" of any
    major infrastructure failure such as loss of PDU or network leafs.
 -  Control plane includes redundant network nodes where OVS-kernel is
    used.

--- a/doc/ref_arch/openstack/chapters/chapter04.rst
+++ b/doc/ref_arch/openstack/chapters/chapter04.rst
@@ -169,7 +169,7 @@ Compute Nodes
 
 This section specifies the compute node configurations to support the
 Basic and High-Performance profiles; in OpenStack this would be
-accomplished by specifying the configurations when creating “flavors”.
+accomplished by specifying the configurations when creating "flavors".
 The cloud operator may choose to implement certain profile-extensions
 (:ref:`ref_model:chapters/chapter02:profile extensions (specialisations)`)
 as a set of standard configurations, of a given profile, capturing some
@@ -356,9 +356,9 @@ Reservation of Compute Node Cores
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :ref:`chapters/chapter02:infrastructure requirements`
-``inf.com.08`` requires the allocation of “certain number of host
-cores/threads to non-tenant workloads such as for OpenStack services.” A
-number (“n”) of random cores can be reserved for host services
+``inf.com.08`` requires the allocation of "certain number of host
+cores/threads to non-tenant workloads such as for OpenStack services." A
+number ("n") of random cores can be reserved for host services
 (including OpenStack services) by specifying the following in nova.conf:
 
          reserved_host_cpus = n
@@ -381,15 +381,15 @@ configuration.
 
 Let us consider a compute host with 20 cores with SMT enabled (let us
 disregard NUMA) and the following parameters specified. The physical
-cores are numbered ‘0’ to ‘19’ while the sibling threads are numbered
-‘20’ to ‘39’ where the vCPUs numbered ‘0’ and ‘20’, ‘1’ and ‘21’, etc.
+cores are numbered ‘0' to ‘19' while the sibling threads are numbered
+‘20' to ‘39' where the vCPUs numbered ‘0' and ‘20', ‘1' and ‘21', etc.
 are siblings:
 
          cpu_shared_set = 1-7,9-19,21-27,29-39          (can also be
 specified as cpu_shared_set = 1-19,\&8,21-39,\&28)
 
-This implies that the two physical cores ‘0’ and ‘8’ and their sibling
-threads ‘20’ and ‘28’ are dedicated to the host services, and 19 cores
+This implies that the two physical cores ‘0' and ‘8' and their sibling
+threads ‘20' and ‘28' are dedicated to the host services, and 19 cores
 and their sibling threads are available for Guest instances and can be
 over allocated as per the specified cpu_allocation_ratio in nova.conf.
 
@@ -399,11 +399,11 @@ Pinned and Unpinned CPUs
 When a server (viz., an instance) is created the vCPUs are, by default,
 not assigned to a particular host CPU. Certain workloads require
 real-time or near real-time behavior viz., uninterrupted access to their
-cores. For such workloads, CPU pinning allows us to bind an instance’s
+cores. For such workloads, CPU pinning allows us to bind an instance's
 vCPUs to particular host cores or SMT threads. To configure a flavor to
 use pinned vCPUs, we use a dedicated CPU policy.
 
-         openstack flavor set .xlarge –property hw:cpu_policy=dedicated
+         openstack flavor set .xlarge -property hw:cpu_policy=dedicated
 
 While an instance with pinned CPUs cannot use CPUs of another pinned
 instance, this does not apply to unpinned instances; an unpinned
@@ -422,13 +422,13 @@ profiles and flavors.
 Cloud Infrastructure Hardware Profile
 '''''''''''''''''''''''''''''''''''''
 
-The Cloud Infrastructure Hardware (or simply “host”) profile and
+The Cloud Infrastructure Hardware (or simply "host") profile and
 configuration parameters are utilised in the reference architecture to
 define different hardware profiles; these are used to configure the BIOS
 settings on a physical server and configure utility software (such as
 Operating System and Hypervisor).
 
-An OpenStack flavor defines the characteristics (“capabilities”) of a
+An OpenStack flavor defines the characteristics ("capabilities") of a
 server (viz., VMs or instances) that will be deployed on hosts assigned
 a host-profile. A many to many relationship exists between flavors and
 host profiles. Multiple flavors can be defined with overlapping
@@ -463,7 +463,7 @@ on the host.
 Server Configurations
 '''''''''''''''''''''
 
-The different networking choices – OVS-Kernel, OVS-DPDK, SR-IOV – result
+The different networking choices - OVS-Kernel, OVS-DPDK, SR-IOV - result
 in different NIC port, LAG (Link Aggregation Group), and other
 configurations. Some of these are shown diagrammatically in section
 :ref:`chapters/chapter04:compute nodes`.
@@ -486,7 +486,7 @@ These packets are then routed on the underlay network GRT.
 Server Flavors: B1, B4, HV, HD
 
 **Compute SR-IOV Port:** TOR port maps VLANs with bridge domains that
-extend to IRBs, using VXLAN VNI. The TOR port associates each packet’s
+extend to IRBs, using VXLAN VNI. The TOR port associates each packet's
 outer VLAN tag with a bridge domain to support VNF interface adjacencies
 over the local EVPN/MAC bridge domain. This model also applies to direct
 physical connections with transport elements.
@@ -739,7 +739,7 @@ Networking Fabric consists of:
 -  Switch OS
 -  Minimum number of switches
 -  Dimensioning for East/West and North/South
--  Spine / Leaf topology – east – west
+-  Spine / Leaf topology - east - west
 -  Global Network parameters
 -  OpenStack control plane VLAN / VXLAN layout
 -  Provider VLANs
@@ -785,7 +785,7 @@ High Level Logical Network Layout
          - Externally Routable: No
          - Connected to: All nodes except foundation
    * - Tenant
-     - VXLAN / Geneve project overlay networks (OVS kernel mode) – i.e., RFC1918 :cite:p:`rfc1918`
+     - VXLAN / Geneve project overlay networks (OVS kernel mode) - i.e., RFC1918 :cite:p:`rfc1918`
        re-usable private networks as controlled by cloud administrator
      -   - Security Domain: Underlay
          - Externally Routable: No
@@ -810,7 +810,7 @@ High Level Logical Network Layout
          - Externally routable: Yes
          - Connected to: OVS DPDK computes
    * - IPMI / Out of Band
-     - The remote “lights-out” management port of the servers e.g., iLO,
+     - The remote "lights-out" management port of the servers e.g., iLO,
        IDRAC / IPMI / Redfish
      -   - Security Domain: Management
          - Externally routable: No
@@ -819,7 +819,7 @@ High Level Logical Network Layout
 A VNF application network topology is expressed in terms of servers,
 vNIC interfaces with vNet access networks, and WAN Networks while the
 VNF Application Servers require multiple vNICs, VLANs, and host routes
-configured within the server’s Kernel.
+configured within the server's Kernel.
 
 Octavia v2 API conformant Load Balancing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -915,7 +915,7 @@ importance):
    to handle tenant networks.
 -  Capacity planning: FW, physical links, switches, routers, NIC
    interfaces and DCGW dimensioning (+ load monitoring: each link within
-   a LAG or a bond shouldn’t be loaded over 50% of its maximum capacity
+   a LAG or a bond shouldn't be loaded over 50% of its maximum capacity
    to guaranty service continuity in case of individual failure).
 -  Hardware choice: e.g., ToR/fabric switches, DCGW and NIC cards should
    have appropriate buffering and queuing capacity.
@@ -1064,7 +1064,7 @@ services running on the control nodes and no services running on the
 compute nodes:
 
 -  Keystone admin API
--  Keystone public API – in Keystone V3 this is the same as the admin
+-  Keystone public API - in Keystone V3 this is the same as the admin
    API
 
 Glance
@@ -1087,7 +1087,7 @@ Cinder :cite:p:`ostk_wallaby_cinder` is the block
 device management service, depends on Keystone and possibly Glance to be
 able to create volumes from images. Cinder has services running on the
 control nodes and no services running on the compute nodes: - Cinder API
-- Cinder Scheduler - Cinder Volume – the Cinder volume process needs to
+- Cinder Scheduler - Cinder Volume - the Cinder volume process needs to
 talk to its backends
 
 *The Cinder backends include SAN/NAS storage, iSCSI drives, Ceph RBD,
@@ -1198,7 +1198,7 @@ With DVR, each compute node also hosts the L3-agent (providing the
 distributed router capability) and this then allows direct instance to
 instance (East-West) communications.
 
-The OpenStack “High Availability Using Distributed Virtual Routing
+The OpenStack "High Availability Using Distributed Virtual Routing
 (DVR) :cite:p:`ostk_nw_liberty_dvr_ovs`"
 provides an in-depth view into how DVR works and the traffic flow
 between the various nodes and interfaces for three different use cases.
@@ -1221,7 +1221,7 @@ Telco workload requirements requires SDN to offload Neutron calls.
 SDN provides a truly scalable and preferred solution to suport dynamic,
 very large-scale, high-density, telco cloud environments. OpenStack
 Neutron, with its plugin architecture, provides the ability to integrate
-SDN controllers (:ref:`chapters/chapter03:virtual networking – 3rd party sdn solution`).
+SDN controllers (:ref:`chapters/chapter03:virtual networking - 3rd party sdn solution`).
 With SDN incorporated in OpenStack, changes to the network is triggered
 by workloads (and users), translated into Neutron APIs and then handled
 through neutron plugins by the corresponding SDN agents.
@@ -1289,7 +1289,7 @@ provides a RESTful API and a data model for the managing of resource
 provider inventories and usage for different classes of resources. In
 addition to standard resource classes, such as vCPU, MEMORY_MB and
 DISK_GB, the Placement service supports custom resource classes
-(prefixed with “CUSTOM\_”) provided by some external resource pools such
+(prefixed with "CUSTOM\_") provided by some external resource pools such
 as a shared storage pool provided by, say, Ceph. The placement service
 is primarily utilised by nova-compute and nova-scheduler. Other
 OpenStack services such as Neutron or Cyborg can also utilise placement
@@ -1307,7 +1307,7 @@ service :cite:p:`ostk_latest_placement`:
    quantity of one or more classes of resources. For example, RP_1 has
    available inventory of 16 vCPU, 16384 MEMORY_MB and 1024 DISK_GB.
 -  Traits are qualitative characteristics of the resources from a
-   resource provider. For example, the trait for RPA_1 “is_SSD” to
+   resource provider. For example, the trait for RPA_1 "is_SSD" to
    indicate that the DISK_GB provided by RP_1 are solid state drives.
 -  Allocations represent resources that have been assigned/used by some
    consumer of that resource.
@@ -1336,10 +1336,10 @@ storage encryption or Object Storage encryption or asymmetric keys and
 certificates used for Glance image signing and verification.
 
 Barbican usage provides a means to fulfill security requirements such as
-sec.sys.012 “The Platform **must** protect all secrets by using strong
+sec.sys.012 "The Platform **must** protect all secrets by using strong
 encryption techniques and storing the protected secrets externally from
-the component” and sec.ci.001 “The Platform **must** support
-Confidentiality and Integrity of data at rest and in transit.”.
+the component" and sec.ci.001 "The Platform **must** support
+Confidentiality and Integrity of data at rest and in transit.".
 
 Cyborg
 ^^^^^^
@@ -1378,8 +1378,8 @@ compute nodes, interacts with generic device type drivers on those
 nodes. These generic device type drivers are an abstraction of the
 vendor specific drivers; there is a generic device type driver for each
 device type (see above for list of some of the device types). The
-current list of the supported vendor drivers is listed under “Driver
-Support :cite:p:`ostk_latest_cyborg_support`”.
+current list of the supported vendor drivers is listed under "Driver
+Support :cite:p:`ostk_latest_cyborg_support`".
 
 Containerised OpenStack Services
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1416,7 +1416,7 @@ infrastructure. To implement these profiles and sizes, it is required to
 set up the flavors as specified in the tables below.
 
 .. list-table:: Neutron Services Placement
-   :widths: 10 17 20 33
+   :widths: 14 14 36 36
    :header-rows: 1
 
    * - Flavor Capabilities
@@ -1424,71 +1424,87 @@ set up the flavors as specified in the tables below.
      - Basic
      - High-Performance
    * - CPU allocation ratio (custom extra_specs)
-     - infra.com.cfg.001
+     - infra.com.cfg.\
+
+       001
      - In flavor create or flavor
-       set –property cpu_all ocation_ratio=4.0
-     - In flavor create or flavor set –property cpu_allocation_ratio=1.0
+       set -property cpu_all ocation_ratio=4.0
+     - In flavor create or flavor set -property cpu_allocation_ratio=1.0
    * - NUMA Awareness
-     - infra.com.cfg.002
+     - infra.com.cfg.\
+
+       002
      -
-     -   - In flavor create or flavor set specify –property hw:numa_nodes=<integer
-           range of 0 to #numa_nodes – 1>.
-         - To restrict an instance’s vCPUs to a
-           single host NUMA node, specify: –property hw:numa_nodes=1.
-         - Some compute intensive* workloads with highly sensitive memory latency
-           or bandwidth requirements, the instance may benefit from spreading
-           across multiple NUMA nodes: –property hw:numa_nodes=2
+     - In flavor create or flavor set specify -property hw:numa_nodes=<integer
+       range of 0 to #numa_nodes - 1>.
+       To restrict an instance's vCPUs to a
+       single host NUMA node, specify: -property hw:numa_nodes=1.
+       Some compute intensive* workloads with highly sensitive memory latency
+       or bandwidth requirements, the instance may benefit from spreading
+       across multiple NUMA nodes: -property hw:numa_nodes=2
    * - CPU Pinning
-     - infra.com.cfg.003
+     - infra.com.cfg.\
+
+       003
      - In flavor create or
        flavor set specify
-       –property hw: cpu_policy=shared
+       -property hw: cpu_policy=shared
        (default)
-     -   - In flavor create
-           or flavor set specify –property
-           hw:cpu_policy=dedicated and –property
-           hw:cpu_thread_policy=<prefer,require, isolate>.
-         - Use “isolate” thread policy for very high
-           compute intensive workloads that require that each vCPU be placed on a
-           different physical core
+     - In flavor create
+       or flavor set specify -property
+       hw:cpu_policy=dedicated and -property
+       hw:cpu_thread_policy=<prefer, require, isolate>.
+       Use "isolate" thread policy for very high
+       compute intensive workloads that require that each vCPU be placed on a
+       different physical core
    * - Huge pages
-     - infra.com.cfg.004
+     - infra.com.cfg.\
+
+       004
      -
-     - –property hw:mem_page_size=<small \|large \| size>
+     - -property hw:mem_page_size=<small \|large \| size>
    * - SMT
-     - infra.com.cfg.005
+     - infra.com.cfg.\
+
+       005
      -
-     - In flavor create or flavor set specify –property
+     - In flavor create or flavor set specify -property
        hw:cpu_threads=<integer#threads (usually 1 or 2)>
    * - OVS-DPDK
-     - infra.net.acc.cfg.001
+     - infra.net.acc.\
+
+       cfg.001
      -
      - ml2.conf.ini configured to support [OVS] datapath_type=netdev
 
-       Note:huge pages should be configured to large
+       Note: huge pages should be configured to large
    * - Local Storage SSD
-     - infra.hw.stg.ssd.cfg.002
+     - infra.hw.stg.\
+
+       ssd.cfg.002
      - trait:STORAGEDISK_SSD=required
      - trait:STORAGE_DISK_SSD=required
    * - Port speed
-     - infra.hw.nic.cfg.002
-     - –property quota vif_inbound_average=1310720 and
+     - infra.hw.nic.\
+
+       cfg.002
+     - -property quota vif_inbound_average=1310720 and
        vif_outbound_average=1310720.
 
        Note:10 Gbps = 1250000 kilobytes per second
-     - –property quota vif_inboundaverage=3125000 and
+     - -property quota vif_inboundaverage=3125000 and
        vif_outbound_average=3125000
 
        Note: 25 Gbps = 3125000 kilobytes per second
 
 ..
 
-   -  To configure profile-extensions, for example, the “Storage
-      Intensive High Performance” profile, as defined in
+   -  To configure profile-extensions, for example, the "Storage
+      Intensive High Performance" profile, as defined in
       :ref:`ref_model:chapters/chapter02:profile extensions (specialisations)`,
       in addition to the above, need to configure the storage IOPS: the
       following two parameters need to be specified in the flavor
-      create: –property quota:disk_write_iops_sec=<IOPS#> and –property
+      create: -property quota:disk_write_iops_sec=<IOPS#> and -property
       quota:disk_read_iops_sec=<IOPS#>.
 
 The flavor create command and the mandatory and optional configuration
@@ -1508,11 +1524,11 @@ will rely on the following principles:
 -  Affinity-groups: allow tenants to make sure that VNFC instances are
    on the same compute node or are on different compute nodes.
 
-Note: The Cloud Infrastructure doesn’t provide any resiliency mechanisms
+Note: The Cloud Infrastructure doesn't provide any resiliency mechanisms
 at the service level. Any server restart shall be triggered by the VNF
 Manager instead of OpenStack:
 
--  It doesn’t implement Instance High Availability which could allow
+-  It doesn't implement Instance High Availability which could allow
    OpenStack Platform to automatically re-spawn instances on a different
    compute node when their host compute node breaks.
 -  Physical host reboot does not trigger automatic server recovery.
@@ -1613,7 +1629,7 @@ such deployment choices.
      - Network Management
      - Storage Management
    * - CCP
-     - Centralised DC – control nodes
+     - Centralised DC - control nodes
      - heat-api, heat-engine, nova-placement-api
      - Identity Provider (IdP), Keystone API
      - Glance API, Glance Registry

--- a/doc/ref_arch/openstack/chapters/chapter05.rst
+++ b/doc/ref_arch/openstack/chapters/chapter05.rst
@@ -16,7 +16,7 @@ interest.
 OpenStack is a multi-project framework composed of independently
 evolving services. It is not enough to rely only on the OpenStack
 release to characterise the capabilities supported by these services.
-Regarding OpenStack services APIs, an “API version” is associated with
+Regarding OpenStack services APIs, an "API version" is associated with
 each OpenStack service. In addition to major API versions, some
 OpenStack services (Nova, Glance, Keystone, Cinder…) support
 microversions. The microversions allow new features to be introduced
@@ -31,16 +31,16 @@ Core OpenStack Services APIs
 ----------------------------
 
 Please note that OpenStack provides a maximum microversion to be used
-with an OpenStack release. In the following sections the “Maximal API
-Version” refers to this maximum microversion specified for the OpenStack
+with an OpenStack release. In the following sections the "Maximal API
+Version" refers to this maximum microversion specified for the OpenStack
 Wallaby release. Please note that in Reference Conformance (RC-1)
 testing, the System Under Test (SUT) can utilise newer microversions
 because of the OpenStack microversion policies. As per multiple
 OpenStack services documentation, for example the `Compute
 Service <https://docs.openstack.org/api-guide/compute/microversions.html>`__,
-“A cloud that is upgraded to support newer microversions will still
+"A cloud that is upgraded to support newer microversions will still
 support all older microversions to maintain the backward compatibility
-for those users who depend on older microversions.”
+for those users who depend on older microversions."
 
 Keystone
 ~~~~~~~~

--- a/doc/ref_arch/openstack/chapters/chapter06.rst
+++ b/doc/ref_arch/openstack/chapters/chapter06.rst
@@ -50,7 +50,7 @@ Platform Module).
 System Access
 ^^^^^^^^^^^^^
 
-Access to all the platform’s components must be restricted (sec.gen.013)
+Access to all the platform's components must be restricted (sec.gen.013)
 applying the following rules:
 
 -  Remove, or at a minimal, disable all unnecessary user accounts
@@ -87,7 +87,7 @@ permitting a password change.
 Passwords must be encrypted at rest and in-transit. Password files must
 be stored separately from application system data.
 
-Password’s composition, complexity and policy should follow the
+Password's composition, complexity and policy should follow the
 recommendations consolidated within the CIS Password Policy
 guide :cite:p:`cispwd` such as:
 
@@ -184,7 +184,7 @@ front end (sec.sys.006).
 OpenStack Keystone can work with an Identity service that your
 enterprise may already have, such as LDAP with Active Directory. In
 those cases, the recommendation is to integrate Keystone with the cloud
-provider’s Identity Services.
+provider's Identity Services.
 
 Authentication
 ^^^^^^^^^^^^^^
@@ -199,11 +199,11 @@ OpenStack Authentication Methods :cite:p:`openstackaut`.
 Limiting the number of repeated failed login attempts (configurable)
 reduces the risk of unauthorised access via password guessing (Bruce
 force attack) - sec.mon.006. The restriction on the number of
-consecutive failed login attempts (“lockout_failure_attempts”) and any
+consecutive failed login attempts ("lockout_failure_attempts") and any
 actions post such access attempts (such as locking the account where the
-“lockout_duration” is left unspecified) should abide by the operator’s
+"lockout_duration" is left unspecified) should abide by the operator's
 policies. For example, an operator may restrict the number of
-consecutive failed login attempts to 3 (“lockout_failure_attempts = 3”)
+consecutive failed login attempts to 3 ("lockout_failure_attempts = 3")
 and lock the account preventing any further access and where the account
 is unlocked by getting necessary approvals.
 
@@ -213,7 +213,7 @@ Keystone Tokens
 Once a user is authenticated, a token is generated for authorisation and
 access to an OpenStack environment and resources. By default, the token
 is set to expire in one hour. This setting can be changed based on the
-business and operational needs, but it’s highly recommended to set the
+business and operational needs, but it's highly recommended to set the
 expiration to the shortest possible value without dramatically impacting
 your operations.
 
@@ -231,7 +231,7 @@ user belongs to groups and each group has a list of roles that permits
 certain actions on certain resources. OpenStack services reference the
 roles of the user attempting to access the service. OpenStack policy
 enforcer middleware takes into consideration the policy rules associated
-with each resource and the user’s group/roles and association to
+with each resource and the user's group/roles and association to
 determine if access will be permitted for the requested resource. For
 more details on policies, please refer to the OpenStack
 Policies :cite:p:`openstackpol`.
@@ -348,7 +348,7 @@ concerns are raised:
 
 -  confidentiality and integrity of the Cloud Infrastructure components
    (networks, hypervisor, OpenStack services)
--  confidentiality and integrity of the tenant’s data
+-  confidentiality and integrity of the tenant's data
 
 The Cloud Infrastructure must also provide the mechanism to identify
 corrupted data.
@@ -506,10 +506,10 @@ Image Security
 
 Images from untrusted sources must not be used (sec.img.001). Valuable
 guidance on trusted image creation process and image signature
-verification is provided in the “Trusted Images” section of the
+verification is provided in the "Trusted Images" section of the
 OpenStack Security Guide :cite:p:`openstackti`.
-The OpenStack Security Guide includes reference to the “`OpenStack
-Virtual Machine Image Guide :cite:p:`openstackim`” that describes how
+The OpenStack Security Guide includes reference to the "`OpenStack
+Virtual Machine Image Guide :cite:p:`openstackim`" that describes how
 to obtain, create, and modify OpenStack compatible virtual machine
 images.
 
@@ -604,7 +604,7 @@ Regular review of security logs that record user access, as well as
 session (sec.mon.010) and network activity (sec.mon.012), is critical in
 preventing and detecting intrusions that could disrupt business
 operations. This monitoring process also allows administrators to
-retrace an intruder’s activity and may help correct any damage caused by
+retrace an intruder's activity and may help correct any damage caused by
 the intrusion (sec.mon.011).
 
 The logs have to be continuously monitored and analysed with alerts
@@ -709,7 +709,7 @@ The security audit log must contain at minimum the following fields
 -  Success/failure
 -  Login ID — Where the Login ID is defined on the
    system/application/authentication server; otherwise, the field should
-   contain ‘unknown’, in order to protect authentication credentials
+   contain ‘unknown', in order to protect authentication credentials
    accidentally entered at the Login ID prompt from appearing in the
    security audit log.
 -  Source and destination IP Addresses and ports

--- a/doc/ref_arch/openstack/chapters/chapter07.rst
+++ b/doc/ref_arch/openstack/chapters/chapter07.rst
@@ -121,9 +121,9 @@ A subset of these tools is described below.
   TripleO is an official OpenStack project which allows to deploy and
   manage a production cloud onto bare metal hardware using a subset
   of existing OpenStack components. The first step of deployment is
-  the creation of an “undercloud” or deployment cloud. The
+  the creation of an "undercloud" or deployment cloud. The
   undercloud contains the necessary OpenStack components to deploy
-  and manage an “overcloud”, representing the deployed cloud.
+  and manage an "overcloud", representing the deployed cloud.
   The architecture document :cite:p:`trarch`
   describes the solution. Nova and Ironic are used in the undercloud to manage
   the servers in bare metal environment. TripleO leverages
@@ -207,7 +207,7 @@ cloned, and appropriate changes made to get to the desired state.
 **Configuration and Version Changes**
 
 Configuration and Version Changes are made in a similar fashion to the
-“Deployment of infrastructure components” except that the IaC tools used
+"Deployment of infrastructure components" except that the IaC tools used
 maybe different.
 
 Logging, Monitoring and Analytics
@@ -260,7 +260,7 @@ Monitoring
 ~~~~~~~~~~
 
 Monitoring is the process of collecting, aggregating, and analysing
-values that improve awareness of the components’ characteristics and
+values that improve awareness of the components' characteristics and
 behavior. The data from various parts of the environment are collected
 into a monitoring system that is responsible for storage, aggregation,
 visualisation, and initiating automated responses when the values meet


### PR DESCRIPTION
It recalculates all tab widths to avoid overfulling.
It also removes Windows style chars and manually handle '/' to eases reading.
    
It also wraps a few lines to 80 chars.
