### PR TITLE
Allow generating docx for GSMA

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter01.rst
+++ b/doc/ref_arch/openstack/chapters/chapter01.rst
@@ -155,7 +155,7 @@ Terminology :ref:`cntt:common/glossary:openstack related terminology`.
 Abbreviations
 -------------
 
-.. list-table:: 
+.. list-table::
    :widths: 20 60
    :header-rows: 1
 

--- a/doc/ref_arch/openstack/chapters/chapter02.rst
+++ b/doc/ref_arch/openstack/chapters/chapter02.rst
@@ -1361,7 +1361,7 @@ Infrastructure Requirements
      - Network
      - The Architecture **must** provide virtual network interfaces to
        instances
-     - :ref:`chapters/chapter05:neutron`
+     - :ref:`chapters/chapter05:neutron api`
    * - inf.nw.02
      - Network
      - The Architecture **must** include capabilities for integrating SDN
@@ -1421,11 +1421,11 @@ VIM Requirements
      - General
      - The Architecture **must** allow VIM to discover and manage Cloud
        Infrastructure resources
-     - :ref:`chapters/chapter05:placement`
+     - :ref:`chapters/chapter05:placement api`
    * - vim.05
      - General
      - The Architecture **must** include image repository management
-     - :ref:`chapters/chapter05:glance`
+     - :ref:`chapters/chapter05:glance api`
    * - vim.07
      - General
      - The Architecture **must** support multi-tenancy
@@ -1451,32 +1451,32 @@ Interfaces & APIs Requirements
      - API
      - The Architecture **must** provide APIs to access the authentication service
        and the associated mandatory features detailed in chapter 5
-     - :ref:`chapters/chapter05:keystone`
+     - :ref:`chapters/chapter05:keystone api`
    * - int.api.02
      - API
      - The Architecture **must** provide APIs to access the image management
        service and the associated mandatory features detailed in chapter 5
-     - :ref:`chapters/chapter05:glance`
+     - :ref:`chapters/chapter05:glance api`
    * - int.api.03
      - API
      - The Architecture **must** provide APIs to access the block storage
        management service and the associated mandatory features detailed in chapter 5
-     - :ref:`chapters/chapter05:cinder`
+     - :ref:`chapters/chapter05:cinder api`
    * - int.api.04
      - API
      - The Architecture **must** provide APIs to access the object storage
        management service and the associated mandatory features detailed in chapter 5
-     - :ref:`chapters/chapter05:swift`
+     - :ref:`chapters/chapter05:swift api`
    * - int.api.05
      - API
      - The Architecture **must** provide APIs to access the network management
        service and the associated mandatory features detailed in chapter 5
-     - :ref:`chapters/chapter05:neutron`
+     - :ref:`chapters/chapter05:neutron api`
    * - int.api.06
      - API
      - The Architecture **must** provide APIs to access the compute resources
        management service and the associated mandatory features detailed in chapter 5
-     - :ref:`chapters/chapter05:nova`
+     - :ref:`chapters/chapter05:nova api`
    * - int.api.07
      - API
      - The Architecture **must** provide GUI access to tenant facing cloud
@@ -1486,11 +1486,11 @@ Interfaces & APIs Requirements
      - API
      - The Architecture **must** provide APIs needed to discover and manage
        Cloud Infrastructure resources
-     - :ref:`chapters/chapter05:placement`
+     - :ref:`chapters/chapter05:placement api`
    * - int.api.09
      - API
      - The Architecture **must** provide APIs to access the orchestration service
-     - :ref:`chapters/chapter05:heat`
+     - :ref:`chapters/chapter05:heat api`
    * - int.api.10
      - API
      - The Architecture **must** expose the latest version and microversion of the

--- a/doc/ref_arch/openstack/chapters/chapter02.rst
+++ b/doc/ref_arch/openstack/chapters/chapter02.rst
@@ -482,8 +482,7 @@ Cloud Infrastructure Hardware Profile-Extensions Requirements
      - SR-IOV over PCI-PT
      - N
      - Yes
