### PR TITLE
[pcac]: Adding RC1 back

### DIFF
--- a/doc/gov/chapters/chapter09.rst
+++ b/doc/gov/chapters/chapter09.rst
@@ -197,7 +197,7 @@ the use of a cookbook, automated install, and/or build from RA1/RI1 or RA2/RC2 r
 Expectation 2: Execute the RC1 or RC2 Test suites
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Anuket will provide the participants with the community :doc:`ref_cert_RC1:index` or :doc:`ref_cert_RC2:index` test
+Anuket will provide the participants with the community :doc:`ref_arch_openstack:chapters/chapter08` or :doc:`ref_cert_RC2:index` test
 suites. The participants will execute test cases per instructions and record the quantitative results.
 
 Test case suite should be executed successfully at least three (3) times, because this number represents the recommended

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,12 +3,13 @@ Anuket Specifications
 
 -  :ref:`Introduction <common/README:anuket project>`
 -  :doc:`Reference Model (RM) <ref_model:index>`
--  :doc:`Reference Architecture (RA1) for OpenStack based cloud infrastructure <ref_arch_openstack:index>`
+-  :doc:`Reference Architecture (RA1) for OpenStack based cloud infrastructure and Reference Conformance (RC1) for RA1
+   based Implementations <ref_arch_openstack:index>`
 -  :doc:`Reference Architecture (RA2) for Kubernetes based cloud infrastructure <ref_arch_kubernetes:index>`
 -  :doc:`Reference Conformance (RC2) for RA2 based Implementations <ref_cert_RC2:index>`
 -  :doc:`Reference Implementation based on RA1 specifications (RI1) <ref_impl_cntt-ri:index>`
 -  :doc:`Reference Implementation based on RA2 specifications (RI2) <ref_impl_cntt-ri2:index>`
--  :ref:`Community Guidelines <gov/README:cloud infrastructure telco taskforce - community guidelines>`
+-  :doc:`Community Guidelines <gov/index>`
 -  :doc:`Code of Conduct <CODE_OF_CONDUCT>`
 - `The License (Creative Commons Attribution 4.0 International) <https://creativecommons.org/licenses/by/4.0/
   legalcode>`_


### PR DESCRIPTION
For some reason RC1 was removed from the landing page of Anuket specifications during the GSMA release effort of RA1 and RC1. In this process RA1 and RC1 were merged into one document, but these are still two logical entities and this should be represented also in the landing page.

