### PR TITLE
Add linkcheck exception for ntia.gov

### DIFF
--- a/doc/ref_arch/openstack/conf.py
+++ b/doc/ref_arch/openstack/conf.py
@@ -15,7 +15,8 @@ linkcheck_ignore = [
     "https://www.cisecurity.org/cis-benchmarks/",
     "https://www.iso.org/obp/ui/",
     'http://127.0.0.1',
-    'https://www.sdxcentral.com'
+    'https://www.sdxcentral.com',
+    'https://ntia.gov'
 ]
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 4

--- a/doc/ref_arch/openstack/refs.bib
+++ b/doc/ref_arch/openstack/refs.bib
@@ -106,7 +106,7 @@
 
 @misc{ntiasbom,
     title = {National Telecommunications and Information Administration - Software Bill Of Materials},
-    url = {https://www.ntia.gov/SBOM}
+    url = {https://ntia.gov/SBOM}
 }
 
 @misc{cis,

--- a/doc/ref_arch/openstack/tox.ini
+++ b/doc/ref_arch/openstack/tox.ini
@@ -5,7 +5,7 @@ skipsdist = True
 [testenv:docs]
 basepython = python3.10
 deps =
-  -chttps://opendev.org/openstack/requirements/raw/branch/stable/yoga/upper-constraints.txt
+  -chttps://opendev.org/openstack/requirements/raw/branch/stable/zed/upper-constraints.txt
   -r{toxinidir}/test-requirements.txt
 install_command = pip install {opts} {packages}
 commands =
@@ -17,7 +17,7 @@ commands =
 [testenv:gsma]
 basepython = python3.10
 deps =
-  -chttps://opendev.org/openstack/requirements/raw/branch/stable/yoga/upper-constraints.txt
+  -chttps://opendev.org/openstack/requirements/raw/branch/stable/zed/upper-constraints.txt
   -r{toxinidir}/test-requirements.txt
 install_command = pip install {opts} {packages}
 allowlist_externals =

--- a/doc/ref_cert/RC2/chapters/chapter02.rst
+++ b/doc/ref_cert/RC2/chapters/chapter02.rst
@@ -204,7 +204,7 @@ Network Testing
 The regexes load.balancer, LoadBalancer and
 Network.should.set.TCP.CLOSE_WAIT.timeout are currently skipped because
 they haven’t been covered successfully neither by
-`sig-release-1.23-blocking <https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.23.yaml>`__
+`sig-release-1.25-blocking <https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml>`__
 nor by `Anuket RC2
 verification <https://build.opnfv.org/ci/view/functest-kubernetes/job/functest-kubernetes-v1.25-daily/11/>`__
 
@@ -285,7 +285,7 @@ Storage Testing
 
 It should be noted that all in-tree driver testing, [Driver:+], is
 skipped. Conforming to `the upstream
-gate <https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.22.yaml>`__,
+gate <https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.25.yaml>`__,
 all PersistentVolumes NFS testing is also skipped. The following
 exclusions are about `the deprecated in-tree GitRepo volume
 type <https://github.com/kubernetes-sigs/kind/issues/2356>`__:

--- a/doc/ref_cert/RC2/chapters/chapter04.rst
+++ b/doc/ref_cert/RC2/chapters/chapter04.rst
@@ -12,7 +12,7 @@ Kubernetes platform interoperability.
 Note that each requirement may have one or more test cases associated
 with it.
 
-The Anuket Assured Workload badge requires that workloads are expected 
+The Anuket Assured Workload badge requires that workloads are expected
 to return **Must/Must Not** results all of the tests/suites identified
 as priority (see table).
 
@@ -52,131 +52,146 @@ for Kubernetes workloads.
      - Priority
    * - ra2.app.001
      - Specifies the container's root filesystem.
-     - `Root <https://github.com/opencontainers/runtime-spec/blob/master/config.md>`__ Parameter Group (OCI Spec)
+     - `Root <https://github.com/opencontainers/runtime-spec/blob/master/config.md>`__
+       Parameter Group (OCI Spec)
      - Must
    * - ra2.app.002
      - Specifies additional mounts beyond root.
-     - `Mounts <https://github.com/opencontainers/runtime-spec/blob/master/config.md#mounts>`__ Parameter Group
-       (OCI Spec)
+     - `Mounts <https://github.com/opencontainers/runtime-spec/blob/master/config.md#mounts>`__
+       Parameter Group (OCI Spec)
      - Must
    * - ra2.app.003
      - Specifies the container process.
-     - `Process <https://github.com/opencontainers/runtime-spec/blob/master/config.md#process>`__ Parameter Group
-       (OCI Spec)
+     - `Process <https://github.com/opencontainers/runtime-spec/blob/master/config.md#process>`__
+       Parameter Group (OCI Spec)
      - Must
    * - ra2.app.004
-     - Specifies the container's hostname as seen by processes running inside the container.
-     - `Hostname <https://github.com/opencontainers/runtime-spec/blob/master/config.md#hostname>`__ Parameter Group
-       (OCI Spec)
+     - Specifies the container's hostname as seen by processes running inside
+       the container.
+     - `Hostname <https://github.com/opencontainers/runtime-spec/blob/master/config.md#hostname>`__
+       Parameter Group (OCI Spec)
      - Must
    * - ra2.app.005
-     - User for the process is a platform-specific structure that allows specific control over which user the process
-       runs as.
-     - `User <https://github.com/opencontainers/runtime-spec/blob/master/config.md#user>`__ Parameter Group (OCI Spec)
+     - User for the process is a platform-specific structure that allows
+       specific control over which user the process runs as.
+     - `User <https://github.com/opencontainers/runtime-spec/blob/master/config.md#user>`__
+       Parameter Group (OCI Spec)
      - Must
    * - ra2.app.006
-     - Consumption of additional, non-default connection points. Any additional non-default connection points must be requested through the use of workload annotations
-       or resource requests and limits within the container spec passed to the Kubernetes API Server.
+     - Consumption of additional, non-default connection points.
+       Any additional non-default connection points must be requested
+       through the use of workload annotations
+       or resource requests and limits within the container spec passed to the
+       Kubernetes API Server.
      - :ref:`int.api.01 <chapters/chapter02:Kubernetes Architecture Requirements>`
      - Must
    * - ra2.app.007
-     - Host Volumes:  Workloads should not use hostPath volumes, as `Pods with identical configuration
-       <https://kubernetes.io/docs/concepts/storage/volumes/#hostpath>`__ (such as those created from a PodTemplate)
-       may behave differently on different nodes due to different files on the nodes.
+     - Host Volumes:  Workloads should not use hostPath volumes, as
+       `Pods with identical configuration
+       <https://kubernetes.io/docs/concepts/storage/volumes/#hostpath>`__
+       (such as those created from a PodTemplate) may behave differently on
+       different nodes due to different files on the nodes.
      - :ref:`kcm.gen.02 <chapters/chapter02:Kubernetes Architecture Requirements>`
      - Must
    * - ra2.app.008
      - Infrastructure dependency
-     - Workloads **must not** rely on the availability of the master nodes for the successful execution of their
-       functionality (i.e. loss of the master nodes may affect non-functional behaviours such as healing and scaling,
-       but components that are already running will continue to do so without issue).     
+     - Workloads **must not** rely on the availability of the master nodes for
+       the successful execution of their functionality (i.e. loss of the
+       master nodes may affect non-functional behaviours such as healing and
+       scaling, but components that are already running will continue to do so
+       without issue).
      - Must (Not)
    * - ra2.app.009
      - Device plugins
-     - Workload descriptors must use the resources advertised by the device plugins to indicate their need for an FPGA,
-       SR-IOV or other acceleration device.
-     - Must   
+     - Workload descriptors must use the resources advertised by the device
+       plugins to indicate their need for an FPGA, SR-IOV or other
+       acceleration device.
+     - Must
    * - ra2.app.010
      - Node Feature Discovery (NFD)
-     - Workload descriptors must use the labels advertised by `Node Feature Discovery
-       <https://kubernetes-sigs.github.io/node-feature-discovery/stable/get-started/index.html>`__ to indicate which
-       node software of hardware features they need.
+     - Workload descriptors must use the labels advertised by
+       `Node Feature Discovery
+       <https://kubernetes-sigs.github.io/node-feature-discovery/stable/get-started/index.html>`__
+       to indicate which node software of hardware features they need.
      - Must
    * - ra2.app.011
-     - Published helm chart:  Helm charts of the CNF must be published into a helm registry and must not be used from local copies.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-helm-chart-is-publi
-       shed-helm_chart_published>`__
-     - Should      
+     - Published helm chart:  Helm charts of the CNF must be published into a
+       helm registry and must not be used from local copies.
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-helm-chart-is-published-helm_chart_published>`__
+     - Should
    * - ra2.app.012
-     - Valid Helm chart:  Helm charts of the CNF must be valid and should pass the helm lint validation.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-helm-chart-is-valid
-       -helm_chart_valid>`__
-     - Should  
+     - Valid Helm chart:  Helm charts of the CNF must be valid and should pass
+       the helm lint validation.
+     - `CNCF CNF Testsuite
+       <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-helm-chart-is-valid-helm_chart_valid>`__
+     - Should
    * - ra2.app.013
-     - Rolling update: Rolling update of the CNF must be possible using Kubernetes deployments.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-test-if-the-cnf-can-perform-
-       a-rolling-update-rolling_update>`__
-     - Must     
+     - Rolling update: Rolling update of the CNF must be possible using
+       Kubernetes deployments.
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-test-if-the-cnf-can-perform-a-rolling-update-rolling_update>`__
+     - Must
    * - ra2.app.014
-     - Rolling downgrade: Rolling downgrade of the CNF must be possible using Kubernetes deployments.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-a-cnf-version-can-b
-       e-downgraded-through-a-rolling_downgrade-rolling_downgrade>`__
+     - Rolling downgrade: Rolling downgrade of the CNF must be possible using
+       Kubernetes deployments.
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-a-cnf-version-can-be-downgraded-through-a-rolling_downgrade-rolling_downgrade>`__
      - Must
    * - ra2.app.015
      - CNI compatibility: The CNF must use CNI compatible networking plugins.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-the-cnf-is-compatib
-       le-with-different-cnis-cni_compatibility>`__
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-the-cnf-is-compatible-with-different-cnis-cni_compatibility>`__
      - Must
    * - ra2.app.016
-     - Kubernetes API stability: The CNF must not use any Kubernetes alpha API-s.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#poc-to-check-if-a-cnf-uses-kube
-       rnetes-alpha-apis-alpha_k8s_apis-alpha_k8s_apis>`__
+     - Kubernetes API stability: The CNF must not use any Kubernetes alpha
+       API-s.
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#poc-to-check-if-a-cnf-uses-kubernetes-alpha-apis-alpha_k8s_apis-alpha_k8s_apis>`__
      - Must (Not)
    * - ra2.app.017
-     - CNF resiliency (node drain): CNF must not loose data, must continue to run and its readiness probe outcome must be Success even in case of a
+     - CNF resiliency (node drain): CNF must not loose data, must continue to
+       run and its readiness probe outcome must be Success even in case of a
        node drain and rescheduling occurs.
      - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-cnf-crashes-when-no
        de-drain-occurs-node_drain>`__
      - Must (Not)
    * - ra2.app.018
-     - CNF resiliency (network latency): CNF must not loose data, must continue to run and its readiness probe outcome must be Success even in case of
-       network latency up to 2000 ms occurs.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-cnf-crashes-when-ne
-       twork-latency-occurs-pod_network_latency>`__
+     - CNF resiliency (network latency): CNF must not loose data, must
+       continue to run and its readiness probe outcome must be Success even
+       in case of network latency up to 2000 ms occurs.
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-cnf-crashes-when-network-latency-occurs-pod_network_latency>`__
      - Must (Not)
    * - ra2.app.019
-     - CNF resiliency (pod delete) CNF must not loose data, must continue to run and its readiness probe outcome must be Success even in case of pod
+     - CNF resiliency (pod delete) CNF must not loose data, must continue to
+       run and its readiness probe outcome must be Success even in case of pod
        delete occurs.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-cnf-crashes-when-di
-       sk-fill-occurs-disk_fill>`__
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-cnf-crashes-when-disk-fill-occurs-disk_fill>`__
      - Must (not)
    * - ra2.app.020
-     - CNF resiliency (pod memory hog): CNF must not loose data, must continue to run and its readiness probe outcome must be Success even in case of pod
-       memory hog occurs.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-cnf-crashes-when-po
-       d-memory-hog-occurs-pod_memory_hog>`__
+     - CNF resiliency (pod memory hog): CNF must not loose data, must continue
+       to run and its readiness probe outcome must be Success even in case of
+       pod memory hog occurs.
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-cnf-crashes-when-pod-memory-hog-occurs-pod_memory_hog>`__
      - Must (Not)
    * - ra2.app.021
-     - CNF resiliency (pod I/O stress): CNF must not loose data, must continue to run and its readiness probe outcome must be Success even in case of pod
-       I/O stress occurs.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-cnf-crashes-when-po
-       d-io-stress-occurs-pod_io_stress>`__
+     - CNF resiliency (pod I/O stress): CNF must not loose data, must continue
+       to run and its readiness probe outcome must be Success even in case of
+       pod I/O stress occurs.
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-cnf-crashes-when-pod-io-stress-occurs-pod_io_stress>`__
      - Must (Not)
    * - ra2.app.022
-     - CNF resiliency (pod network corruption): CNF must not loose data, must continue to run and its readiness probe outcome must be Success even in case of pod
-       network corruption occurs.
+     - CNF resiliency (pod network corruption): CNF must not loose data, must
+       continue to run and its readiness probe outcome must be Success even in
+       case of pod network corruption occurs.
      - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-cnf-crashes-when-po
        d-network-corruption-occurs-pod_network_corruptio  n>`__
      - Must (Not)
    * - ra2.app.023
-     - CNF resiliency (pod network duplication):  CNF must not loose data, must continue to run and its readiness probe outcome must be Success even in case of pod
-       network duplication occurs.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-cnf-crashes-when-po
-       d-network-duplication-occurs-pod_network_duplication>`__
+     - CNF resiliency (pod network duplication):  CNF must not loose data,
+       must continue to run and its readiness probe outcome must be Success
+       even in case of pod network duplication occurs.
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#test-if-the-cnf-crashes-when-pod-network-duplication-occurs-pod_network_duplication>`__
      - Must (Not)
    * - ra2.app.024
-     - CNF resiliency (pod DNS error): CNF must not lose data, must continue to run and its readiness probe outcome must be Success even in case of pod
-       DNS error occurs.
+     - CNF resiliency (pod DNS error): CNF must not lose data, must continue
+       to run and its readiness probe outcome must be Success even in case of
+       pod DNS error occurs.
      - N/A
      - Must (Not)
    * - ra2.app.025
@@ -186,60 +201,62 @@ for Kubernetes workloads.
      - Must (Not)
    * - ra2.app.026
      - Liveness probe: All Pods of the CNF must have livenessProbe defined.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-test-if-there-is-a-liveness-
-       entry-in-the-helm-chart-liveness>`__
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-test-if-there-is-a-liveness-entry-in-the-helm-chart-liveness>`__
      - Must
    * - ra2.app.027
      - Readiness probe: All Pods of the CNF must have readinessProbe defined.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-test-if-there-is-a-readiness
-       -entry-in-the-helm-chart-readiness>`__
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-test-if-there-is-a-readiness-entry-in-the-helm-chart-readiness>`__
      - Must
    * - ra2.app.028
-     - No access to container daemon sockets: The CNF must not have any of the container daemon sockets (e.g.: /var/run/docker.sock, /var/run/containerd.sock
-       or /var/run/crio.sock) mounted.
+     - No access to container daemon sockets: The CNF must not have any of the
+       container daemon sockets (e.g.: /var/run/docker.sock,
+       /var/run/containerd.sock or /var/run/crio.sock) mounted.
      - N/A
      - Must (Not)
    * - ra2.app.029
-     - No automatic service account mapping: Non specified service accounts must not be automatically mapped. To prevent this the
-       automountServiceAccountToken: false flag must be set in all Pods of the CNF.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-there-are-service-a
-       ccounts-that-are-automatically-mapped-application_credentials>`__
+     - No automatic service account mapping: Non specified service accounts
+       must not be automatically mapped. To prevent this the
+       automountServiceAccountToken: false flag must be set in all Pods of the
+       CNF.
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-there-are-service-accounts-that-are-automatically-mapped-application_credentials>`__
      - Must (Not)
    * - ra2.app.030
-     - No host network access: Host network must not be attached to any of the Pods of the CNF. hostNetwork attribute of the Pod specifications
+     - No host network access: Host network must not be attached to any of the
+       Pods of the CNF. hostNetwork attribute of the Pod specifications
        must be False or should not be specified.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-there-is-a-host-net
-       work-attached-to-a-pod-host_network>`__
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-there-is-a-host-network-attached-to-a-pod-host_network>`__
      - Must (Not)
    * - ra2.app.031
-     - Host process namespace separation: Pods of the CNF must not share the host process ID namespace or the host IPC namespace. Pod manifests must not
-       have the hostPID or the hostIPC attribute set to true.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-containers-are-runn
-       ing-with-hostpid-or-hostipc-privileges-host_pid_ipc_privileges>`__
+     - Host process namespace separation: Pods of the CNF must not share the
+       host process ID namespace or the host IPC namespace. Pod manifests must
+       not have the hostPID or the hostIPC attribute set to true.
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-containers-are-running-with-hostpid-or-hostipc-privileges-host_pid_ipc_privileges>`__
      - Must (Not)
    * - ra2.app.032
-     - Resource limits: All containers and namespaces of the CNF must have defined resource limits for at least CPU and memory resources.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-containers-have-res
-       ource-limits-defined-resource_policies>`__
+     - Resource limits: All containers and namespaces of the CNF must have
+       defined resource limits for at least CPU and memory resources.
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-containers-have-resource-limits-defined-resource_policies>`__
      - Must
    * - ra2.app.033
-     - Read only filesystem: All containers of the CNF must have a read only filesystem. The readOnlyRootFilesystem attribute of the Pods in
+     - Read only filesystem: All containers of the CNF must have a read only
+       filesystem. The readOnlyRootFilesystem attribute of the Pods in
        the their securityContext should be set to true.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-containers-have-imm
-       utable-file-systems-immutable_file_systems>`__
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-containers-have-immutable-file-systems-immutable_file_systems>`__
      - Must
    * - ra2.app.034
-     - Container image tags: All referred container images in the Pod manifests must be referred by a version tag pointing to a concrete
+     - Container image tags: All referred container images in the Pod
+       manifests must be referred by a version tag pointing to a concrete
        version of the image. latest tag must not be used
      - N/A
      - Must
    * - ra2.app.035
-     - No hardcoded IP addresses: The CNF must not have any hardcoded IP addresses in its Pod specifications.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-test-if-there-are-any-non-de
-       clarative-hardcoded-ip-addresses-or-subnet-masks-in-the-k8s-runtime-configuration>`__
+     - No hardcoded IP addresses: The CNF must not have any hardcoded IP
+       addresses in its Pod specifications.
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-test-if-there-are-any-non-declarative-hardcoded-ip-addresses-or-subnet-masks-in-the-k8s-runtime-configuration>`__
      - Must (Not)
    * - ra2.app.036
-     - No node ports: Service declarations of the CNF must not contain nodePort definition.
+     - No node ports: Service declarations of the CNF must not contain
+       nodePort definition.
      - `Kubernetes documentation <https://kubernetes.io/docs/concepts/services-networking/service/>`__
      - Must (Not)
    * - ra2.app.037
@@ -247,45 +264,50 @@ for Kubernetes workloads.
      - `Kubernetes documentation <https://kubernetes.io/docs/concepts/configuration/configmap/#configmap-immutable>`__
      - Must
    * - ra2.app.038
-     - Horizontal scaling:Increasing and decreasing of the CNF capacity should be implemented using horizontal scaling. If horizontal
-       scaling is supported, automatic scaling must be possible using Kubernetes `Horizontal Pod Autoscale (HPA)
-       <https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/>`__ feature.
+     - Horizontal scaling:Increasing and decreasing of the CNF capacity should
+       be implemented using horizontal scaling. If horizontal
+       scaling is supported, automatic scaling must be possible using
+       Kubernetes
+       `Horizontal Pod Autoscale (HPA)
+       <https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/>`__
+       feature.
      - TBD
      - Should
    * - ra2.app.039
-     - CNF image size: The different container images of the CNF should not be bigger than 5GB.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-the-cnf-has-a-reaso
-       nable-image-size-reasonable_image_size>`__
+     - CNF image size: The different container images of the CNF should not be
+       bigger than 5GB.
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-the-cnf-has-a-reasonable-image-size-reasonable_image_size>`__
      - Should (Not)
    * - ra2.app.040
-     - CNF startup time: Startup time of the Pods of a CNF should not be more than 60s where startup time is the time between starting the
+     - CNF startup time: Startup time of the Pods of a CNF should not be more
+       than 60s where startup time is the time between starting the
        Pod until the readiness probe outcome is Success.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-the-cnf-have-a-reas
-       onable-startup-time-reasonable_startup_time>`__
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-the-cnf-have-a-reasonable-startup-time-reasonable_startup_time>`__
      - Should (Not)
    * - ra2.app.041
-     - No privileged mode: None of the Pods of the CNF should run in privileged mode.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-there-are-any-privi
-       leged-containers-kubscape-version-privileged_containers>`__
+     - No privileged mode: None of the Pods of the CNF should run in
+       privileged mode.
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-there-are-any-privileged-containers-kubscape-version-privileged_containers>`__
      - Should (Not)
    * - ra2.app.042
      - No root user: None of the Pods of the CNF should run as a root user.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-any-containers-are-
-       running-as-a-root-user-checks-the-user-outside-the-container-that-is-running-dockerd-non_root_user>`__
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-any-containers-are-running-as-a-root-user-checks-the-user-outside-the-container-that-is-running-dockerd-non_root_user>`__
      - Should (Not)
    * - ra2.app.043
-     - No privilege escalation: None of the containers of the CNF should allow privilege escalation.
+     - No privilege escalation: None of the containers of the CNF should allow
+       privilege escalation.
      - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-there-are-any-privi
        leged-containers-kubscape-version-privileged_containers>`__
      - Should (Not)
    * - ra2.app.044
-     - Non-root user: All Pods of the CNF should be able to execute with a non-root user having a non-root group. Both runAsUser and
+     - Non-root user: All Pods of the CNF should be able to execute with a
+       non-root user having a non-root group. Both runAsUser and
        runAsGroup attributes should be set to a greater value than 999.
-     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-containers-are-runn
-       ing-with-non-root-user-with-non-root-membership-non_root_containers>`__
+     - `CNCF CNF Testsuite <https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md#to-check-if-containers-are-running-with-non-root-user-with-non-root-membership-non_root_containers>`__
      - Should
    * - ra2.app.045
-     - Labels: Pods of the CNF should define at least the following labels: app.kubernetes.io/name, app.kubernetes.io/version
+     - Labels: Pods of the CNF should define at least the following labels:
+       app.kubernetes.io/name, app.kubernetes.io/version
        and app.kubernetes.io/part-of
      - `Kubernetes documentation <https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/>`__
-     - Should     
+     - Should

--- a/doc/ref_cert/RC2/chapters/chapter05.rst
+++ b/doc/ref_cert/RC2/chapters/chapter05.rst
@@ -1,17 +1,21 @@
 CNF Testing Cookbook
 ====================
-The purpose of this chapter is to direct the reader to information regarding the test suites
-available and where to find the test suite code for workloads.
+The purpose of this chapter is to direct the reader to information regarding
+the test suites available and where to find the test suite code for workloads.
 
-The description of the tests can be found in the `CNCF CNF Testsuite Descriptions <https://github.com/cncf/cnf-testsuite/blob/main/docs/LIST_OF_TESTS.md>`__.
+The description of the tests can be found in the
+`CNCF CNF Testsuite Descriptions <https://github.com/cncf/cnf-testsuite/blob/main/docs/LIST_OF_TESTS.md>`__.
 
-The installation of the CNCF test suite is described in the `CNCF CNF Testsuite Installation <https://github.com/cncf/cnf-testsuite/blob/main/INSTALL.md>`__.
+The installation of the CNCF test suite is described in the
+`CNCF CNF Testsuite Installation <https://github.com/cncf/cnf-testsuite/blob/main/INSTALL.md>`__.
 
-Some of the necessary tests are found in `Kubernetes documentation <https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/>`__.
+Some of the necessary tests are found in
+`Kubernetes documentation <https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/>`__.
 
 Functest
 ========
-RC2 platform testing is executed via Functest. Funbctest can be configured to execute the CNCF
-Testsuite as part of Functest. At this time, the ability to select specifc CNCF CNF tests is 
-not available. Thus all of the CNCF Test will execute when called by Functest. the results of 
-tests that are not **Must** or **Must Not** should be ignored.  
+RC2 platform testing is executed via Functest. Funbctest can be configured to
+execute the CNCF Testsuite as part of Functest. At this time, the ability to
+select specifc CNCF CNF tests is  not available. Thus all of the CNCF Test
+will execute when called by Functest. the results of tests that are not
+**Must** or **Must Not** should be ignored.

--- a/doc/ref_cert/RC2/conf.py
+++ b/doc/ref_cert/RC2/conf.py
@@ -11,7 +11,9 @@ extensions = [
 ]
 html_theme = "sphinx_material"
 linkcheck_ignore = [
-    'http://127.0.0.1'
+    'http://127.0.0.1',
+    'https://github.com/cncf/cnf-testsuite/',
+    'https://github.com/opencontainers/'
 ]
 intersphinx_mapping = {
     'ref_arch_kubernetes': ('https://cntt.readthedocs.io/projects/ra2/en/latest/', None)

--- a/doc/ref_cert/RC2/tox.ini
+++ b/doc/ref_cert/RC2/tox.ini
@@ -5,7 +5,7 @@ skipsdist = True
 [testenv:docs]
 basepython = python3.10
 deps =
-  -chttps://opendev.org/openstack/requirements/raw/branch/stable/yoga/upper-constraints.txt
+  -chttps://opendev.org/openstack/requirements/raw/branch/stable/zed/upper-constraints.txt
   -r{toxinidir}/test-requirements.txt
 install_command = pip install {opts} {packages}
 commands =

--- a/doc/ref_cert/tox.ini
+++ b/doc/ref_cert/tox.ini
@@ -3,9 +3,9 @@ envlist = docs
 skipsdist = True
 
 [testenv:docs]
-basepython = python3.9
+basepython = python3.10
 deps =
-  -chttps://opendev.org/openstack/requirements/raw/branch/stable/xena/upper-constraints.txt
+  -chttps://opendev.org/openstack/requirements/raw/branch/stable/zed/upper-constraints.txt
   -r{toxinidir}/test-requirements.txt
 install_command = pip install {opts} {packages}
 commands =

--- a/doc/ref_impl/cntt-ri/tox.ini
+++ b/doc/ref_impl/cntt-ri/tox.ini
@@ -3,8 +3,9 @@ envlist = docs
 skipsdist = True
 
 [testenv:docs]
-basepython = python3
+basepython = python3.10
 deps =
+  -chttps://opendev.org/openstack/requirements/raw/branch/stable/zed/upper-constraints.txt
   -r{toxinidir}/test-requirements.txt
 commands =
   # very long lines are allowed

--- a/doc/ref_impl/cntt-ri2/tox.ini
+++ b/doc/ref_impl/cntt-ri2/tox.ini
@@ -3,8 +3,9 @@ envlist = docs
 skipsdist = True
 
 [testenv:docs]
-basepython = python3.9
+basepython = python3.10
 deps =
+  -chttps://opendev.org/openstack/requirements/raw/branch/stable/zed/upper-constraints.txt
   -r{toxinidir}/requirements.txt
 commands =
   doc8 . --ignore-path .tox --ignore-path build --max-line-length=120

--- a/doc/ref_model/chapters/chapter07.rst
+++ b/doc/ref_model/chapters/chapter07.rst
@@ -742,7 +742,7 @@ Software Bill of Materials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In order to ensure software security, it is crucial to identify the software components and their origins. The
-Software Bill of Materials (SBOM), described by `US NTIA <https://www.ntia.gov/SBOM>`__ (National
+Software Bill of Materials (SBOM), described by `US NTIA <https://ntia.gov/page/software-bill-materials>`__ (National
 Telecommunications and Information Administration), is an efficient and highly recommended tool to identify software
 components. The SBOM is an inventory of software components and the relationships between them. NTIA describes how to
 establish an SBOM and provides SBOM standard data formats. In case of vulnerability detected for a component, the
@@ -753,7 +753,7 @@ and it provides assurance of the source and integrity of components. To achieve 
 a shared model must be supported by industry. This is the goal of the work performed by the US Department of Commerce
 and the National Telecommunications and Information administration (NTIA) and published, in July 2021, in the report
 `"The Minimum Elements for a Software Bill of Materials (SBOM)"
-<https://www.ntia.doc.gov/files/ntia/publications/sbom_minimum_elements_report.pdf>`__ in July 2021. The document gives
+<https://ntia.gov/files/ntia/publications/sbom_minimum_elements_report.pdf>`__ in July 2021. The document gives
 guidance and specifies the minimum elements for the SBOM, as a starting point.
 
 A piece of software can be modelled as a hierarchical tree with components and subcomponents, each
@@ -788,7 +788,7 @@ component should have its SBOM including,  as a baseline, the information descri
 +------------------------------+---------------------------------------------------+
 
 **Table 7-2**: SBOM Data Fields components, source
-`NTIA <https://www.ntia.doc.gov/files/ntia/publications/sbom_minimum_elements_report.pdf>`__
+`NTIA <https://ntia.gov/files/ntia/publications/sbom_minimum_elements_report.pdf>`__
 
 Refer to the NTIA SBOM document for more details on each data field. Examples of commonly used identifiers are provided.
 
@@ -1489,9 +1489,9 @@ Open Source Software
 |                 | environment **must** be used to store vetted open source content.         |                        |
 +-----------------+---------------------------------------------------------------------------+------------------------+
 | req.sec.oss.005 | A Software Bill of Materials (SBOM) **should** be provided or build, and  | Inventory of software  |
-|                 | maintained to identify the software components and their origins.         | components, `https://w |
-|                 |                                                                           | ww.ntia.gov/SBOM <http |
-|                 |                                                                           | s://www.ntia.gov/SBO   |
+|                 | maintained to identify the software components and their origins.         | components, `https://  |
+|                 |                                                                           | ntia.gov/SBOM <http    |
+|                 |                                                                           | s://ntia.gov/SBO       |
 |                 |                                                                           | M>`__                  |
 +-----------------+---------------------------------------------------------------------------+------------------------+
 

--- a/doc/ref_model/conf.py
+++ b/doc/ref_model/conf.py
@@ -18,7 +18,8 @@ linkcheck_ignore = [
     'https://www.iso.org',
     'https://www.etsi.org',
     'https://infocentre2.gsma.com',
-    'https://nplang.org'
+    'https://nplang.org',
+    'https://ntia.gov'
 ]
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 4

--- a/doc/ref_model/tox.ini
+++ b/doc/ref_model/tox.ini
@@ -3,9 +3,9 @@ envlist = docs
 skipsdist = True
 
 [testenv:docs]
-basepython = python3.9
+basepython = python3.10
 deps =
-  -chttps://opendev.org/openstack/requirements/raw/branch/stable/xena/upper-constraints.txt
+  -chttps://opendev.org/openstack/requirements/raw/branch/stable/zed/upper-constraints.txt
   -r{toxinidir}/test-requirements.txt
 install_command = pip install {opts} {packages}
 commands =


### PR DESCRIPTION
The certificate has just expired.
It also updates tox.ini to take latest OpenStack stable upper-constraint inito account.

Please note there are other issues in RM which are out of this PR 

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>