-     - :ref:`chapters/chapter04:compute node configurations
-       for profiles and openstack flavors`
+     - :ref:`chapters/chapter04:compute node configurations for profiles and openstack flavors`
 
 Cloud Infrastructure Management Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -500,18 +499,15 @@ Cloud Infrastructure Management Requirements
    * - e.man.001
      - Capability to allocate virtual compute resources to a workload
      - Must support
-     - :ref:`chapters/chapter03:consumable infrastructure
-       resources and services`
+     - :ref:`chapters/chapter03:consumable infrastructure resources and services`
    * - e.man.002
      - Capability to allocate virtual storage resources to a workload
      - Must support
-     - :ref:`chapters/chapter03:consumable infrastructure
-       resources and services`
+     - :ref:`chapters/chapter03:consumable infrastructure resources and services`
    * - e.man.003
      - Capability to allocate virtual networking resources to a workload
      - Must support
-     - :ref:`chapters/chapter03:consumable infrastructure
-       resources and services`
+     - :ref:`chapters/chapter03:consumable infrastructure resources and services`
    * - e.man.004
      - Capability to isolate resources between tenants
      - Must support
@@ -559,8 +555,7 @@ System Hardening Requirements
      - Hardening
      - The Platform **must** maintain the specified configuration
      - :ref:`chapters/chapter06:security lcm` and
-       :ref:`chapters/chapter07:\
-       cloud infrastructure provisioning and configuration management`
+       :ref:`chapters/chapter07:cloud infrastructure provisioning and configuration management`
    * - sec.gen.002
      - Hardening
      - All systems part of Cloud Infrastructure **must** support hardening as
@@ -594,8 +589,7 @@ System Hardening Requirements
      - Hardening
      - All servers part of Cloud Infrastructure **must** be Time synchronised
        with authenticated Time service
-     - :ref:`chapters/chapter06:\
-       security logs time synchronisation`
+     - :ref:`chapters/chapter06:security logs time synchronisation`
    * - sec.gen.008
      - Hardening
      - All servers part of Cloud Infrastructure **must** be regularly updated
@@ -605,16 +599,14 @@ System Hardening Requirements
      - Hardening
      - The Platform **must** support software integrity protection and
        verification
-     - :ref:`chapters/chapter06:\
-       integrity of openstack components configuration`
+     - :ref:`chapters/chapter06:integrity of openstack components configuration`
    * - sec.gen.010
      - Hardening
      - The Cloud Infrastructure **must** support encrypted storage, for
        example, block, object and file storage, with access to encryption
        keys restricted based on a need to know
        (Controlled Access Based on the Need to Know :cite:p:`ciscontrols`)
-     - :ref:`chapters/chapter06:\
-       confidentiality and integrity`
+     - :ref:`chapters/chapter06:confidentiality and integrity`
    * - sec.gen.012
      - Hardening
      - The Operator **must** ensure that only authorised actors have physical
@@ -695,15 +687,13 @@ Platform and Access Requirements
        authenticate users for them them or to allow access to its resources
        from the trusted domain. In a bidirectional relationship both domain
        are "trusting" and "trusted"
-     - :ref:`chapters/chapter04:logical segregation
-       and high availability`
+     - :ref:`chapters/chapter04:logical segregation and high availability`
    * - sec.sys.010
      - Access
      - For two or more domains without existing trust relationships, the Platform
        **must not** allow the effect of an attack on one domain to impact the other
        domains either directly or indirectly
-     - :ref:`chapters/chapter04:logical segregation
-       and high availability`
+     - :ref:`chapters/chapter04:logical segregation and high availability`
    * - sec.sys.011
      - Access
      - The Platform **must not** reuse the same authentication credentials
@@ -766,23 +756,20 @@ Confidentiality and Integrity Requirements
        Integrity
      - The Platform **must** support Confidentiality and Integrity of data
        at rest and in transit
-     - :ref:`chapters/chapter06:confidentiality and
-       integrity`
+     - :ref:`chapters/chapter06:confidentiality and integrity`
    * - sec.ci.003
      - Confidentiality /
 
        Integrity
      - The Platform **must** support Confidentiality and Integrity of data
        related metadata
