### PR TITLE
[RA1] Remove duplicated {{ and }} in title

### DIFF
--- a/doc/ref_arch/openstack/refs.bib
+++ b/doc/ref_arch/openstack/refs.bib
@@ -6,7 +6,7 @@
 	doi =		{10.17487/RFC1918},
 	url =		{https://www.rfc-editor.org/info/rfc1918},
         author =	{Robert Moskowitz and Daniel Karrenberg and Yakov Rekhter and Eliot Lear and Geert Jan de Groot},
-	title =		{{Address Allocation for Private Internets}},
+	title =		{Address Allocation for Private Internets},
 	pagetotal =	9,
 	year =		1996,
 	month =		feb,
@@ -21,7 +21,7 @@
 	doi =		{10.17487/RFC2119},
 	url =		{https://www.rfc-editor.org/info/rfc2119},
         author =	{Scott O. Bradner},
-	title =		{{Key words for use in RFCs to Indicate Requirement Levels}},
+	title =		{Key words for use in RFCs to Indicate Requirement Levels},
 	pagetotal =	3,
 	year =		1997,
 	month =		mar,
@@ -36,7 +36,7 @@
 	doi =		{10.17487/RFC5905},
 	url =		{https://www.rfc-editor.org/info/rfc5905},
         author =	{Jim Martin and Jack Burbank and William Kasch and Professor David L. Mills},
-	title =		{{Network Time Protocol Version 4: Protocol and Algorithms Specification}},
+	title =		{Network Time Protocol Version 4: Protocol and Algorithms Specification},
 	pagetotal =	110,
 	year =		2010,
 	month =		jun,
@@ -51,7 +51,7 @@
 	doi =		{10.17487/RFC5906},
 	url =		{https://www.rfc-editor.org/info/rfc5906},
         author =	{Professor David L. Mills and Brian Haberman},
-	title =		{{Network Time Protocol Version 4: Autokey Specification}},
+	title =		{Network Time Protocol Version 4: Autokey Specification},
 	pagetotal =	58,
 	year =		2010,
 	month =		jun,
@@ -66,7 +66,7 @@
 	doi =		{10.17487/RFC5907},
 	url =		{https://www.rfc-editor.org/info/rfc5907},
         author =	{Chris Elliott and Brian Haberman and Heiko Gerstung},
-	title =		{{Definitions of Managed Objects for Network Time Protocol Version 4 (NTPv4)}},
+	title =		{Definitions of Managed Objects for Network Time Protocol Version 4 (NTPv4)},
 	pagetotal =	26,
 	year =		2010,
 	month =		jun,
@@ -81,7 +81,7 @@
 	doi =		{10.17487/RFC5908},
 	url =		{https://www.rfc-editor.org/info/rfc5908},
         author =	{Benoit Lourdelet and Richard Gayraud},
-	title =		{{Network Time Protocol (NTP) Server Option for DHCPv6}},
+	title =		{Network Time Protocol (NTP) Server Option for DHCPv6},
 	pagetotal =	9,
 	year =		2010,
 	month =		jun,
@@ -100,7 +100,7 @@
 	doi =		{10.17487/RFC2544},
 	url =		{https://www.rfc-editor.org/info/rfc2544},
         author =	{},
-	title =		{{Benchmarking Methodology for Network Interconnect Devices}},
+	title =		{Benchmarking Methodology for Network Interconnect Devices},
 	pagetotal =	31,
 	year =		1999,
 	month =		mar,
@@ -110,19 +110,19 @@
 % Chapter 1 References
 
 @misc{refmodel,
-	title =	{{Cloud Infrastructure Reference Model}},
+	title =	{Cloud Infrastructure Reference Model},
 	howpublished = {GSMA PRD NG.126 v3.0},
 	publisher = {GSM Association},
 	year = 2022
 }
 
 @misc{openstack,
-	title =	{{OpenStack Documentation}},
+	title =	{OpenStack Documentation},
 	url = {https://docs.openstack.org/}
 }
 
 @misc{etsinfvinf,
-	title = {{Network Functions Virtualisation (NFV); Infrastructure Overview}},
+	title = {Network Functions Virtualisation (NFV); Infrastructure Overview},
 	howpublished = {ETSI GS NFV-INF 001 V1.1.1},
 	url = {https://www.etsi.org/deliver/etsi_gs/NFV-INF/001_099/001/01.01.01_60/gs_NFV-INF001v010101p.pdf},
 	year = 2015,
@@ -130,17 +130,17 @@
 }
 
 @misc{openstackuc,
-	title = {{OpenStack Use cases}},
+	title = {OpenStack Use cases},
 	url = {https://docs.openstack.org/arch-design/use-cases.html}
 }
 
 @misc{ovs,
-	title = {{Open vSwitch}},
+	title = {Open vSwitch},
 	url = {https://www.openvswitch.org/}
 }
 
 @misc{wallaby,
-	title = {{OpenStack Wallaby projects}},
+	title = {OpenStack Wallaby projects},
 	url = {https://docs.openstack.org/wallaby/projects.html},
 	author = {OpenStack Community}
 }
@@ -148,106 +148,106 @@
 % Chapter 2 References
 
 @misc{cispwd,
-	title =	{{Center for Internet Security - Password Policy Guide}},
+	title =	{Center for Internet Security - Password Policy Guide},
 	url = {https://www.cisecurity.org/insights/white-papers/cis-password-policy-guide},
 	author = {H. Philip White},
 	year = 2020
 }
 
 @misc{ciscontrols,
-	title =	{{Center for Internet Security - Controls V7.1}},
+	title =	{Center for Internet Security - Controls V7.1},
 	url = {https://www.cisecurity.org/controls/cis-controls-list}
 }
 
 @misc{openstackcpu,
-	title = {{OpenStack - CPU Dedicated Set}},
+	title = {OpenStack - CPU Dedicated Set},
 	url = {https://docs.openstack.org/nova/latest/configuration/config.html#compute.cpu_dedicated_set}
 }
 
 @misc{openstackcputopo,
-	title = {{OpenStack - CPU Topologies}},
+	title = {OpenStack - CPU Topologies},
 	url = {https://docs.openstack.org/nova/latest/admin/cpu-topologies.html}
 }
 
 @misc{openstackneut,
-	title = {{OpenStack - Neutron Plugins and Drivers}},
+	title = {OpenStack - Neutron Plugins and Drivers},
 	url = {https://wiki.openstack.org/wiki/Neutron_Plugins_and_Drivers}
 }
 
 @misc{openstacktags,
-	title = {{OpenStack - Tags}},
+	title = {OpenStack - Tags},
 	url = {https://specs.openstack.org/openstack/api-wg/guidelines/tags.html}
 }
 
 @misc{openstackha,
-	title = {{OpenStack - Configuring the stateful services}},
+	title = {OpenStack - Configuring the stateful services},
 	url = {https://docs.openstack.org/ha-guide/control-plane-stateful.html}
 }
 
 @misc{openstacksen,
-	title = {{OpenStack - Senlin documentation}},
+	title = {OpenStack - Senlin documentation},
 	url = {https://docs.openstack.org/senlin/wallaby/}
 }
 
 @misc{openstackneutovs,
-	title = {{OpenStack - Neutron OVS Agent Support for Baremetal with Smart NIC}},
+	title = {OpenStack - Neutron OVS Agent Support for Baremetal with Smart NIC},
 	url = {https://specs.openstack.org/openstack/neutron-specs/specs/stein/neutron-ovs-agent-support-baremetal-with-smart-nic.html}
 }
 
 @misc{ntiasbom,
-	title = {{National Telecommunications and Information Administration - Software Bill Of Materials}},
+	title = {National Telecommunications and Information Administration - Software Bill Of Materials},
 	url = {https://www.ntia.gov/SBOM}
 }
 
 @misc{cis,
-	title = {{Center for Internet Security}},
+	title = {Center for Internet Security},
 	url = {https://www.cisecurity.org/}
 }
 
 @misc{csa,
-	title = {{Cloud Security Alliance}},
+	title = {Cloud Security Alliance},
 	url = {https://cloudsecurityalliance.org/}
 }
 
 @misc{ocss,
-	title = {{Open Web Application Security Project - Cheat Sheet Series}},
+	title = {Open Web Application Security Project - Cheat Sheet Series},
 	url = {https://github.com/OWASP/CheatSheetSeries}
 }
 
 @misc{owasp,
-	title = {{Open Web Application Security Project}},
+	title = {Open Web Application Security Project},
 	url = {https://www.owasp.org}
 }
 
 @misc{owaspten,
-	title = {{Open Web Application Security Project - Top Ten Security Risks}},
+	title = {Open Web Application Security Project - Top Ten Security Risks},
 	url = {https://owasp.org/www-project-top-ten/}
 }
 
 @misc{samm,
-	title = {{Open Web Application Security Project - Software Maturity Model (SAMM)}},
+	title = {Open Web Application Security Project - Software Maturity Model (SAMM)},
 	url = {https://owaspsamm.org/blog/2019/12/20/version2-community-release/}
 }
 
 @misc{wstg,
-	title = {{Open Web Application Security Project - Web Security Testing Guide}},
+	title = {Open Web Application Security Project - Web Security Testing Guide},
 	url = {https://github.com/OWASP/wstg/tree/master/document}
 }
 
 @misc{isoiec27001,
-	title = {{ISO (International Organization for Standardization) and IEC (International Electrotechnical Commission) ISO/IEC 27001:2013}},
+	title = {ISO (International Organization for Standardization) and IEC (International Electrotechnical Commission) ISO/IEC 27001:2013},
 	url = {https://www.iso.org/obp/ui/#iso:std:iso-iec:27001:ed-2:v1:en},
 	year = 2013
 }
 
 @misc{isoiec27002,
-	title = {{ISO (International Organization for Standardization) and IEC (International Electrotechnical Commission) ISO/IEC 27002:2013}},
+	title = {ISO (International Organization for Standardization) and IEC (International Electrotechnical Commission) ISO/IEC 27002:2013},
 	url = {https://www.iso.org/obp/ui/#iso:std:iso-iec:27002:ed-2:v1:en},
 	year = 2013
 }
 
 @misc{isoiec27032,
-	title = {{ISO (International Organization for Standardization) and IEC (International Electrotechnical Commission) ISO/IEC 7032:2012}},
+	title = {ISO (International Organization for Standardization) and IEC (International Electrotechnical Commission) ISO/IEC 7032:2012},
 	url = {https://www.iso.org/obp/ui/#iso:std:iso-iec:27032:ed-1:v1:en},
 	year = 2012
 }
@@ -255,256 +255,256 @@
 % Chapter 3 References
 
 @misc{openstackstor,
-	title = {{OpenStack Storage}},
+	title = {OpenStack Storage},
 	url = {https://docs.openstack.org/arch-design/design-storage/design-storage-concepts.html#table-openstack-storage}
 }
 
 @misc{openstackcind,
-	title = {{OpenStack Cinder Driver Support Matrix}},
+	title = {OpenStack Cinder Driver Support Matrix},
 	url = {https://docs.openstack.org/cinder/latest/reference/support-matrix.html}
 }
 
 @misc{tungsten,
 
-	title = {{Tungsten Fabric - Multicloud Multistack SDN}},
+	title = {Tungsten Fabric - Multicloud Multistack SDN},
 	url = {https://tungsten.io}
 }
 
 @misc{openstackglos,
-	title = {{OpenStack Glossary}},
+	title = {OpenStack Glossary},
 	url = {https://docs.openstack.org/doc-contrib-guide/common/glossary.html}
 }
 
 @misc{openstackfeat,
-	title = {{OpenStack Feature Support Matrix}},
+	title = {OpenStack Feature Support Matrix},
 	url = {https://docs.openstack.org/nova/latest/user/support-matrix.html}
 }
 
 @misc{openstackstar,
-	title = {{OpenStack Storage Architecture Design}},
+	title = {OpenStack Storage Architecture Design},
 	url = {https://docs.openstack.org/arch-design/design-storage.html}
 }
 
 % Chapter 4 References
 
 @misc{dpdk_rel_notes,
-	title = {{(DPDK) Release Notes}},
+	title = {(DPDK) Release Notes},
 	url = {http://doc.dpdk.org/guides/rel_notes}
 }
 
 @misc{dpdk_perf,
-	title = {{(DPDK) Performance Reports}},
+	title = {(DPDK) Performance Reports},
 	url = {http://core.dpdk.org/perf-reports/}
 }
 
 @misc{ceph,
-	title = {{Ceph - The Future of Storage}},
+	title = {Ceph - The Future of Storage},
 	url = {https://ceph.io/en}
 }
 
 @misc{ostk_svr,
-	title = {{OpenStack Compute API Guide 2.1.0: Server concepts}},
+	title = {OpenStack Compute API Guide 2.1.0: Server concepts},
 	url = {https://docs.openstack.org/api-guide/compute/server_concepts.html}
 }
 
 @misc{ostk_bm,
-	title = {{OpenStack Ironic API Reference: Bare Metal API}},
+	title = {OpenStack Ironic API Reference: Bare Metal API},
 	url = {https://docs.openstack.org/api-ref/baremetal/}
 }
 
 @misc{ostk_nw_ext,
-	title = {{OpenStack Networking API v2.0: List extensions}},
+	title = {OpenStack Networking API v2.0: List extensions},
 	url = {https://docs.openstack.org/api-ref/network/v2/#list-extensions}
 }
 
 @misc{ostk_nw_ext_details,
-	title = {{OpenStack Networking API v2.0: Show extension details}},
+	title = {OpenStack Networking API v2.0: Show extension details},
 	url = {https://docs.openstack.org/api-ref/network/v2/#show-extension-details}
 }
 
 @misc{ostk_wallaby-barbican,
-	title = {{OpenStack Key Manager (barbican)}},
+	title = {OpenStack Key Manager (barbican)},
 	url = {https://docs.openstack.org/barbican/wallaby/}
 }
 
 @misc{ostk_latest_cinder,
-	title = {{OpenStack Cinder Administration}},
+	title = {OpenStack Cinder Administration},
 	url = {https://docs.openstack.org/cinder/latest/admin/index.html}
 }
 
 @misc{ostk_latest_cinder_config,
-	title = {{OpenStack Cinder Service Configuration}},
+	title = {OpenStack Cinder Service Configuration},
 	url = {https://docs.openstack.org/cinder/latest/configuration/index.html}
 }
 
 @misc{ostk_latest_cinder_drivers,
-	title = {{OpenStack (Cinder) Available Drivers}},
+	title = {OpenStack (Cinder) Available Drivers},
 	url = {https://docs.openstack.org/cinder/latest/drivers.html}
 }
 
 @misc{ostk_latest_cinder_support,
-	title = {{OpenStack Cinder Driver Support Matrix}},
+	title = {OpenStack Cinder Driver Support Matrix},
 	url = {https://docs.openstack.org/cinder/latest/reference/support-matrix.html}
 }
 
 @misc{ostk_wallaby_cinder,
-	title = {{OpenStack Block Storage (Cinder) documentation}},
+	title = {OpenStack Block Storage (Cinder) documentation},
 	url = {https://docs.openstack.org/cinder/wallaby/}
 }
 
 @misc{ostk_latest_cyborg_support,
-	title = {{OpenStack Cyborg Support Matrix}},
+	title = {OpenStack Cyborg Support Matrix},
 	url = {https://docs.openstack.org/cyborg/latest/reference/support-matrix.html}
 }
 
 @misc{ostk_latest_cyborg_arch,
-	title = {{OpenStack Cyborg architecture}},
+	title = {OpenStack Cyborg architecture},
 	url = {https://docs.openstack.org/cyborg/latest/user/architecture.html}
 }
 
 @misc{ostk_wallaby_cyborg,
-	title = {{OpenStack Accelerator (Cyborg)}},
+	title = {OpenStack Accelerator (Cyborg)},
 	url = {https://docs.openstack.org/cyborg/wallaby/}
 }
 
 @misc{ostk_wallaby_cyborg_support,
-	title = {{OpenStack Cyborg Support Matrix (Wallaby)}},
+	title = {OpenStack Cyborg Support Matrix (Wallaby)},
 	url = {https://docs.openstack.org/cyborg/wallaby/reference/support-matrix.html}
 }
 
 @misc{ostk_wallaby_glance,
-	title = {{OpenStack - Welcome to Glance’s documentation!}},
+	title = {OpenStack - Welcome to Glance’s documentation!},
 	url = {https://docs.openstack.org/glance/wallaby/}
 }
 
 @misc{ostk_wallaby_heat,
-	title = {{OpenStack - Welcome to the Heat documentation!}},
+	title = {OpenStack - Welcome to the Heat documentation!},
 	url = {https://docs.openstack.org/heat/wallaby/}
 }
 
 @misc{ostk_wallaby_horizon,
-	title = {{Horizon: The OpenStack Dashboard Project}},
+	title = {Horizon: The OpenStack Dashboard Project},
 	url = {https://docs.openstack.org/horizon/wallaby/}
 }
 
 @misc{ostk_wallaby_ironic,
-	title = {{OpenStack - Welcome to Ironic’s documentation!}},
+	title = {OpenStack - Welcome to Ironic’s documentation!},
 	url = {https://docs.openstack.org/ironic/wallaby/}
 }
 
 @misc{ostk_wallaby_keystone,
-	title = {{Keystone, the OpenStack Identity Service}},
+	title = {Keystone, the OpenStack Identity Service},
 	url = {https://docs.openstack.org/keystone/wallaby/}
 }
 
 @misc{ostk_nw_liberty_dvr_ovs,
-	title = {{OpenStack - Scenario: High Availability using Distributed Virtual Routing (DVR)}},
+	title = {OpenStack - Scenario: High Availability using Distributed Virtual Routing (DVR)},
 	url = {https://docs.openstack.org/liberty/networking-guide/scenario-dvr-ovs.html}
 }
 
 @misc{ostk_neutron_api_ext,
-	title = {{OpenStack Neutron: API Extensions}},
+	title = {OpenStack Neutron: API Extensions},
 	url = {https://docs.openstack.org/neutron/latest/contributor/internals/api_extensions.html}
 }
 
 @misc{ostk_wallaby_neutron,
-	title = {{OpenStack - Welcome to Neutron’s documentation!}},
+	title = {OpenStack - Welcome to Neutron’s documentation!},
 	url = {https://docs.openstack.org/neutron/wallaby/ }
 }
 
 @misc{ostk_wallaby_nw_svr_snat_config,
-	title = {{OpenStack Neutron: Distributed Virtual Routing with VRRP}},
+	title = {OpenStack Neutron: Distributed Virtual Routing with VRRP},
 	url = {https://docs.openstack.org/neutron/wallaby/admin/config-dvr-ha-snat.html}
 }
 
 @misc{ostk_latest_nova_pre_caching,
-	title = {{OpenStack Nova: Image pre-caching}},
+	title = {OpenStack Nova: Image pre-caching},
 	url = {https://docs.openstack.org/nova/latest/admin/image-caching.html#image-pre-caching}
 }
 
 @misc{ostk_latest_nova_flavors,
-	title = {{OpenStack Nova: Flavors}},
+	title = {OpenStack Nova: Flavors},
 	url = {https://docs.openstack.org/nova/latest/user/flavors.html}
 }
 
 @misc{ostk_wallaby_nova,
-	title = {{OpenStack Compute (nova)}},
+	title = {OpenStack Compute (nova)},
 	url = {https://docs.openstack.org/nova/wallaby/}
 }
 
 @misc{ostk_wallaby_hypervisor_config,
-	title = {{OpenStack Nova: KVM}},
+	title = {OpenStack Nova: KVM},
 	url = {https://docs.openstack.org/nova/wallaby/admin/configuration/hypervisor-kvm.html}
 }
 
 @misc{ostk_latest_octavia,
-	title = {{OpenStack - Introducing Octavia}},
+	title = {OpenStack - Introducing Octavia},
 	url = {https://docs.openstack.org/octavia/latest/reference/introduction.html}
 }
 
 @misc{ostk_latest_placement,
-	title = {{OpenStack - Placement Usage}},
+	title = {OpenStack - Placement Usage},
 	url = {https://docs.openstack.org/placement/latest/user/index.html}
 }
 
 @misc{ostk_latest_placement_provider_tree,
-	title = {{OpenStack - Placement: Modeling with Provider Trees}},
+	title = {OpenStack - Placement: Modeling with Provider Trees},
 	url = {https://docs.openstack.org/placement/latest/user/provider-tree.html}
 }
 
 @misc{ostk_wallaby_placement,
-	title = {{OpenStack - Placement}},
+	title = {OpenStack - Placement},
 	url = {https://docs.openstack.org/placement/wallaby/index.html}
 
 }
 
 @misc{ostk_sec_guide_hardening_virt_lyrs,
-	title = {{OpenStack - Hardening the virtualization layers}},
+	title = {OpenStack - Hardening the virtualization layers},
 	url = {https://docs.openstack.org/security-guide/compute/hardening-the-virtualization-layers.html}
 }
 
 @misc{ostk_wallaby_swift,
-	title = {{OpenStack - Welcome to Swift’s documentation!}},
+	title = {OpenStack - Welcome to Swift’s documentation!},
 	url = {https://docs.openstack.org/swift/wallaby/}
 }
 
 @misc{fuel_ref_arch_100,
-	title = {{OpenStack Reference Architecture For 100, 300 and 500 Nodes}},
+	title = {OpenStack Reference Architecture For 100, 300 and 500 Nodes},
 	url = {https://fuel-ccp.readthedocs.io/en/latest/design/ref_arch_100_nodes.html}
 }
 
 @misc{fuel_ref_arch_100_svcs_placement,
-	title = {{OpenStack Reference Architecture For 100, 300 and 500 Nodes: Services Placement Summary}},
+	title = {OpenStack Reference Architecture For 100, 300 and 500 Nodes: Services Placement Summary},
 	url = {https://fuel-ccp.readthedocs.io/en/latest/design/ref_arch_100_nodes.html#services-placement-summary}
 }
 
 @misc{edge_glossary,
-	title = {{Open Glossary of Edge Computing}},
+	title = {Open Glossary of Edge Computing},
 	url = {https://github.com/State-of-the-Edge/glossary/blob/master/edge-glossary.md}
 }
 
 @misc{ostk_octavia_gov,
-	title = {{OpenStack Octavia (Load-balancer service)}},
+	title = {OpenStack Octavia (Load-balancer service)},
 	url = {https://governance.openstack.org/tc/reference/projects/octavia.html}
 }
 
 @misc{ostk_neutron_vpnaas,
-	title = {{openstack/neutron-vpnaas}},
+	title = {openstack/neutron-vpnaas},
 	url = {https://opendev.org/openstack/neutron-vpnaas}
 }
 
 @misc{ostk_neutron_plugins,
-	title = {{OpenStack Neutron: Plugins}},
+	title = {OpenStack Neutron: Plugins},
 	url = {https://wiki.openstack.org/wiki/Neutron#Plugins}
 }
 
 @misc{ostk_neutron_ml2,
-	title = {{OpenStack Neutron/ML2}},
+	title = {OpenStack Neutron/ML2},
 	url = {https://wiki.openstack.org/wiki/Neutron/ML2}
 }
 
 @misc{ostk_uses_edge_arch_design,
-	title = {{OpenStack - Edge Computing: Next Steps in Architecture, Design and Testing}},
+	title = {OpenStack - Edge Computing: Next Steps in Architecture, Design and Testing},
 	url = {https://www.openstack.org/use-cases/edge-computing/edge-computing-next-steps-in-architecture-design-and-testing}
 }
 
@@ -513,87 +513,87 @@
 % Chapter 6 References
 
 @misc{openstacksecb,
-	title = {{OpenStack - Security Boundaries and Threats}},
+	title = {OpenStack - Security Boundaries and Threats},
 	url = {https://docs.openstack.org/security-guide/introduction/security-boundaries-and-threats.html}
 }
 
 @misc{openstacksecg,
-	title = {{OpenStack Security Guide}},
+	title = {OpenStack Security Guide},
 	url = {https://docs.openstack.org/security-guide/introduction/introduction-to-openstack.html}
 }
 
 @misc{cve,
-	title = {{Mitre - Common Vulnerabilities and Exposures}},
+	title = {Mitre - Common Vulnerabilities and Exposures},
 	url = {https://cve.mitre.org/}
 }
 
 @misc{nistvm,
-	title = {{National Institute of Standards and Technology Vulnerabilities Metrics}},
+	title = {National Institute of Standards and Technology Vulnerabilities Metrics},
 	url = {https://nvd.nist.gov/vuln-metrics/cvss}
 }
 
 @misc{openstackseci,
-	title = {{OpenStack Security Guide - Identity}},
+	title = {OpenStack Security Guide - Identity},
 	url = {https://docs.openstack.org/security-guide/identity.html}
 }
 
 @misc{openstackaut,
-	title = {{OpenStack Security Guide - Authentication Methods}},
+	title = {OpenStack Security Guide - Authentication Methods},
 	url = {https://docs.openstack.org/security-guide/identity/authentication-methods.html}
 }
 
 @misc{openstackpol,
-	title = {{OpenStack Security Guide - Policies}},
+	title = {OpenStack Security Guide - Policies},
 	url = {https://docs.openstack.org/security-guide/identity/policies.html#policy-section}
 }
 
 @misc{openstackdr,
-	title = {{OpenStack KeyStone Default Roles}},
+	title = {OpenStack KeyStone Default Roles},
 	url = {https://docs.openstack.org/keystone/latest/admin/service-api-protection.html}
 }
 
 @misc{openstackseccom,
-	title = {{OpenStack - Introduction to TLS and SSL}},
+	title = {OpenStack - Introduction to TLS and SSL},
 	url = {https://docs.openstack.org/security-guide/secure-communication/introduction-to-ssl-and-tls.html}
 }
 
 @misc{ciscat,
-	title = {{Center for Internet Security CIS-CAT Pro}},
+	title = {Center for Internet Security CIS-CAT Pro},
 	url = {https://www.cisecurity.org/cybersecurity-tools/cis-cat-pro/}
 }
 
 @misc{cisben,
-	title = {{Center for Internet Security Benchmarks}},
+	title = {Center for Internet Security Benchmarks},
 	url = {https://www.cisecurity.org/cis-benchmarks/}
 }
 
 @misc{openstackisv,
-	title = {{OpenStack Image Signature Verification}},
+	title = {OpenStack Image Signature Verification},
 	url = {https://docs.openstack.org/glance/wallaby/user/signature.html}
 }
 
 @misc{openstacksr,
-	title = {{OpenStack - SR-IOV Passthrough For Networking}},
+	title = {OpenStack - SR-IOV Passthrough For Networking},
 	url = {https://wiki.openstack.org/wiki/SR-IOV-Passthrough-For-Networking}
 }
 
 @misc{openstackti,
-	title = {{OpenStack Trusted Images}},
+	title = {OpenStack Trusted Images},
 	url = {https://docs.openstack.org/security-guide/instance-management/security-services-for-instances.html#trusted-images}
 }
 
 @misc{openstackim,
-	title = {{OpenStack Virtual Machine Image Guide}},
+	title = {OpenStack Virtual Machine Image Guide},
 	url = {https://docs.openstack.org/image-guide/}
 }
 
 @misc{openstackasi,
-	title = {{Adding Signed Images}},
+	title = {Adding Signed Images},
 	url = {https://docs.openstack.org/operations-guide/ops-user-facing-operations.html#adding-signed-images}
 }
 
 @misc{etsisol4,
-	title = {{Network Functions Virtualisation (NFV) Release 4; Protocols and Data Models; VNF Package and PNFD Archive specification}},
+	title = {Network Functions Virtualisation (NFV) Release 4; Protocols and Data Models; VNF Package and PNFD Archive specification},
 	howpublished = {ETSI GS NFV-SOL 004 V4.3.1},
 	url = {https://www.etsi.org/deliver/etsi_gs/NFV-SOL/001_099/004/04.03.01_60/gs_NFV-SOL004v040301p.pdf},
 	year = 2022,
@@ -601,7 +601,7 @@
 }
 
 @misc{etsisec21,
-	title = {{Network Functions Virtualisation (NFV) Release 2; Security; VNF Package Security Specification}},
+	title = {Network Functions Virtualisation (NFV) Release 2; Security; VNF Package Security Specification},
 	howpublished = {ETSI GS NFV-SEC 021 V2.6.1},
 	url = {https://www.etsi.org/deliver/etsi_gs/NFV-SEC/001_099/021/02.06.01_60/gs_nfv-sec021v020601p.pdf},
 	year = 2019,
@@ -611,416 +611,426 @@
 % Chapter 7 References
 
 @misc{forem,
-	title = {{Foreman}},
+	title = {Foreman},
 	url = {https://www.theforeman.org/}
 }
 
 @misc{ansib,
-	title = {{Ansible Documentation}},
+	title = {Ansible Documentation},
 	url = {https://docs.ansible.com/}
 }
 
 @misc{tripl,
-	title = {{OpenStack TripleO}},
+	title = {OpenStack TripleO},
 	url = {http://opendev.org/openstack/tripleo-common}
 }
 
 @misc{trarch,
-	title = {{OpenStack TripleO Architecture}},
+	title = {OpenStack TripleO Architecture},
 	url = {https://docs.openstack.org/tripleo-docs/latest/install/introduction/architecture.html#project-architecture}
 }
 
 @misc{airsh,
-	title = {{Airship v2}},
+	title = {Airship v2},
 	url = {https://www.airshipit.org/}
 }
 
 @misc{starl,
-	title = {{StarlingX - Deploy Your Edge Cloud Now}},
+	title = {StarlingX - Deploy Your Edge Cloud Now},
 	url = {https://www.starlingx.io/}
 }
 
 % Chapter 8 References
 
 @misc{ovp,
-	title = {{OVP}},
+	title = {OVP},
 	url = {https://www.opnfv.org/verification}
 }
 
 @misc{jenkins,
-	title = {{jenkins}},
+	title = {jenkins},
 	url = {https://build.opnfv.org/}
 }
 
 @misc{testdb,
-	title = {{Test Dabase}},
+	title = {Test Dabase},
 	url = {https://docs.opnfv.org/en/stable-hunter/_images/OPNFV_testing_working_group.png}
 }
 
 @misc{s3storageservice,
-	title = {{S3 compatible storage service}},
+	title = {S3 compatible storage service},
 	url = {http://artifacts.opnfv.org/}
 }
 
 @misc{functestwallabyzip,
-	title = {{functest-wallaby-zip}},
+	title = {functest-wallaby-zip},
 	url = {https://build.opnfv.org/ci/job/functest-wallaby-zip/4/console}
 }
 
 @misc{xtestingci,
-	title = {{Xtesting CI}},
+	title = {Xtesting CI},
 	url = {https://galaxy.ansible.com/collivier/xtesting}
 }
 
 @misc{docker,
-	title = {{Docker}},
+	title = {Docker},
 	url = {https://www.docker.com/}
 }
 
 @misc{xtesting,
-	title = {{Xtesting}},
+	title = {Xtesting},
 	url = {https://xtesting.readthedocs.io/en/latest/}
 }
 
 @misc{opnfvfraser,
-	title = {{OPNFV Fraser}},
+	title = {OPNFV Fraser},
 	url = {https://www.sdxcentral.com/articles/news/opnfvs-6th-release-brings-testing-capabilities-that-orange-is-already-using/2018/05/}
 }
 
 @misc{xtestingpythonpackage,
-	title = {{Xtesting Python package}},
+	title = {Xtesting Python package},
 	url = {https://pypi.org/project/xtesting/}
 }
 
 @misc{testcasedescription,
-	title = {{Test case execution description}},
+	title = {Test case execution description},
 	url = {https://git.opnfv.org/functest-xtesting/tree/docker/core/testcases.yaml}
 }
 
 @misc{cicdtoolchainsinafewcommands,
-	title = {{CI/CD toolchains in a few commands}},
+	title = {CI/CD toolchains in a few commands},
 	url = {https://github.com/collivier/ansible-role-xtesting#readme}
 }
 
 @misc{cicddeploymentmodels,
-	title = {{CI/CD deployment models}},
+	title = {CI/CD deployment models},
 	url = {https://lists.opnfv.org/g/opnfv-tsc/message/5702}
 }
 
 @misc{anuketreleng,
-	title = {{Anuket Releng}},
+	title = {Anuket Releng},
 	url = {https://git.opnfv.org/releng/tree/jjb/functest}
 }
 
 @misc{testcaseresultdump,
-	title = {{Test Case result dump}},
+	title = {Test Case result dump},
 	url = {http://artifacts.opnfv.org/functest/9ID39XK47PMZ.zip}
 }
 
 @misc{xtestingsamples,
-	title = {{Xtesting Samples}},
+	title = {Xtesting Samples},
 	url = {https://git.opnfv.org/functest-xtesting/plain/ansible/site.yml?h=stable/wallaby}
 }
 
 @misc{openstackverification,
-	title = {{OpenStack verification}},
+	title = {OpenStack verification},
 	url = {https://git.opnfv.org/functest/plain/ansible/site.yml?h=stable/wallaby}
 }
 
 @misc{anuketrc1,
-	title = {{Anuket RC1}},
+	title = {Anuket RC1},
 	url = {https://git.opnfv.org/functest/plain/ansible/site.cntt.yml?h=stable/wallaby}
 }
 
 @misc{kubernetesverification,
-	title = {{Kubernetes verification}},
+	title = {Kubernetes verification},
 	url = {https://git.opnfv.org/functest-kubernetes/plain/ansible/site.yml?h=stable/v1.22}
 }
 
 @misc{functest,
-	title = {{Functest}},
+	title = {Functest},
 	url = {https://functest.readthedocs.io/en/stable-wallaby/}
 }
 
 @misc{refstack,
-	title = {{RefStack}},
+	title = {RefStack},
 	url = {https://refstack.openstack.org/}
 }
 
 @misc{networkingbgpvpn,
-	title = {{Networking BGPVPN}},
+	title = {Networking BGPVPN},
 	url = {https://docs.openstack.org/networking-bgpvpn/latest/}
 }
 
 @misc{networkingsfc,
-	title = {{Networking SFC}},
+	title = {Networking SFC},
 	url = {https://docs.openstack.org/networking-sfc/latest/}
 }
 
+@misc{k8se2etests,
+	title = {Kubernetes End-to-end tests},
+	url = {https://kubernetes.io/blog/2019/03/22/kubernetes-end-to-end-testing-for-everyone/}
+}
+
+@misc{k8sconformance,
+	title = {k8s-conformance},
+	url = {https://build.opnfv.org/ci/job/functest-kubernetes-opnfv-functest-kubernetes-smoke-v1.22-k8s_conformance-run/25/console}
+}
+
 @misc{devstackgates,
-	title = {{DevStack Gates}},
+	title = {DevStack Gates},
 	url = {https://docs.opendev.org/opendev/system-config/latest/devstack-gate.html}
 }
 
 @misc{rally,
-	title = {{Rally}},
+	title = {Rally},
 	url = {https://github.com/openstack/rally-openstack}
 }
 
 @misc{tempest,
-	title = {{Temptest}},
+	title = {Temptest},
 	url = {https://github.com/openstack/tempest}
 }
 
 @misc{devstack,
-	title = {{Temptest}},
+	title = {Temptest},
 	url = {https://docs.openstack.org/devstack/latest/}
 }
 
 @misc{raspberrypi,
-	title = {{Raspberry PI}},
+	title = {Raspberry PI},
 	url = {https://www.raspberrypi.org/}
 }
 
 @misc{functestdailyjobs,
-	title = {{Functest daily jobs}},
+	title = {Functest daily jobs},
 	url = {https://build.opnfv.org/ci/view/functest/job/functest-wallaby-daily/17/}
 }
 
 @misc{osperformancetools,
-	title = {{OpenStack performance tools}},
+	title = {OpenStack performance tools},
 	url = {https://docs.openstack.org/developer/performance-docs/methodologies/tools.html}
 }
 
 @misc{functestgates,
-	title = {{Functest gates}},
+	title = {Functest gates},
 	url = {https://build.opnfv.org/ci/view/functest}
 }
 
 @misc{runalpinefunctestcontainers,
-	title = {{Run Alpine Functest containers (Wallaby)}},
+	title = {Run Alpine Functest containers (Wallaby)},
 	url = {https://wiki.anuket.io/display/HOME/Functest+Wallaby}
 }
 
 @misc{newfunctestcnttcontainers,
-	title = {{New Functest CNTT containers}},
+	title = {New Functest CNTT containers},
 	url = {https://lists.opnfv.org/g/opnfv-tsc/message/5717}
 }
 
 @misc{keystonetempestplugin,
-	title = {{keystone-tempest-plugin}},
+	title = {keystone-tempest-plugin},
 	url = {https://opendev.org/openstack/keystone-tempest-plugin}
 }
 
 @misc{functestsmokecntt,
-	title = {{Functest Smoke CNTT}},
+	title = {Functest Smoke CNTT},
 	url = {https://git.opnfv.org/functest/tree/docker/smoke-cntt/testcases.yaml?h=stable%2Fwallaby}
 }
 
 @misc{cindertempestplugin,
-	title = {{cinder-tempest-plugin}},
+	title = {cinder-tempest-plugin},
 	url = {https://opendev.org/openstack/cinder-tempest-plugin}
 }
 
 @misc{neutrontempestplugin,
-	title = {{neutron-tempest-plugin}},
+	title = {neutron-tempest-plugin},
 	url = {https://opendev.org/openstack/neutron-tempest-plugin}
 }
 
 @misc{heattempestplugin,
-	title = {{heat-tempest-plugin}},
+	title = {heat-tempest-plugin},
 	url = {https://opendev.org/openstack/heat-tempest-plugin}
 }
 
 @misc{tempesthorizon,
-	title = {{tempest-horizon}},
+	title = {tempest-horizon},
 	url = {https://github.com/openstack/tempest-horizon}
 }
 
 @misc{functesthealthcheck,
-	title = {{Functest Healthcheck}},
+	title = {Functest Healthcheck},
 	url = {https://git.opnfv.org/functest/tree/docker/healthcheck/testcases.yaml?h=stable%2Fwallaby}
 }
 
 @misc{functestbenchmarkingcntt,
-	title = {{Functest Benchmarking CNTT}},
+	title = {Functest Benchmarking CNTT},
 	url = {https://git.opnfv.org/functest/tree/docker/benchmarking-cntt/testcases.yaml?h=stable%2Fwallaby}
 }
 
 @misc{rallyfullcntt,
-	title = {{rally_full_cntt}},
+	title = {rally_full_cntt},
 	url = {http://artifacts.opnfv.org/functest/KDBNITEN317M/functest-opnfv-functest-benchmarking-cntt-wallaby-rally_full_cntt-run-5/rally_full_cntt/rally_full_cntt.html}
 }
 
 @misc{rallyjobscntt,
-	title = {{rally_jobs_cntt}},
+	title = {rally_jobs_cntt},
 	url = {http://artifacts.opnfv.org/functest/KDBNITEN317M/functest-opnfv-functest-benchmarking-cntt-wallaby-rally_jobs_cntt-run-5/rally_jobs_cntt/rally_jobs_cntt.html}
 }
 
 @misc{vmtp,
-	title = {{VMTP}},
+	title = {VMTP},
 	url = {http://vmtp.readthedocs.io/en/latest}
 }
 
 @misc{shaker,
-	title = {{Shaker}},
+	title = {Shaker},
 	url = {https://pyshaker.readthedocs.io/en/latest/}
 }
 
 @misc{vmtpscenarios,
-	title = {{VMTP scenarios}},
+	title = {VMTP scenarios},
 	url = {http://artifacts.opnfv.org/functest/KDBNITEN317M/functest-opnfv-functest-benchmarking-wallaby-vmtp-run-8/vmtp/vmtp.json}
 }
 
 @misc{functestvmtp,
-	title = {{Functest VMTP}},
+	title = {Functest VMTP},
 	url = {http://artifacts.opnfv.org/functest/KDBNITEN317M/functest-opnfv-functest-benchmarking-wallaby-vmtp-run-8/vmtp/vmtp.html}
 }
 
 @misc{shakerscenarios,
-	title = {{Shaker scenarios}},
+	title = {Shaker scenarios},
 	url = {http://artifacts.opnfv.org/functest/KDBNITEN317M/functest-opnfv-functest-benchmarking-wallaby-shaker-run-8/shaker/report.json}
 }
 
 @misc{functestvnf,
-	title = {{Functest VNF}},
+	title = {Functest VNF},
 	url = {https://git.opnfv.org/functest/tree/docker/vnf/testcases.yaml?h=stable%2Fwallaby}
 }
 
 @misc{clearwaterims,
-	title = {{Clearwater IMS}},
+	title = {Clearwater IMS},
 	url = {https://clearwater.readthedocs.io/en/stable/}
 }
 
 @misc{vyosvrouter,
-	title = {{VyOS vRouter}},
+	title = {VyOS vRouter},
 	url = {https://www.vyos.io/}
 }
 
 @misc{oaivepc,
-	title = {{OpenAirInterface vEPC}},
+	title = {OpenAirInterface vEPC},
 	url = {https://www.openairinterface.org/}
 }
 
 @misc{cloudify,
-	title = {{Cloudify}},
+	title = {Cloudify},
 	url = {https://cloudify.co}
 }
 
 @misc{juju,
-	title = {{Juju}},
+	title = {Juju},
 	url = {https://jaas.ai/}
 }
 
 @misc{clearwaterlivetest,
-	title = {{clearwater-live-test}},
+	title = {clearwater-live-test},
 	url = {https://github.com/Metaswitch/clearwater-live-test}
 }
 
 @misc{dockerproxy,
-	title = {{Docker HTTP/HTTPS proxy}},
+	title = {Docker HTTP/HTTPS proxy},
 	url = {https://docs.docker.com/config/daemon/systemd/#httphttps-proxy}
 }
 
 @misc{review68881,
-	title = {{Functest review 68881}},
+	title = {Functest review 68881},
 	url = {https://gerrit.opnfv.org/gerrit/68881}
 }
 
 @misc{review71011,
-	title = {{Functest review 71011}},
+	title = {Functest review 71011},
 	url = {https://gerrit.opnfv.org/gerrit/71011}
 }
 
 @misc{bug1770179,
-	title = {{OpenStack bug 1770179}},
+	title = {OpenStack bug 1770179},
 	url = {https://launchpad.net/bugs/1770179}
 }
 
 @misc{bug1677525,
-	title = {{OpenStack bug 1677525}},
+	title = {OpenStack bug 1677525},
 	url = {https://launchpad.net/bugs/1677525}
 }
 
 @misc{bug1317133,
-	title = {{OpenStack bug 1317133}},
+	title = {OpenStack bug 1317133},
 	url = {https://launchpad.net/bugs/1317133}
 }
 
 @misc{bug1905432,
-	title = {{OpenStack bug 1905432}},
+	title = {OpenStack bug 1905432},
 	url = {https://launchpad.net/bugs/1905432}
 }
 
 @misc{bug1863707,
-	title = {{OpenStack bug 1863707}},
+	title = {OpenStack bug 1863707},
 	url = {https://launchpad.net/bugs/1863707}
 }
 
 @misc{review69105,
-	title = {{Functest review 69105}},
+	title = {Functest review 69105},
 	url = {https://gerrit.opnfv.org/gerrit/69105}
 }
 
 @misc{bug1676207,
-	title = {{OpenStack bug 1676207}},
+	title = {OpenStack bug 1676207},
 	url = {https://launchpad.net/bugs/1676207}
 }
 
 @misc{bug1836595,
-	title = {{OpenStack bug 1836595}},
+	title = {OpenStack bug 1836595},
 	url = {https://launchpad.net/bugs/1836595}
 }
 
 @misc{bug1186354,
-	title = {{OpenStack bug 1186354}},
+	title = {OpenStack bug 1186354},
 	url = {https://launchpad.net/bugs/1186354}
 }
 
 @misc{bug1014647,
-	title = {{OpenStack bug 1014647}},
+	title = {OpenStack bug 1014647},
 	url = {https://launchpad.net/bugs/1014647}
 }
 
 @misc{bug1311500,
-	title = {{OpenStack bug 1311500}},
+	title = {OpenStack bug 1311500},
 	url = {https://launchpad.net/bugs/1311500}
 }
 
 @misc{bug1161411,
-	title = {{OpenStack bug 1161411}},
+	title = {OpenStack bug 1161411},
 	url = {https://launchpad.net/bugs/1161411}
 }
 
 @misc{bug1540645,
-	title = {{OpenStack bug 1540645}},
+	title = {OpenStack bug 1540645},
 	url = {https://launchpad.net/bugs/1540645}
 }
 
 @misc{story2007804,
-	title = {{OpenStack story 2007804}},
+	title = {OpenStack story 2007804},
 	url = {https://storyboard.openstack.org/#!/story/2007804}
 }
 
 @misc{review69926,
-	title = {{Functest review 69926}},
+	title = {Functest review 69926},
 	url = {https://gerrit.opnfv.org/gerrit/69926}
 }
 
 @misc{review69931,
-	title = {{Functest review 69931}},
+	title = {Functest review 69931},
 	url = {https://gerrit.opnfv.org/gerrit/69931}
 }
 
 @misc{review70004,
-	title = {{Functest review 70004}},
+	title = {Functest review 70004},
 	url = {https://gerrit.opnfv.org/gerrit/70004}
 }
 
 % Chapter 9 References
 
 @misc{autosc,
-	title = {{OpenStack Autoscaling with Heat}},
+	title = {OpenStack Autoscaling with Heat},
 	url = {https://docs.openstack.org/senlin/latest/scenarios/autoscaling_heat.html}
 }
 


### PR DESCRIPTION
The second one is falsy interpreted as part of title.
It may become a big issue if we dynamically convert them
to rst for GSMA docx.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>