### PR TITLE
Add bash in external programs allowed by tox

### DIFF
--- a/doc/ref_arch/openstack/tox.ini
+++ b/doc/ref_arch/openstack/tox.ini
@@ -3,9 +3,9 @@ envlist = docs,gsma
 skipsdist = True
 
 [testenv:docs]
-basepython = python3.9
+basepython = python3.10
 deps =
-  -chttps://opendev.org/openstack/requirements/raw/branch/stable/xena/upper-constraints.txt
+  -chttps://opendev.org/openstack/requirements/raw/branch/stable/yoga/upper-constraints.txt
   -r{toxinidir}/test-requirements.txt
 install_command = pip install {opts} {packages}
 commands =
@@ -15,13 +15,14 @@ commands =
   sphinx-build --keep-going -W -b linkcheck . build
 
 [testenv:gsma]
-basepython = python3.9
+basepython = python3.10
 deps =
-  -chttps://opendev.org/openstack/requirements/raw/branch/stable/xena/upper-constraints.txt
+  -chttps://opendev.org/openstack/requirements/raw/branch/stable/yoga/upper-constraints.txt
   -r{toxinidir}/test-requirements.txt
 install_command = pip install {opts} {packages}
 allowlist_externals =
   pandoc
+  bash
 commands =
   python togsma.py
   doc8 . --ignore-path .tox --ignore-path build --ignore-path gsma --max-line-length 120


### PR DESCRIPTION
It also updates py to 3.10 and selects the latest
OpenSTack stable upper constraints.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>