-     - :ref:`chapters/chapter06:confidentiality and
-       integrity`
+     - :ref:`chapters/chapter06:confidentiality and integrity`
    * - sec.ci.004
      - Confidentiality
      - The Platform **must** support Confidentiality of processes and
        restrict information sharing with only the process owner (e.g.,
        tenant)
-     - :ref:`chapters/chapter06:confidentiality and
-       integrity`
+     - :ref:`chapters/chapter06:confidentiality and integrity`
    * - sec.ci.005
      - Confidentiality /
 
@@ -790,8 +777,7 @@ Confidentiality and Integrity Requirements
      - The Platform **must** support Confidentiality and Integrity of process-
        related metadata and restrict information sharing with only the
        process owner (e.g., tenant)
-     - :ref:`chapters/chapter06:confidentiality and
-       integrity`
+     - :ref:`chapters/chapter06:confidentiality and integrity`
    * - sec.ci.006
      - Confidentiality /
 
@@ -839,8 +825,7 @@ Workload Security Requirements
      - The Cloud Infrastructure **must** provide methods to ensure the
        platform's trust status and integrity (e.g., remote attestation,
        Trusted Platform Module)
-     - :ref:`chapters/chapter06:cloud
-       infrastructure and vim security`
+     - :ref:`chapters/chapter06:cloud infrastructure and vim security`
    * - sec.wl.003
      - Workload
      - The Platform **must** support secure provisioning of Workloads
@@ -896,19 +881,16 @@ Image Security Requirements
    * - sec.img.004
      - Image
      - Images **must** only be accessible to authorised actors
-     - :ref:`chapters/chapter06:integrity of openstack
-       components configuration`
+     - :ref:`chapters/chapter06:integrity of openstack components configuration`
    * - sec.img.005
      - Image
      - Image Registries **must** only be accessible to authorised actors
-     - :ref:`chapters/chapter06:integrity of openstack
-       components configuration`
+     - :ref:`chapters/chapter06:integrity of openstack components configuration`
    * - sec.img.006
      - Image
      - Image Registries **must** only be accessible over networks that
        enforce authentication, integrity and confidentiality
-     - :ref:`chapters/chapter06:integrity of openstack
-       components configuration`
+     - :ref:`chapters/chapter06:integrity of openstack components configuration`
    * - sec.img.007
      - Image
      - Image registries **must** be clear of vulnerable and out of date versions
@@ -936,8 +918,7 @@ Security LCM Requirements
      - The Platform **must** support Secure Provisioning, Availability, and
        Deprovisioning (Secure Clean-Up) of workload resources where Secure
        Clean-Up includes tear-down, defense against virus or other attacks
-     - :ref:`chapters/chapter06:monitoring and security
-       audit`
+     - :ref:`chapters/chapter06:monitoring and security audit`
    * - sec.lcm.002
      - LCM
      - The Cloud Operator **must** use management protocols limiting security
@@ -949,20 +930,17 @@ Security LCM Requirements
        management processes for Cloud Infrastructure, Infrastructure
        Manager and othercomponents of the cloud, and Platform change control
        on hardware
-     - :ref:`chapters/chapter06:monitoring and security
-       audit`
+     - :ref:`chapters/chapter06:monitoring and security audit`
    * - sec.lcm.005
      - LCM
      - Platform **must** provide logs and these logs must be monitored for
        anomalous behaviour
-     - :ref:`chapters/chapter06:monitoring and security
-       audit`
+     - :ref:`chapters/chapter06:monitoring and security audit`
    * - sec.lcm.006
      - LCM
      - The Platform **must** verify the integrity of all Resource management
        requests
-     - :ref:`chapters/chapter06:confidentiality and
-       integrity of tenant data (sec.ci.001)`
+     - :ref:`chapters/chapter06:confidentiality and integrity of tenant data (sec.ci.001)`
    * - sec.lcm.007
      - LCM
      - The Platform **must** be able to update newly instantiated, suspended,
@@ -994,8 +972,7 @@ Security LCM Requirements
    * - sec.lcm.012
      - LCM
      - The Platform **must** log any access privilege escalation
