### PR TITLE
[RM refs.bib] Specify url for GSMA FS 40

### DIFF
--- a/doc/ref_model/refs.bib
+++ b/doc/ref_model/refs.bib
@@ -277,7 +277,7 @@
 @misc{gsmafs40,
 	title = {{5G Security Guide}},
 	howpublished  = {GSMA FS.40-v02.00},
-	url = {},
+	url = {https://infocentre2.gsma.com/gp/wg/FSG/OfficialDocuments/FS.40%205G%20Security%20Guide%20v2.0%20(Current)/FS.40%20v2.0.pdf},
 	year = 2021,
 	month = oct
 }


### PR DESCRIPTION
url for GSMA FS.40 was missing and is now specified