### PR TITLE
[RA1] Bug: Titles levels corrected

### DIFF
--- a/doc/ref_arch/openstack/chapters/chapter02.rst
+++ b/doc/ref_arch/openstack/chapters/chapter02.rst
@@ -430,8 +430,8 @@ Cloud Infrastructure Hardware Profile Requirements
      - No requirement specified
      - Not detailed
 
-Cloud Infrastructure Hardware Profile-Extensions Requirements
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Cloud Infrastructure Hardware Profile Extensions Requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table:: Reference Model Requirements - Cloud Infrastructure Hardware
                 Profile Extensions Requirements
@@ -1574,7 +1574,7 @@ Assurance Requirements
 
 
 Architecture and OpenStack Recommendations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------
 
 The requirements listed in this section are optional, and are not
 required in order to be deemed a conformant implementation.

--- a/doc/ref_arch/openstack/chapters/chapter03.rst
+++ b/doc/ref_arch/openstack/chapters/chapter03.rst
@@ -726,7 +726,8 @@ characteristics of each. Ultimately the decision rests with the operator
 to achieve specific availability target taking into account use case,
 data centre capabilities, economics and risks.
 
-**Topology Overview**
+Topology Overview
+~~~~~~~~~~~~~~~~~
 
 Availability of any single OpenStack cloud is dependent on a number of
 factors including:
@@ -800,8 +801,6 @@ Assumptions and conventions:
      - Required
      - Suitable where local and region application HA is required Control plane
        could be kept available in one site during upgrades
-
-**Topology Overview**
 
 **Topology 1 - Local Redundancy**
 

--- a/doc/ref_arch/openstack/chapters/chapter05.rst
+++ b/doc/ref_arch/openstack/chapters/chapter05.rst
@@ -442,7 +442,7 @@ The KVM APIs are documented in Section 4 of the document
 :cite:p:`kvmapis`.
 
 Libvirt Interfaces
-^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~
 
 The Libvirt APIs are documented in :cite:p:`libvirtapis`.
 


### PR DESCRIPTION
Chapters 2,3,5
Some titles were setup at the wrong level (Level 3 rather 2, or vice versa.
Modifications aligned with the GSMA document version of the 13th of September