-     - :ref:`chapters/chapter06:what to log / what not
-       to log`
+     - :ref:`chapters/chapter06:what to log / what not to log`
 
 Monitoring and Security Audit Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1027,14 +1004,12 @@ can trigger alerts and notifications for appropriate action.
    * - sec.mon.002
      - Monitoring
      - Security logs **must** be time synchronised
-     - :ref:`chapters/chapter06:security logs time
-       synchronisation`
+     - :ref:`chapters/chapter06:security logs time synchronisation`
    * - sec.mon.003
      - Monitoring
      - The Platform **must** log all changes to time server source, time,
        date and time zones
-     - :ref:`chapters/chapter06:security logs time
-       synchronisation`
+     - :ref:`chapters/chapter06:security logs time synchronisation`
    * - sec.mon.004
      - Audit
      - The Platform **must** secure and protect Audit logs (containing
@@ -1045,42 +1020,36 @@ can trigger alerts and notifications for appropriate action.
      - The Platform **must** Monitor and Audit various behaviours of
        connection and login attempts to detect access attacks and potential
        access attempts and take corrective accordingly actions
-     - :ref:`chapters/chapter06:what to log / what not
-       to log`
+     - :ref:`chapters/chapter06:what to log / what not to log`
    * - sec.mon.006
      - Monitoring / Audit
      - The Platform **must** Monitor and Audit operations by authorised
        account access after login to detect malicious operational activity
        and take corrective actions
-     - :ref:`chapters/chapter06:monitoring and security
-       audit`
+     - :ref:`chapters/chapter06:monitoring and security audit`
    * - sec.mon.007
      - Monitoring / Audit
      - The Platform **must** Monitor and Audit security parameter
        configurations for compliance with defined security policies
-     - :ref:`chapters/chapter06:integrity of openstack
-       components configuration`
+     - :ref:`chapters/chapter06:integrity of openstack components configuration`
    * - sec.mon.008
      - Monitoring / Audit
      - The Platform **must** Monitor and Audit externally exposed interfaces
        for illegal access (attacks) and take corrective security hardening
        measures
-     - :ref:`chapters/chapter06:confidentiality and
-       integrity of communications (sec.ci.001)`
+     - :ref:`chapters/chapter06:confidentiality and integrity of communications (sec.ci.001)`
    * - sec.mon.009
      - Monitoring / Audit
      - The Platform **must** Monitor and Audit service for various attacks
        (malformed messages, signalling flooding and replaying, etc.) and take
        corrective actions accordingly
-     - :ref:`chapters/chapter06:monitoring and security
-       audit`
+     - :ref:`chapters/chapter06:monitoring and security audit`
    * - sec.mon.010
      - Monitoring / Audit
      - The Platform **must** Monitor and Audit running processes to detect
        unexpected or unauthorised processes and take corrective actions
        accordingly
-     - :ref:`chapters/chapter06:monitoring and security
-       audit`
+     - :ref:`chapters/chapter06:monitoring and security audit`
    * - sec.mon.011
      - Monitoring / Audit
      - The Platform **must** Monitor and Audit logs from infrastructure elements
@@ -1091,8 +1060,7 @@ can trigger alerts and notifications for appropriate action.
      - Monitoring / Audit
      - The Platform **must** Monitor and Audit Traffic patterns and volumes to
        prevent malware download attempts
-     - :ref:`chapters/chapter06:confidentiality and
-       integrity`
+     - :ref:`chapters/chapter06:confidentiality and integrity`
    * - sec.mon.013
      - Monitoring
      - The monitoring system **must not** affect the security (integrity and
@@ -1104,8 +1072,7 @@ can trigger alerts and notifications for appropriate action.
      - The Platform **must** ensure that the Monitoring systems are never
        starved of resources and must activate alarms when resource utilisation
        exceeds a configurable threshold
-     - :ref:`chapters/chapter06:monitoring and security
-       audit`
+     - :ref:`chapters/chapter06:monitoring and security audit`
    * - sec.mon.017
      - Audit
      - The Platform **must** audit systems for any missing security patches
@@ -1121,8 +1088,7 @@ can trigger alerts and notifications for appropriate action.
      - Monitoring
      - The Platform's components **must not** include an authentication
        credential, e.g., password, in any logs, even if encrypted
-     - :ref:`chapters/chapter06:what to log / what not
-       to log`
+     - :ref:`chapters/chapter06:what to log / what not to log`
    * - sec.mon.020
      - Monitoring / Audit
      - The Platform's logging system **must** support the storage of security
@@ -1345,27 +1311,23 @@ Infrastructure Requirements
      - The Architecture **must** be able to support multiple CPU type options
        to support various infrastructure profiles (Basic and High
        Performance)
-     - :ref:`chapters/chapter04:\
-       support for cloud infrastructure profiles and flavors`
+     - :ref:`chapters/chapter04:support for cloud infrastructure profiles and flavors`
    * - inf.com.05
      - Compute
      - The Architecture **must** support Hardware Platforms with NUMA
        capabilities
-     - :ref:`chapters/chapter04:\
-       support for cloud infrastructure profiles and flavors`
+     - :ref:`chapters/chapter04:support for cloud infrastructure profiles and flavors`
    * - inf.com.06
      - Compute
      - The Architecture **must** support CPU Pinning of the vCPUs of an
        instance
-     - :ref:`chapters/chapter04:\
-       support for cloud infrastructure profiles and flavors`
+     - :ref:`chapters/chapter04:support for cloud infrastructure profiles and flavors`
    * - inf.com.07
      - Compute
      - The Architecture **must** support different hardware configurations
        to support various infrastructure profiles (Basic and High
        Performance)
-     - :ref:`chapters/chapter03:\
-       cloud partitioning: host aggregates, availability zones`
+     - :ref:`chapters/chapter03:cloud partitioning: host aggregates, availability zones`
    * - inf.com.08
      - Compute
      - The Architecture **must** support allocating certain number of host
@@ -1375,16 +1337,14 @@ Infrastructure Requirements
        workloads (e.g., OpenStack services) :cite:p:`openstackcpu`.
        Please see example, Configuring libvirt compute nodes for CPU pinning
        :cite:p:`openstackcputopo`
-     - :ref:`chapters/chapter03:\
-       cloud partitioning: host aggregates, availability zones`
+     - :ref:`chapters/chapter03:cloud partitioning: host aggregates, availability zones`
    * - inf.com.09
      - Compute
      - The Architecture **must** ensure that the host cores assigned to
        non-tenant and tenant workloads are SMT aware: that is, a host core and
        its associated SMT threads are either all assigned to non-tenant
        workloads or all assigned to tenant workloads
-     - :ref:`chapters/chapter04:\
-       pinned and unpinned cpus`
+     - :ref:`chapters/chapter04:pinned and unpinned cpus`
    * - inf.stg.01
      - Storage
      - The Architecture **must** provide remote (not directly attached to the
@@ -1408,8 +1368,7 @@ Infrastructure Requirements
        controllers to support provisioning of network services, from the SDN
        OpenStack Neutron service, such as networking of VTEPs to the Border
        Edge based VRFs
-     - :ref:`chapters/chapter03:\
-       virtual networking - 3rd party sdn solution`
+     - :ref:`chapters/chapter03:virtual networking - 3rd party sdn solution`
    * - inf.nw.03
      - Network
      - The Architecture **must** support low latency and high throughput
@@ -1422,8 +1381,8 @@ Infrastructure Requirements
      - :ref:`chapters/chapter04:network fabric`
    * - inf.nw.07
      - Network
-     - The Architecture must support network :ref:`resiliency
-       <cntt:common/glossary:cloud platform abstraction related terminology:>`
+     - The Architecture must support network
+       :ref:`resiliency <cntt:common/glossary:cloud platform abstraction related terminology:>`
      - :ref:`chapters/chapter03:network`
    * - inf.nw.10
      - Network
@@ -1457,8 +1416,7 @@ VIM Requirements
    * - vim.01
      - General
      - The Architecture **must** allow infrastructure resource sharing
-     - :ref:`chapters/chapter03:consumable
-       infrastructure resources and services`
+     - :ref:`chapters/chapter03:consumable infrastructure resources and services`
    * - vim.03
      - General
      - The Architecture **must** allow VIM to discover and manage Cloud
@@ -1471,8 +1429,7 @@ VIM Requirements
    * - vim.07
      - General
      - The Architecture **must** support multi-tenancy
-     - :ref:`chapters/chapter03:multi-tenancy
-       (execution environment)`
+     - :ref:`chapters/chapter03:multi-tenancy (execution environment)`
    * - vim.08
      - General
      - The Architecture **must** support resource tagging
@@ -1764,8 +1721,7 @@ VIM Recommendations
      - General
      - The Architecture **should** support deployment of OpenStack components
        in containers
-     - :ref:`chapters/chapter04:\
-       containerised openstack services`
+     - :ref:`chapters/chapter04:containerised openstack services`
    * - vim.04
      - General
      - The Architecture **should** support Enhanced Platform Awareness (EPA)

--- a/doc/ref_arch/openstack/chapters/chapter03.rst
+++ b/doc/ref_arch/openstack/chapters/chapter03.rst
@@ -162,8 +162,7 @@ Data is accessed via API. Object storage is managed by OpenStack Swift.
 Images are persistent data, stored using the OpenStack Glance service.
 
 Cinder, Swift, and Glance services are discussed in the section
-:ref:`chapters/chapter04:virtualised infrastructure
-manager (VIM)`.
+:ref:`chapters/chapter04:virtualised infrastructure manager (VIM)`.
 
 
 Virtual Networking Neutron standalone
@@ -395,7 +394,7 @@ The following OpenStack components are deployed on the Infrastructure.
 Some of them will be only deployed on control hosts and some of them
 will be deployed within both control and compute hosts. The table below
 also maps the OpenStack core services to the Virtual Infrastructure
- Manager in the Reference Model (RM) :cite:p:`refmodel`.
+Manager in the Reference Model (RM) :cite:p:`refmodel`.
 
 .. list-table:: OpenStack components deployment
    :widths: 20 10 20 10 10 10

--- a/doc/ref_arch/openstack/chapters/chapter04.rst
+++ b/doc/ref_arch/openstack/chapters/chapter04.rst
@@ -537,7 +537,7 @@ Example Host Configurations
 Let us refer to the data traffic networking configuration of
 :numref:`Basic Profile Host Configuration` to be part of the hp-B1-a and
 hp-B4-a host profiles and this requires the configurations as Table
-:ref:`Configuration of Basic Flavor Capabilities`.
+`Configuration of Basic Flavor Capabilities`_.
 
 .. _Configuration of Basic Flavor Capabilities:
 .. list-table:: Configuration of Basic Flavor Capabilities
@@ -587,7 +587,7 @@ but are independent of the PXE network.
 
 Let us refer to the above networking set up to be part of the hp-B1-b
 and hp-B4-b host profiles but the basic configurations as specified in
-Table :ref:`Configuration of Basic Flavor Capabilities`.
+Table `Configuration of Basic Flavor Capabilities`_.
 
 In our example, the Profile Extensions B1 and B4, are each mapped to two
 different host profiles hp-B1-a and hp-B1-b, and hp-B4-a and hp-B4-b
@@ -616,7 +616,7 @@ The above examples of host networking configurations for the B1 and B4
 Profile Extensions are also suitable for the HV Profile Extensions;
 however, the hypervisor and BIOS settings will be different (see table
 below) and hence there will be a need for different host profiles. Table
-:ref:`Configuration of High Performance Flavor Capabilities` gives examples of
+`Configuration of High Performance Flavor Capabilities`_ gives examples of
 three different host profiles; one each for HV, HD and HS Profile Extensions.
 
 .. _Configuration of High Performance Flavor Capabilities:
@@ -883,7 +883,7 @@ Additions to resources, such as additional attributes, must be
 accompanied by an extension.
 
 :ref:`chapters/chapter05:interfaces and apis` of this Reference
-Architecture provides a list of :ref:`Neutron Extensions<chapters/chapter05:neutron>`.
+Architecture provides a list of :ref:`chapters/chapter04:neutron extensions`.
 The current available
 extensions can be obtained using the List Extensions
 API :cite:p:`ostk_nw_ext`
@@ -1749,5 +1749,4 @@ number of open-source tools are available for the purpose including:
 
 These installers are described in more details in
 
-:ref:`chapters/chapter07:\
-Operations and Life Cycle Management`.
+:ref:`chapters/chapter07:Operations and Life Cycle Management`.

--- a/doc/ref_arch/openstack/chapters/chapter04.rst
+++ b/doc/ref_arch/openstack/chapters/chapter04.rst
@@ -620,6 +620,7 @@ below) and hence there will be a need for different host profiles. Table
 three different host profiles; one each for HV, HD and HS Profile Extensions.
 
 .. _Configuration of High Performance Flavor Capabilities:
+
 .. list-table:: Configuration of High Performance Flavor Capabilities
    :widths: 15 29 12 12 12
    :header-rows: 2
@@ -1053,8 +1054,8 @@ VIM Services
 ~~~~~~~~~~~~
 
 A high-level overview of the core OpenStack Services was provided in
-:ref:`chapters/chapter03:modelling`. In this section we
-describe the core and other needed services in more detail.
+:ref:`chapters/chapter03:cloud infrastructure architecture - openStack`.
+In this section we describe the core and other needed services in more detail.
 
 Keystone
 ^^^^^^^^

--- a/doc/ref_arch/openstack/chapters/chapter05.rst
+++ b/doc/ref_arch/openstack/chapters/chapter05.rst
@@ -42,8 +42,8 @@ Service <https://docs.openstack.org/api-guide/compute/microversions.html>`__,
 support all older microversions to maintain the backward compatibility
 for those users who depend on older microversions."
 
-Keystone
-~~~~~~~~
+Keystone API
+~~~~~~~~~~~~
 
 .. table:: Keystone
    :widths: auto
@@ -79,8 +79,8 @@ https://docs.openstack.org/api-ref/identity/v3-ext/
 Security compliance and PCI-DSS:
 https://docs.openstack.org/keystone/train/admin/configuration.html#security-compliance-and-pci-dss
 
-Glance
-~~~~~~
+Glance API
+~~~~~~~~~~
 
 .. table:: Glance
    :widths: auto
@@ -105,8 +105,8 @@ Glance
 Image Service Versions:
 https://docs.openstack.org/api-ref/image/versions/index.html#version-history
 
-Cinder
-~~~~~~
+Cinder API
+~~~~~~~~~~
 
 .. table:: Cinder
    :widths: auto
@@ -140,8 +140,8 @@ Block Storage API: https://docs.openstack.org/api-ref/block-storage/
 REST API Version History:
 https://docs.openstack.org/cinder/latest/contributor/api_microversion_history.html
 
-Swift
-~~~~~
+Swift API
+~~~~~~~~~
 
 .. table:: Swift
    :widths: auto
@@ -182,8 +182,8 @@ https://docs.openstack.org/api-ref/object-store/index.html
 Discoverability:
 https://docs.openstack.org/swift/latest/api/discoverability.html
 
-Neutron
-~~~~~~~
+Neutron API
+~~~~~~~~~~~
 
 .. table:: Neutron
    :widths: auto
@@ -295,8 +295,8 @@ Networking Service APIs: https://docs.openstack.org/api-ref/network/
 The exhaustive list of extensions is available at
 https://docs.openstack.org/api-ref/network/v2/
 
-Nova
-~~~~
+Nova API
+~~~~~~~~
 
 .. table:: Nova
    :widths: auto
@@ -346,8 +346,8 @@ Compute API: https://docs.openstack.org/api-ref/compute/
 REST API Version History:
 https://docs.openstack.org/nova/latest/reference/api-microversion-history.html
 
-Placement
-~~~~~~~~~
+Placement API
+~~~~~~~~~~~~~
 
 .. table:: Placement
    :widths: auto
@@ -363,8 +363,8 @@ Placement API: https://docs.openstack.org/api-ref/placement/
 REST API Version History:
 https://docs.openstack.org/placement/latest/placement-api-microversion-history.html
 
-Heat
-~~~~
+Heat API
+~~~~~~~~
 
 .. table:: Heat
    :widths: auto
@@ -455,8 +455,8 @@ Libvirt Interfaces
 
 The Libvirt APIs are documented in https://libvirt.org/html/index.html.
 
-Barbican
-~~~~~~~~
+Barbican API
+~~~~~~~~~~~~
 
 .. table:: Barbican
    :widths: auto

--- a/doc/ref_arch/openstack/chapters/chapter06.rst
+++ b/doc/ref_arch/openstack/chapters/chapter06.rst
@@ -548,8 +548,8 @@ infrastructure safe and operational (sec.lcm.003).
 Regarding the provisioning of servers, switches, routers and networking,
 tools must be used to automate the provisioning eliminating human error.
 For Infrastructure hardware resources, a set of recommendations is
-detailed in :ref:`chapters/chapter07:underlying resources
-provisioning` to automate and secure their provisioning (sec.lcm.001).
+detailed in :ref:`chapters/chapter07:underlying resources provisioning`
+to automate and secure their provisioning (sec.lcm.001).
 
 For OpenStack services and software components, deployment tools or
 components must be used to automate the deployment and avoid errors. The

--- a/doc/ref_arch/openstack/chapters/chapter07.rst
+++ b/doc/ref_arch/openstack/chapters/chapter07.rst
@@ -33,7 +33,7 @@ management systems; some open-source tools may be mentioned but their
 capabilities are beyond the scope of this chapter.
 
 Procedural versus Declarative code
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------
 
 The procedural style IaC tools require code that specifies how to
 achieve the desired state. Whilst the declarative style IaC tools
@@ -51,7 +51,7 @@ figured by tracing the created code files and the order in which they
 were applied.
 
 Mutable versus Immutable infrastructure
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------
 
 In the mutable infrastructure paradigm, software updates are made in
 place. Over time this can lead to configuration drift where each server

--- a/doc/ref_arch/openstack/conf.py
+++ b/doc/ref_arch/openstack/conf.py
@@ -3,7 +3,8 @@ copyright = '2022, Anuket. Licensed under CC BY 4.0'
 author = 'Anuket Project of Linux Foundation Networking'
 exclude_patterns = [
     '.tox',
-    'README.rst'
+    'README.rst',
+    'tmp/index.rst'
 ]
 extensions = [
     'sphinx.ext.intersphinx',

--- a/doc/ref_arch/openstack/tox.ini
+++ b/doc/ref_arch/openstack/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs
+envlist = docs,gsma
 skipsdist = True
 
 [testenv:docs]
@@ -9,7 +9,32 @@ deps =
   -r{toxinidir}/test-requirements.txt
 install_command = pip install {opts} {packages}
 commands =
-  doc8 . --ignore-path .tox --ignore-path build --max-line-length 120
+  doc8 . --ignore-path .tox --ignore-path build --ignore-path tmp --max-line-length 120
   sphinx-build --keep-going -W -b html . build
   sphinx-build --keep-going -W -b latex . build
   sphinx-build --keep-going -W -b linkcheck . build
+
+[testenv:gsma]
+basepython = python3.9
+deps =
+  -chttps://opendev.org/openstack/requirements/raw/branch/stable/xena/upper-constraints.txt
+  -r{toxinidir}/test-requirements.txt
+install_command = pip install {opts} {packages}
+allowlist_externals =
+  mkdir
+  cp
+  cat
+  bash
+  sed
+  rm
+  pandoc
+commands =
+  rm -f tmp/index.rst
+  mkdir -p tmp
+  cp -rf conf.py figures refs.bib tmp/
+  bash -c 'for i in chapters/*.rst; do cat $i >> tmp/index.rst; echo "" >> tmp/index.rst; done'
+  sed "s/:ref:`chapters\/chapter0[1-9]:\(.*\)`/`\1`_/g" -i tmp/index.rst
+  sed -i "s/..\/figures\//figures\//g" tmp/index.rst
+  bash -c '(cd tmp && sphinx-build --keep-going -b html . build)'
+  bash -c '(cd tmp && sphinx-build --keep-going -b latex . build)'
+  pandoc -s -o ra1.docx -t docx tmp/index.rst


### PR DESCRIPTION
It stops wrapping ref to ease dynamically change
in the single rst for GSMA document.

It must be noted they are lots of duplicated
label (titles) in ra1.

It also fixes a few issues added by the latest
merges.

run tox -e gsma to get ra1.docx

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>